### PR TITLE
refactor(storage): pick single-table L0 compaction by vnode partition

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -41,6 +41,7 @@ env_scripts = [
   is_udf_enabled = get_env ENABLE_UDF
   is_datafusion_enabled = get_env ENABLE_DATAFUSION
   is_default_features_disabled = get_env DISABLE_DEFAULT_FEATURES
+  is_lancedb_sink_disabled = get_env DISABLE_LANCEDB_SINK
 
   if ${is_sanitizer_enabled}
     set_env RISEDEV_CARGO_BUILD_EXTRA_ARGS "--timings -Zbuild-std --target ${CARGO_MAKE_RUST_TARGET_TRIPLE}"
@@ -72,6 +73,15 @@ env_scripts = [
 
   if ${is_default_features_disabled}
     set_env RISINGWAVE_FEATURE_FLAGS "${flags} --no-default-features"
+  else
+    if ${is_lancedb_sink_disabled}
+      # Cargo cannot subtract a feature from the default bundle. Disable defaults,
+      # then restore rw-static-link and all connectors except LanceDB.
+      # These linking features control different dependencies: rw-static-link enables
+      # static libz/lzma/sasl2, while rw-dynamic-link enables dynamic zstd.
+      # They can coexist in dev builds, so keep rw-static-link to preserve the defaults.
+      set_env RISINGWAVE_FEATURE_FLAGS "${flags} --no-default-features --features rw-static-link,all-connectors-without-lancedb"
+    end
   end
 
   if ${is_hummock_trace}

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -41,7 +41,7 @@ env_scripts = [
   is_udf_enabled = get_env ENABLE_UDF
   is_datafusion_enabled = get_env ENABLE_DATAFUSION
   is_default_features_disabled = get_env DISABLE_DEFAULT_FEATURES
-  are_heavy_sinks_disabled = get_env DISABLE_HEAVY_SINKS
+  are_heavy_connectors_disabled = get_env DISABLE_HEAVY_CONNECTORS
 
   if ${is_sanitizer_enabled}
     set_env RISEDEV_CARGO_BUILD_EXTRA_ARGS "--timings -Zbuild-std --target ${CARGO_MAKE_RUST_TARGET_TRIPLE}"
@@ -74,9 +74,9 @@ env_scripts = [
   if ${is_default_features_disabled}
     set_env RISINGWAVE_FEATURE_FLAGS "${flags} --no-default-features"
   else
-    if ${are_heavy_sinks_disabled}
+    if ${are_heavy_connectors_disabled}
       # Cargo cannot subtract a feature from the default bundle. Disable defaults,
-      # then restore rw-static-link and all connectors except heavyweight sinks.
+      # then restore rw-static-link and all connectors except heavyweight connectors.
       # These linking features control different dependencies: rw-static-link enables
       # static libz/lzma/sasl2, while rw-dynamic-link enables dynamic zstd.
       # They can coexist in dev builds, so keep rw-static-link to preserve the defaults.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -41,7 +41,7 @@ env_scripts = [
   is_udf_enabled = get_env ENABLE_UDF
   is_datafusion_enabled = get_env ENABLE_DATAFUSION
   is_default_features_disabled = get_env DISABLE_DEFAULT_FEATURES
-  is_lancedb_sink_disabled = get_env DISABLE_LANCEDB_SINK
+  are_heavy_sinks_disabled = get_env DISABLE_HEAVY_SINKS
 
   if ${is_sanitizer_enabled}
     set_env RISEDEV_CARGO_BUILD_EXTRA_ARGS "--timings -Zbuild-std --target ${CARGO_MAKE_RUST_TARGET_TRIPLE}"
@@ -74,13 +74,13 @@ env_scripts = [
   if ${is_default_features_disabled}
     set_env RISINGWAVE_FEATURE_FLAGS "${flags} --no-default-features"
   else
-    if ${is_lancedb_sink_disabled}
+    if ${are_heavy_sinks_disabled}
       # Cargo cannot subtract a feature from the default bundle. Disable defaults,
-      # then restore rw-static-link and all connectors except LanceDB.
+      # then restore rw-static-link and all connectors except heavyweight sinks.
       # These linking features control different dependencies: rw-static-link enables
       # static libz/lzma/sasl2, while rw-dynamic-link enables dynamic zstd.
       # They can coexist in dev builds, so keep rw-static-link to preserve the defaults.
-      set_env RISINGWAVE_FEATURE_FLAGS "${flags} --no-default-features --features rw-static-link,all-connectors-without-lancedb"
+      set_env RISINGWAVE_FEATURE_FLAGS "${flags} --no-default-features --features rw-static-link,all-connectors-lite"
     end
   end
 

--- a/docs/dev/src/SUMMARY.md
+++ b/docs/dev/src/SUMMARY.md
@@ -43,6 +43,7 @@
     - [Streaming Parallelism Configuration](./design/streaming-parallelism.md)
 - [State Store](./design/state-store-overview.md)
     - [Shared Buffer](./design/shared-buffer.md)
+    - [Hummock Partition-Aware L0 Compaction](./design/hummock-partition-l0-compaction.md)
     - [Relational Table](./design/relational-table.md)
     - [Multiple Object Storage Backends](./design/multi-object-store.md)
 - [Meta Service](./design/meta-service.md)

--- a/docs/dev/src/design/hummock-partition-l0-compaction.md
+++ b/docs/dev/src/design/hummock-partition-l0-compaction.md
@@ -63,6 +63,12 @@ non-overlapping prefix. It chooses one seed sub-level using the existing heurist
 range closures, and checks their depth and Base pending inputs. It does not enumerate every SST or
 every intermediate closure. Maximum point-overlap depth is telemetry only.
 
+Ordinary partition ToBase attempts a depth-qualified normal task before falling back to a Base
+trivial move. A normal result with one non-overlapping source level and no Base inputs retains the
+existing metadata-only move behavior. Legacy remains move-first; shallow partition candidates
+remain move-only. A returned normal task that fails the outer output-conflict check does not cause
+another search or a move fallback within that partition.
+
 The partition path may proceed past a fully pending oldest sub-level when a disjoint runnable stack
 exists. Pending SSTs remain in the view and must still pass the existing closure checks. Legacy
 retains its oldest-sub-level early return.

--- a/docs/dev/src/design/hummock-partition-l0-compaction.md
+++ b/docs/dev/src/design/hummock-partition-l0-compaction.md
@@ -1,0 +1,191 @@
+# Hummock Partition-Aware L0 Compaction Contract
+
+This document records the experimental compaction contract for a Hummock compaction group that
+contains exactly one state table and whose L0 SST references conform to a fixed vnode partition
+layout. It also records the observability required to evaluate the policy. It is not the contract
+for legacy or multi-table compaction groups.
+
+## Terminology
+
+- A **vnode partition** is a static key range derived from the table vnode count and the compaction
+  group's `split_weight_by_vnode`.
+- **Partition depth** is the number of non-empty non-overlapping L0 sub-levels containing at least
+  one runnable SST reference in that vnode partition. It is a scheduling pressure proxy.
+- **Maximum overlap depth** is the maximum number of runnable L0 SST key ranges covering the same
+  key in that partition. It is a closer approximation of point-read amplification.
+- An **SST reference** is a logical `SstableInfo` entry. Multiple references can share an object.
+  Reference count, distinct object count, and range-local `sst_size` must be observed separately.
+
+Partition depth is deliberately not called read amplification. For example, two sub-levels with
+disjoint key ranges contribute a partition depth of two but a maximum overlap depth of one.
+
+## Activation and fallback
+
+The partition-aware policy is active only when all of the following hold:
+
+1. The compaction group contains exactly one table.
+2. The table vnode count and `split_weight_by_vnode` define more than one valid static partition.
+3. Every L0 SST reference belongs to exactly one static partition.
+
+If the fixed partition view cannot be built, L0 selection falls back to the legacy global L0
+strategy. Multi-table compaction groups always use the legacy path.
+
+## Scheduling contract
+
+The current policy separates global L0 admission from local task construction:
+
+1. Raw L0 pressure is the maximum partition-depth score. At least one partition must exceed the
+   configured depth threshold.
+2. The L0 priority is adjusted by effective Base-level fill, using the same shape as Pebble:
+   `raw_l0_score / max(0.01, effective_base_fill)`. Effective fill accounts for pending incoming
+   and outgoing compactions.
+3. Ordinary ToBase candidates exist only for partitions above the depth threshold, and the picker
+   must select at least the configured number of L0 levels. They are tried by adjusted global
+   priority and then by decreasing partition pressure.
+4. A shallow partition may be considered only for a trivial move. If that move is not possible,
+   the attempt must not fall through to an ordinary ToBase rewrite.
+5. Intra candidates also exist only for partitions above the depth threshold. At the same global
+   L0 pressure, deep ToBase candidates are tried first, then shallow trivial moves, and finally
+   deep Intra candidates. Each class is ordered by decreasing partition pressure.
+6. A failed picker attempt means only that the current heuristic did not produce an acceptable
+   task. It does not prove that no legal ToBase task exists.
+
+`sub_level_max_compaction_bytes` is not a minimum-byte admission rule for the partition-aware
+ToBase path. The existing picker still applies its L0 byte, file, and level limits. The partition
+path does not apply the legacy validator, so selected L0 input plus its Base overlap has no uniform
+hard total-size check. Admission uses partition depth strictly greater than the configured threshold;
+the selected task must contain at least that many L0 levels.
+
+## Task construction and conflict contract
+
+Partition ToBase reuses the unchanged `NonOverlapSubLevelPicker` on the partition-local
+non-overlapping prefix. It chooses one seed sub-level using the existing heuristic, constructs its
+range closures, and checks their depth and Base pending inputs. It does not enumerate every SST or
+every intermediate closure. Maximum point-overlap depth is telemetry only.
+
+The partition path may proceed past a fully pending oldest sub-level when a disjoint runnable stack
+exists. Pending SSTs remain in the view and must still pass the existing closure checks. Legacy
+retains its oldest-sub-level early return.
+
+The selector applies the normal in-progress output-range conflict check to the returned task. A
+conflict advances to the next picker candidate, not another seed in the same partition. Consequently,
+both seed-layer selection and final output conflicts may hide otherwise legal tasks; the policy does
+not promise exhaustive search.
+
+### Optional free growth
+
+Correctness closure pulls in older overlapping L0 data so newer versions do not reach Base first.
+Free growth instead unions already-closed candidates to amortize one task and its Base rewrite.
+Only ordinary partition ToBase uses this optional phase:
+
+1. Accept the initial depth-qualified seed and its non-pending Base inputs. If its output already
+   conflicts, return it to the normal selector check without attempting growth.
+2. When Base input is non-empty, consume the remaining plans from the same NonOverlap picker call.
+   A donor may be shallower than the initial depth threshold. No second picker pass, exhaustive
+   seed enumeration, or cross-partition search is performed.
+3. Deduplicate L0 SST IDs and reject a donor that adds none. Rebuild the union in source-level order,
+   preserving each independent closure; do not validate the union as a single gap-free L0 hull.
+4. Require the exact initial Base SST ID set to stay unchanged. The union must satisfy existing L0
+   byte/file/level limits and the combined L0-plus-Base `max_compaction_bytes` limit. These are
+   range-local `sst_size` limits, not whole-object download limits.
+5. Check the complete grown output against in-progress outputs before replacing the accepted task.
+   A failed donor leaves the previously accepted task intact and does not prevent later donors.
+
+The donor loop is bounded by the already-generated plans, not an arbitrary new candidate budget.
+It adds no closure construction; rebuilding a union scans the partition view for each donor.
+"Free" means no additional Base SSTs, not zero write cost: added L0 input is still rewritten, and
+a donor that could later move trivially need not improve write amplification.
+
+### Relationship to Pebble and retained evidence
+
+The source comparison is pinned to official Pebble commit
+`13596f1e1cea9196defa14dec5c2ac9d90120010` (master inspected on 2026-09-10):
+
+- [Base closure construction](https://github.com/cockroachdb/pebble/blob/13596f1e1cea9196defa14dec5c2ac9d90120010/internal/manifest/l0_sublevels.go#L1502-L1591)
+  preserves version order. Optional rectangle filling is explicitly separate.
+- [L0 free growth](https://github.com/cockroachdb/pebble/blob/13596f1e1cea9196defa14dec5c2ac9d90120010/compaction_picker.go#L500-L565)
+  uses the neighboring unselected Base boundaries, skips empty Base inputs, and rolls back expansion
+  when the combined size is too large. RW uses existing closed donors instead of porting the
+  interval organizer/rectangle algorithm.
+- [Size and grandparent limits](https://github.com/cockroachdb/pebble/blob/13596f1e1cea9196defa14dec5c2ac9d90120010/compaction.go#L48-L76)
+  serve different purposes: expanded input size is bounded by target-file-size and disk capacity;
+  grandparent overlap primarily limits individual output files, and also affects trivial-move
+  eligibility. RW does not import those constants or introduce a new grandparent policy here.
+
+RW already batches immutable memtables in upload tasks; this proposal is not based on a claim that
+RW never batches flush input. Fixed vnode partitioning and upload batching do not guarantee that a
+chosen L0 closure amortizes the Base SST it rewrites.
+
+The retained 8 GiB runs do not prove a runtime growth benefit: bf57's score-plus-growth run wrote
+46.48 GiB and did not isolate the two changes; depth-seed and independent-picker runs accepted
+0/3 and 0/90 growth candidates respectively. Their old `merge-limit` counter mixed duplicate/subset
+donors with actual limits. That evidence rejects a claim of measured benefit, but does not show
+whether useful distinct donors were absent or refused. The small optional mechanism remains an
+experiment, not a demonstrated fix for the workload's write amplification.
+
+## Read and write cost model
+
+No single counter is sufficient:
+
+| Signal | Primary meaning |
+| --- | --- |
+| Maximum per-key overlap depth | Point-read probe pressure in L0 |
+| Non-empty partition depth | Coarse scheduling pressure and retained sub-levels |
+| Logical SST reference count | Version metadata, picker work, and range-iterator fragmentation |
+| Distinct object count | Object metadata and cache identity pressure |
+| Selected L0 `sst_size` | Range-local work amortized by a ToBase task |
+| Target `sst_size` / selected L0 `sst_size` | Range-local Base rewrite cost paid for that L0 work |
+| Referenced `file_size` sum | Existing whole-object task-size accounting; may count one split object more than once |
+| Growth-added `sst_size` | Extra L0 work included without expanding the Base SST set |
+
+Small logical references do not by themselves prove that physical output SSTs are too small.
+Conversely, low overlap depth does not prove that reference count, object count, or batching cost is
+irrelevant.
+
+The current policy has no independent minimum L0 bytes or file-count admission rule. Depth is the
+only batching threshold until task-level evidence can distinguish fixed task overhead from Base
+rewrite cost. A total-task byte minimum would not make that distinction: a large Base overlap can
+make an expensive task pass even when its L0 input is small.
+
+## Observability contract
+
+Partition index is emitted only in structured logs; it must not be a Prometheus label. The metrics
+use bounded labels (`group`, `picker`, `outcome`, and `kind`):
+
+- `storage_partition_l0_compaction_total`: candidate snapshots plus picker-empty, range-conflict,
+  and selected outcomes. Candidate snapshots are emitted once per ordinary-ToBase or
+  trivial-move-only partition on each scheduling pass; they are observation-weighted rather than
+  independent version snapshots.
+- `storage_partition_l0_compaction_bytes`: partition total/runnable bytes, Base current/incoming/
+  outgoing/effective/target bytes, selected L0 bytes, target bytes, ordinary-ToBase initial L0
+  bytes and growth-added L0 bytes,
+  and the corresponding referenced-object `file_size` sums where applicable. `u64::MAX` dynamic
+  Base target sentinels are excluded.
+- `storage_partition_l0_compaction_count`: coarse and maximum-overlap depths, logical reference and
+  distinct object counts, selected task shape, and ordinary-ToBase donor outcomes.
+- `storage_partition_l0_compaction_score`: raw global, adjusted global, and partition scores,
+  represented as score times 100.
+
+Every selected partition task emits an info-level structured log under
+`risingwave_meta::hummock::partition_l0`. Failed attempts are debug-level logs and aggregate into
+the outcome counter. Selected-task histograms exclude failed attempts, trivial moves have their own
+picker label. Growth outcome kinds are `growth-accepted`, `growth-no-new-sst`,
+`growth-base-set-change`, `growth-bytes`, `growth-files`, `growth-levels`, and
+`growth-output-conflict`. Each donor records its first decisive outcome; summing their histogram
+sums gives donor attempts. The rejection check order is no-new-SST, files, levels, bytes, Base set,
+then output conflict. Zero attempts mean growth was not attempted (for example, no remaining donor
+or empty Base input), not that an expansion failed a limit.
+No exhaustive-search metrics are emitted.
+
+## Non-goals and open questions
+
+The current policy does not claim:
+
+- equivalence with Pebble's interval organizer or file-pressure score;
+- that partition depth equals actual read amplification;
+- that partition depth alone guarantees optimal write amplification;
+- that the existing seed heuristic finds every legal partition task;
+- that the Base pressure adjustment has been isolated as the cause of an observed regression.
+
+These questions must be answered from selected-task observations and controlled A/B evidence, not
+from aggregate task count alone.

--- a/src/cmd_all/Cargo.toml
+++ b/src/cmd_all/Cargo.toml
@@ -33,11 +33,11 @@ openssl-vendored = ["workspace-config/openssl-vendored"]
 udf = ["risingwave_expr_impl/udf"]
 fips = ["workspace-config/fips"]
 all-connectors = [
-    "risingwave_connector/all-sinks",
-    "all-connectors-without-lancedb",
+    "risingwave_connector/all-sinks-heavy",
+    "all-connectors-lite",
 ]
-all-connectors-without-lancedb = [
-    "risingwave_connector/all-sinks-without-lancedb",
+all-connectors-lite = [
+    "risingwave_connector/all-sinks-lite",
     "risingwave_connector/all-sources",
     "risingwave_compute/all-sources",
     "risingwave_frontend/all-sources",

--- a/src/cmd_all/Cargo.toml
+++ b/src/cmd_all/Cargo.toml
@@ -34,6 +34,10 @@ udf = ["risingwave_expr_impl/udf"]
 fips = ["workspace-config/fips"]
 all-connectors = [
     "risingwave_connector/all-sinks",
+    "all-connectors-without-lancedb",
+]
+all-connectors-without-lancedb = [
+    "risingwave_connector/all-sinks-without-lancedb",
     "risingwave_connector/all-sources",
     "risingwave_compute/all-sources",
     "risingwave_frontend/all-sources",

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -13,13 +13,13 @@ ignored = []
 [features]
 default = []
 test = []
-all-sinks = [
+all-sinks = ["all-sinks-without-lancedb", "sink-lancedb"]
+all-sinks-without-lancedb = [
     "sink-bigquery",
     "sink-deltalake",
     "sink-google_pubsub",
     "sink-clickhouse",
     "sink-doris",
-    "sink-lancedb",
     "sink-starrocks",
 ]
 all-sources = ["source-adbc_snowflake"]

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -13,8 +13,9 @@ ignored = []
 [features]
 default = []
 test = []
-all-sinks = ["all-sinks-without-lancedb", "sink-lancedb"]
-all-sinks-without-lancedb = [
+all-sinks = ["all-sinks-lite", "all-sinks-heavy"]
+all-sinks-heavy = ["sink-lancedb"]
+all-sinks-lite = [
     "sink-bigquery",
     "sink-deltalake",
     "sink-google_pubsub",

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -17,6 +17,7 @@
 pub mod compaction_config;
 pub(crate) mod in_progress_compaction;
 mod overlap_strategy;
+pub(crate) mod vnode_partition;
 use risingwave_common::catalog::{TableId, TableOption};
 use risingwave_hummock_sdk::compact_task::CompactTask;
 use risingwave_hummock_sdk::level::Levels;
@@ -39,7 +40,7 @@ use risingwave_pb::hummock::compaction_config::CompactionMode;
 use risingwave_pb::hummock::{CompactionConfig, PbSstableFilterLayout, PbSstableFilterType};
 pub use selector::{CompactionSelector, CompactionSelectorContext};
 
-use self::selector::{EmergencySelector, LocalSelectorStatistic};
+use self::selector::{EmergencySelector, LocalSelectorStatistic, SingleTableCompactionGroup};
 use super::GroupStateValidator;
 use crate::MetaOpts;
 use crate::hummock::compaction::in_progress_compaction::InProgressCompactionView;
@@ -104,6 +105,7 @@ impl CompactStatus {
         &mut self,
         levels: &Levels,
         member_table_ids: &BTreeSet<TableId>,
+        single_table_compaction_group: Option<SingleTableCompactionGroup>,
         task_id: HummockCompactionTaskId,
         group: &CompactionGroup,
         stats: &mut LocalSelectorStatistic,
@@ -118,6 +120,7 @@ impl CompactStatus {
             group,
             levels,
             member_table_ids,
+            single_table_compaction_group,
             level_handlers: &mut self.level_handlers,
             selector_stats: stats,
             table_id_to_options,
@@ -144,6 +147,7 @@ impl CompactStatus {
                         group,
                         levels,
                         member_table_ids,
+                        single_table_compaction_group,
                         level_handlers: &mut self.level_handlers,
                         selector_stats: stats,
                         table_id_to_options,

--- a/src/meta/src/hummock/compaction/picker/base_level_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/base_level_compaction_picker.rs
@@ -22,7 +22,7 @@ use risingwave_pb::hummock::{CompactionConfig, LevelType};
 
 use super::non_overlap_sub_level_picker::NonOverlapSubLevelPicker;
 use super::{
-    CompactionInput, CompactionPicker, CompactionTaskValidator, LocalPickerStatistic,
+    CompactionInput, CompactionPicker, CompactionTaskValidator, L0PickerMode, LocalPickerStatistic,
     ValidationRuleType,
 };
 use crate::hummock::compaction::picker::TrivialMovePicker;
@@ -35,6 +35,7 @@ std::thread_local! {
 
 pub struct LevelCompactionPicker {
     target_level: usize,
+    mode: L0PickerMode,
     config: Arc<CompactionConfig>,
     compaction_task_validator: Arc<CompactionTaskValidator>,
     developer_config: Arc<CompactionDeveloperConfig>,
@@ -100,6 +101,7 @@ impl LevelCompactionPicker {
     ) -> LevelCompactionPicker {
         LevelCompactionPicker {
             target_level,
+            mode: L0PickerMode::Legacy,
             compaction_task_validator: Arc::new(CompactionTaskValidator::new(config.clone())),
             config,
             developer_config,
@@ -112,8 +114,25 @@ impl LevelCompactionPicker {
         compaction_task_validator: Arc<CompactionTaskValidator>,
         developer_config: Arc<CompactionDeveloperConfig>,
     ) -> LevelCompactionPicker {
+        Self::new_with_mode(
+            target_level,
+            config,
+            compaction_task_validator,
+            developer_config,
+            L0PickerMode::Legacy,
+        )
+    }
+
+    pub(crate) fn new_with_mode(
+        target_level: usize,
+        config: Arc<CompactionConfig>,
+        compaction_task_validator: Arc<CompactionTaskValidator>,
+        developer_config: Arc<CompactionDeveloperConfig>,
+        mode: L0PickerMode,
+    ) -> LevelCompactionPicker {
         LevelCompactionPicker {
             target_level,
+            mode,
             config,
             compaction_task_validator,
             developer_config,
@@ -136,8 +155,9 @@ impl LevelCompactionPicker {
             0,
             self.target_level,
             overlap_strategy.clone(),
-            if self.compaction_task_validator.is_enable() {
-                // tips: Older versions of the compaction group will be upgraded without this configuration, we leave it with its default behaviour and enable it manually when needed.
+            if self.mode.is_single_table_partition() {
+                0
+            } else if self.compaction_task_validator.is_enable() {
                 self.config.sst_allowed_trivial_move_min_size.unwrap_or(0)
             } else {
                 0
@@ -166,6 +186,7 @@ impl LevelCompactionPicker {
     ) -> Option<CompactionInput> {
         let overlap_strategy = create_overlap_strategy(self.config.compaction_mode());
         let min_compaction_bytes = self.config.sub_level_max_compaction_bytes;
+        let min_expected_level_count = self.mode.min_l0_level_count();
         let non_overlap_sub_level_picker = NonOverlapSubLevelPicker::new(
             min_compaction_bytes,
             // divide by 2 because we need to select files of base level and it need use the other
@@ -174,7 +195,7 @@ impl LevelCompactionPicker {
                 self.config.max_bytes_for_level_base,
                 self.config.max_compaction_bytes / 2,
             ),
-            1,
+            min_expected_level_count,
             // The maximum number of sub_level compact level per task
             self.config.level0_max_compact_file_number,
             overlap_strategy.clone(),
@@ -187,18 +208,32 @@ impl LevelCompactionPicker {
                 .unwrap_or(compaction_config::enable_optimize_l0_interval_selection()),
         );
 
-        let mut max_vnode_partition_idx = 0;
-        for (idx, level) in l0.sub_levels.iter().enumerate() {
-            if level.vnode_partition_count < vnode_partition_count {
-                break;
+        let candidate_levels = if self.mode.is_single_table_partition() {
+            // The partition view has already removed unrelated vnode ranges. It may contain
+            // levels with different legacy partition markers, but must never cross an overlapping
+            // sub-level.
+            let non_overlapping_count = l0
+                .sub_levels
+                .iter()
+                .take_while(|level| level.level_type == LevelType::Nonoverlapping)
+                .count();
+            if non_overlapping_count == 0 {
+                return None;
             }
-            max_vnode_partition_idx = idx;
-        }
+            &l0.sub_levels[..non_overlapping_count]
+        } else {
+            let mut max_vnode_partition_idx = 0;
+            for (idx, level) in l0.sub_levels.iter().enumerate() {
+                if level.vnode_partition_count < vnode_partition_count {
+                    break;
+                }
+                max_vnode_partition_idx = idx;
+            }
+            &l0.sub_levels[..=max_vnode_partition_idx]
+        };
 
-        let candidate_l0_plans = non_overlap_sub_level_picker.pick_l0_multi_non_overlap_level(
-            &l0.sub_levels[..=max_vnode_partition_idx],
-            &level_handlers[0],
-        );
+        let candidate_l0_plans = non_overlap_sub_level_picker
+            .pick_l0_multi_non_overlap_level(candidate_levels, &level_handlers[0]);
         if candidate_l0_plans.is_empty() {
             stats.skip_by_pending_files += 1;
             return None;
@@ -208,6 +243,16 @@ impl LevelCompactionPicker {
         let mut input_levels = vec![];
 
         for input in candidate_l0_plans {
+            // Partition admission already checks the configured L0 depth. Keep the same check at
+            // the task boundary as a defense against a key-range candidate that spans fewer
+            // sub-levels than the partition-level view suggested.
+            if self.mode.is_single_table_partition()
+                && input.sstable_infos.len() < min_expected_level_count
+            {
+                stats.skip_by_count_limit += 1;
+                continue;
+            }
+
             let l0_select_tables = input
                 .sstable_infos
                 .iter()
@@ -305,6 +350,7 @@ impl LevelCompactionPicker {
 
 #[cfg(test)]
 pub mod tests {
+    use risingwave_common::util::iter_util::ZipEqFast;
 
     use super::*;
     use crate::hummock::compaction::compaction_config::CompactionConfigBuilder;
@@ -319,6 +365,87 @@ pub mod tests {
                 .build(),
         );
         LevelCompactionPicker::new(1, config, Arc::new(CompactionDeveloperConfig::default()))
+    }
+
+    #[test]
+    fn test_small_trivial_moves_ignore_legacy_min_size_and_count_all_files() {
+        let config = Arc::new(CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .sst_allowed_trivial_move_min_size(Some(u64::MAX))
+                .sst_allowed_trivial_move_max_count(Some(10))
+                .build()
+        });
+        let mut picker = LevelCompactionPicker::new_with_mode(
+            1,
+            config,
+            Arc::new(CompactionTaskValidator::unused()),
+            Arc::new(CompactionDeveloperConfig::default()),
+            L0PickerMode::SingleTablePartition {
+                min_l0_level_count: 1,
+            },
+        );
+        let levels = Levels {
+            l0: generate_l0_nonoverlapping_multi_sublevels(vec![vec![
+                generate_table(1, 1, 0, 10, 1),
+                generate_table(2, 1, 20, 30, 1),
+            ]]),
+            levels: vec![generate_level(1, vec![])],
+            ..Default::default()
+        };
+        let mut handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        let ret = picker
+            .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
+            .unwrap();
+        assert_eq!(ret.input_levels[0].table_infos.len(), 2);
+        assert!(ret.input_levels[1].table_infos.is_empty());
+        assert_eq!(ret.total_file_count, 1);
+        ret.add_pending_task(1, &mut handlers);
+        assert!(
+            picker
+                .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_to_base_ignores_partition_markers_but_stops_at_overlapping_level() {
+        let config = Arc::new(CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new().build()
+        });
+        let mut picker = LevelCompactionPicker::new_with_mode(
+            1,
+            config,
+            Arc::new(CompactionTaskValidator::unused()),
+            Arc::new(CompactionDeveloperConfig::default()),
+            L0PickerMode::SingleTablePartition {
+                min_l0_level_count: 1,
+            },
+        );
+        let mut levels = Levels {
+            l0: generate_l0_nonoverlapping_sublevels(
+                (1..=3).map(|id| generate_table(id, 1, 0, 10, id)).collect(),
+            ),
+            levels: vec![generate_level(1, vec![generate_table(10, 1, 0, 10, 0)])],
+            ..Default::default()
+        };
+        for (level, count) in levels.l0.sub_levels.iter_mut().zip_eq_fast([0, 4, 16]) {
+            level.vnode_partition_count = count;
+        }
+        let handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        let ret = picker
+            .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
+            .unwrap();
+        assert_eq!(ret.input_levels.len(), 4);
+        assert_eq!(ret.input_levels.last().unwrap().table_infos[0].sst_id, 10);
+
+        levels.l0.sub_levels[1].level_type = LevelType::Overlapping;
+        let ret = picker
+            .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
+            .unwrap();
+        assert_eq!(ret.input_levels.len(), 2);
+        assert_eq!(ret.input_levels[0].table_infos[0].sst_id, 1);
     }
 
     #[test]
@@ -611,7 +738,6 @@ pub mod tests {
             Arc::new(config),
             Arc::new(CompactionDeveloperConfig::default()),
         );
-
         let mut levels = Levels {
             levels: vec![Level {
                 level_idx: 1,
@@ -639,11 +765,114 @@ pub mod tests {
         );
 
         let mut levels_handler = vec![LevelHandler::new(0), LevelHandler::new(1)];
-        let mut local_stats = LocalPickerStatistic::default();
         levels_handler[0].add_pending_task(1, 4, &levels.l0.sub_levels[0].table_infos);
-        let ret = picker.pick_compaction(&levels, &levels_handler, &mut local_stats);
-        // Skip this compaction because the write amplification is too large.
+        let ret = picker.pick_compaction(
+            &levels,
+            &levels_handler,
+            &mut LocalPickerStatistic::default(),
+        );
         assert!(ret.is_none());
+    }
+
+    #[test]
+    fn test_to_base_does_not_reject_by_write_amplification() {
+        let config: CompactionConfig = CompactionConfigBuilder::new()
+            .level0_tier_compact_file_number(2)
+            .max_compaction_bytes(1000)
+            .sub_level_max_compaction_bytes(150)
+            .max_bytes_for_level_multiplier(1)
+            .level0_sub_level_compact_level_count(2)
+            .build();
+        let mut picker = LevelCompactionPicker::new_with_mode(
+            1,
+            Arc::new(config),
+            Arc::new(CompactionTaskValidator::unused()),
+            Arc::new(CompactionDeveloperConfig::default()),
+            L0PickerMode::SingleTablePartition {
+                min_l0_level_count: 2,
+            },
+        );
+
+        let mut levels = Levels {
+            levels: vec![Level {
+                level_idx: 1,
+                level_type: LevelType::Nonoverlapping,
+                table_infos: vec![
+                    generate_table(1, 1, 100, 399, 2),
+                    generate_table(2, 1, 400, 699, 2),
+                    generate_table(3, 1, 700, 999, 2),
+                ],
+                total_file_size: 900,
+                sub_level_id: 0,
+                uncompressed_file_size: 900,
+                ..Default::default()
+            }],
+            l0: generate_l0_nonoverlapping_sublevels(vec![]),
+            ..Default::default()
+        };
+        push_tables_level0_nonoverlapping(
+            &mut levels,
+            vec![
+                generate_table(4, 1, 100, 180, 2),
+                generate_table(5, 1, 400, 450, 2),
+                generate_table(6, 1, 600, 700, 2),
+            ],
+        );
+        push_tables_level0_nonoverlapping(
+            &mut levels,
+            vec![
+                generate_table(7, 1, 100, 180, 3),
+                generate_table(8, 1, 400, 450, 3),
+                generate_table(9, 1, 600, 700, 3),
+            ],
+        );
+
+        let levels_handler = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        let mut local_stats = LocalPickerStatistic::default();
+        let ret = picker.pick_compaction(&levels, &levels_handler, &mut local_stats);
+        assert!(ret.is_some());
+        assert_eq!(local_stats.skip_by_write_amp_limit, 0);
+    }
+
+    #[test]
+    fn test_to_base_defensively_rejects_too_few_selected_levels() {
+        let config = Arc::new(
+            CompactionConfigBuilder::new()
+                .level0_sub_level_compact_level_count(3)
+                .build(),
+        );
+        let developer_config = Arc::new(CompactionDeveloperConfig {
+            enable_trivial_move: false,
+            ..Default::default()
+        });
+        let validator = Arc::new(CompactionTaskValidator::new(config.clone()));
+        let mut picker = LevelCompactionPicker::new_with_mode(
+            1,
+            config,
+            validator,
+            developer_config,
+            L0PickerMode::SingleTablePartition {
+                min_l0_level_count: 3,
+            },
+        );
+        let levels = Levels {
+            levels: vec![generate_level(1, vec![])],
+            l0: generate_l0_nonoverlapping_sublevels(vec![
+                generate_table(1, 1, 0, 10, 1),
+                generate_table(2, 1, 20, 30, 2),
+                generate_table(3, 1, 40, 50, 3),
+            ]),
+            ..Default::default()
+        };
+        let handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        let mut stats = LocalPickerStatistic::default();
+
+        assert!(
+            picker
+                .pick_compaction(&levels, &handlers, &mut stats)
+                .is_none()
+        );
+        assert!(stats.skip_by_count_limit > 0);
     }
 
     #[test]
@@ -771,15 +1000,16 @@ pub mod tests {
                 .build(),
         );
 
-        // Only include sub-level 0 results will violate MAX_WRITE_AMPLIFICATION.
-        // But stopped by pending sub-level when trying to include more sub-levels.
         let mut picker = LevelCompactionPicker::new(
             1,
             config.clone(),
             Arc::new(CompactionDeveloperConfig::default()),
         );
-        let ret = picker.pick_compaction(&levels, &levels_handler, &mut local_stats);
-        assert!(ret.is_none());
+        assert!(
+            picker
+                .pick_compaction(&levels, &levels_handler, &mut local_stats)
+                .is_none()
+        );
 
         // Free the pending sub-level.
         for pending_task_id in &levels_handler[0].pending_tasks_ids() {

--- a/src/meta/src/hummock/compaction/picker/base_level_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/base_level_compaction_picker.rs
@@ -19,13 +19,12 @@ use std::sync::Arc;
 use itertools::Itertools;
 use risingwave_common::config::meta::default::compaction_config;
 use risingwave_hummock_sdk::level::{InputLevel, Level, Levels, OverlappingLevel};
-use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use risingwave_pb::hummock::{CompactionConfig, LevelType};
 
 use super::non_overlap_sub_level_picker::{NonOverlapSubLevelPicker, SubLevelSstables};
 use super::{
     CompactionInput, CompactionPicker, CompactionTaskValidator, L0PickerMode, LocalPickerStatistic,
-    ValidationRuleType,
+    PartitionL0GrowthOutcome, ValidationRuleType,
 };
 use crate::hummock::compaction::picker::TrivialMovePicker;
 use crate::hummock::compaction::{CompactionDeveloperConfig, create_overlap_strategy};
@@ -50,6 +49,20 @@ impl CompactionPicker for LevelCompactionPicker {
         level_handlers: &[LevelHandler],
         stats: &mut LocalPickerStatistic,
     ) -> Option<CompactionInput> {
+        self.pick_compaction_with_output_conflict_check(levels, level_handlers, stats, |_| false)
+    }
+}
+
+impl LevelCompactionPicker {
+    /// The selector supplies its output-conflict check only for partition ToBase growth. The
+    /// initial task still goes through the normal outer check; a failed growth never replaces it.
+    pub(crate) fn pick_compaction_with_output_conflict_check(
+        &mut self,
+        levels: &Levels,
+        level_handlers: &[LevelHandler],
+        stats: &mut LocalPickerStatistic,
+        has_output_conflict: impl Fn(&CompactionInput) -> bool,
+    ) -> Option<CompactionInput> {
         let l0 = &levels.l0;
         if l0.sub_levels.is_empty() {
             return None;
@@ -64,7 +77,9 @@ impl CompactionPicker for LevelCompactionPicker {
         let is_l0_pending_compact =
             level_handlers[0].is_level_all_pending_compact(&l0.sub_levels[0]);
 
-        if is_l0_pending_compact {
+        // Preserve the legacy early return. A partition-local view can contain a disjoint,
+        // runnable stack in newer sub-levels; let the existing picker check its overlap closure.
+        if is_l0_pending_compact && !self.mode.is_single_table_partition() {
             stats.skip_by_pending_files += 1;
             return None;
         }
@@ -76,7 +91,12 @@ impl CompactionPicker for LevelCompactionPicker {
             stats,
         ) {
             ret.vnode_partition_count = self.config.split_weight_by_vnode;
+            stats.is_trivial_move = self.mode.is_single_table_partition();
             return Some(ret);
+        }
+
+        if self.mode.is_trivial_move_only() {
+            return None;
         }
 
         debug_assert!(self.target_level == levels.get_level(self.target_level).level_idx as usize);
@@ -86,6 +106,7 @@ impl CompactionPicker for LevelCompactionPicker {
             self.config.split_weight_by_vnode,
             level_handlers,
             stats,
+            &has_output_conflict,
         ) {
             return Some(ret);
         }
@@ -185,17 +206,9 @@ impl LevelCompactionPicker {
         vnode_partition_count: u32,
         level_handlers: &[LevelHandler],
         stats: &mut LocalPickerStatistic,
+        has_output_conflict: &impl Fn(&CompactionInput) -> bool,
     ) -> Option<CompactionInput> {
         let overlap_strategy = create_overlap_strategy(self.config.compaction_mode());
-        // Partition admission is based on runnable stack depth. Reusing the legacy sub-level byte
-        // target here only changes candidate ordering (unexpected plans are still returned), and
-        // couples ToBase selection to an Intra/Tier sizing knob.
-        let min_compaction_bytes = if self.mode.is_single_table_partition() {
-            0
-        } else {
-            self.config.sub_level_max_compaction_bytes
-        };
-        let min_expected_level_count = self.mode.min_l0_level_count();
         let max_l0_compaction_bytes = std::cmp::max(
             self.config.max_bytes_for_level_base,
             self.config.max_compaction_bytes / 2,
@@ -204,13 +217,18 @@ impl LevelCompactionPicker {
             self.config
                 .max_l0_compact_level_count
                 .unwrap_or(compaction_config::max_l0_compact_level_count()) as usize;
+        let min_expected_level_count = match self.mode {
+            L0PickerMode::SingleTablePartition { min_l0_level_count } => min_l0_level_count.max(1),
+            _ => 1,
+        };
         let non_overlap_sub_level_picker = NonOverlapSubLevelPicker::new(
-            min_compaction_bytes,
-            // divide by 2 because we need to select files of base level and it need use the other
-            // half quota.
+            if self.mode.is_single_table_partition() {
+                0
+            } else {
+                self.config.sub_level_max_compaction_bytes
+            },
             max_l0_compaction_bytes,
             min_expected_level_count,
-            // The maximum number of sub_level compact level per task
             self.config.level0_max_compact_file_number,
             overlap_strategy.clone(),
             self.developer_config.enable_check_task_level_overlap,
@@ -221,18 +239,14 @@ impl LevelCompactionPicker {
         );
 
         let candidate_levels = if self.mode.is_single_table_partition() {
-            // The partition view has already removed unrelated vnode ranges. It may contain
-            // levels with different legacy partition markers, but must never cross an overlapping
-            // sub-level.
-            let non_overlapping_count = l0
+            // The fixed view already validates vnode boundaries. Stop before an overlapping
+            // sub-level: the non-overlapping closure builder must not cross that boundary.
+            let count = l0
                 .sub_levels
                 .iter()
                 .take_while(|level| level.level_type == LevelType::Nonoverlapping)
                 .count();
-            if non_overlapping_count == 0 {
-                return None;
-            }
-            &l0.sub_levels[..non_overlapping_count]
+            &l0.sub_levels[..count]
         } else {
             let mut max_vnode_partition_idx = 0;
             for (idx, level) in l0.sub_levels.iter().enumerate() {
@@ -243,7 +257,9 @@ impl LevelCompactionPicker {
             }
             &l0.sub_levels[..=max_vnode_partition_idx]
         };
-
+        if candidate_levels.is_empty() {
+            return None;
+        }
         let candidate_l0_plans = non_overlap_sub_level_picker
             .pick_l0_multi_non_overlap_level(candidate_levels, &level_handlers[0]);
         if candidate_l0_plans.is_empty() {
@@ -251,93 +267,34 @@ impl LevelCompactionPicker {
             return None;
         }
 
-        let mut skip_by_pending = false;
-        let mut input_levels = vec![];
-
-        for input in candidate_l0_plans {
-            // Partition admission already checks the configured L0 depth. Keep the same check at
-            // the task boundary as a defense against a key-range candidate that spans fewer
-            // sub-levels than the partition-level view suggested.
+        let mut skipped_pending_target = false;
+        let mut candidates = candidate_l0_plans.into_iter();
+        while let Some(input) = candidates.next() {
+            // Partition depth is only admission pressure. A chosen range must independently
+            // satisfy the depth contract, including after the legacy builder's truncation.
             if self.mode.is_single_table_partition()
                 && input.sstable_infos.len() < min_expected_level_count
             {
                 stats.skip_by_count_limit += 1;
                 continue;
             }
-
             let l0_select_tables = input
                 .sstable_infos
                 .iter()
                 .flat_map(|(_, select_tables)| select_tables.clone())
                 .collect_vec();
-
-            let target_level_ssts = overlap_strategy
+            let target_level_files = overlap_strategy
                 .check_base_level_overlap(&l0_select_tables, &target_level.table_infos);
-
-            let mut target_level_size = 0;
-            let mut pending_compact = false;
-            for sst in &target_level_ssts {
-                if level_handlers[target_level.level_idx as usize].is_pending_compact(&sst.sst_id) {
-                    pending_compact = true;
-                    break;
-                }
-
-                target_level_size += sst.sst_size;
-            }
-
-            if pending_compact {
-                skip_by_pending = true;
+            if target_level_files.iter().any(|sst| {
+                level_handlers[target_level.level_idx as usize].is_pending_compact(&sst.sst_id)
+            }) {
+                skipped_pending_target = true;
                 continue;
             }
+            let target_input_size = target_level_files.iter().map(|sst| sst.sst_size).sum();
+            let target_file_count = target_level_files.len();
 
-            input_levels.push((input, target_level_size, target_level_ssts));
-        }
-
-        if input_levels.is_empty() {
-            if skip_by_pending {
-                stats.skip_by_pending_files += 1;
-            }
-            return None;
-        }
-
-        if self.mode.is_single_table_partition() {
-            let mut candidates = std::mem::take(&mut input_levels);
-            let (mut selected, target_level_size, target_level_ssts) = candidates.remove(0);
-            if !target_level_ssts.is_empty() {
-                for (candidate, _, _) in candidates {
-                    let Some(merged) = Self::merge_partition_l0_inputs(
-                        candidate_levels,
-                        &selected,
-                        &candidate,
-                        max_l0_compaction_bytes,
-                        self.config.level0_max_compact_file_number,
-                        max_l0_level_count,
-                    ) else {
-                        continue;
-                    };
-                    if merged.total_file_size.saturating_add(target_level_size)
-                        > self.config.max_compaction_bytes
-                    {
-                        continue;
-                    }
-
-                    let merged_l0_ssts = merged
-                        .sstable_infos
-                        .iter()
-                        .flat_map(|(_, ssts)| ssts.iter().cloned())
-                        .collect_vec();
-                    let merged_target_ssts = overlap_strategy
-                        .check_base_level_overlap(&merged_l0_ssts, &target_level.table_infos);
-                    if Self::same_sst_ids(&merged_target_ssts, &target_level_ssts) {
-                        selected = merged;
-                    }
-                }
-            }
-            input_levels.push((selected, target_level_size, target_level_ssts));
-        }
-
-        for (input, target_file_size, target_level_files) in input_levels {
-            let mut select_level_inputs = input
+            let mut input_levels = input
                 .sstable_infos
                 .into_iter()
                 .map(|(_, table_infos)| InputLevel {
@@ -346,24 +303,22 @@ impl LevelCompactionPicker {
                     table_infos,
                 })
                 .collect_vec();
-            select_level_inputs.reverse();
-            let target_file_count = target_level_files.len();
-            select_level_inputs.push(InputLevel {
+            input_levels.reverse();
+            input_levels.push(InputLevel {
                 level_idx: target_level.level_idx,
                 level_type: target_level.level_type,
                 table_infos: target_level_files,
             });
 
-            let result = CompactionInput {
-                input_levels: select_level_inputs,
+            let mut result = CompactionInput {
+                input_levels,
                 target_level: self.target_level,
                 select_input_size: input.total_file_size,
-                target_input_size: target_file_size,
+                target_input_size,
                 total_file_count: (input.total_file_count + target_file_count) as u64,
                 vnode_partition_count,
                 ..Default::default()
             };
-
             if !self.compaction_task_validator.valid_compact_task(
                 &result,
                 ValidationRuleType::ToBase,
@@ -374,8 +329,6 @@ impl LevelCompactionPicker {
                         *counter += 1;
                         *counter
                     });
-
-                    // reduce log
                     if log_counter.is_multiple_of(100) {
                         tracing::warn!(
                             "skip task with level count: {}, file count: {}, select size: {}, target size: {}, target level size: {}",
@@ -389,73 +342,130 @@ impl LevelCompactionPicker {
                 }
                 continue;
             }
-
+            if self.mode.is_single_table_partition() {
+                stats.partition_l0_growth.initial_l0_size = result.select_input_size;
+                // Reuse only the remaining, already correctness-closed plans. Donors need not
+                // satisfy the initial seed depth. Do not grow moves or an output-conflicting seed.
+                if target_file_count > 0 && !has_output_conflict(&result) {
+                    for donor in candidates {
+                        let outcome = match self.try_grow_partition_l0_input(
+                            &result,
+                            &donor,
+                            candidate_levels,
+                            target_level,
+                        ) {
+                            Ok(grown) if has_output_conflict(&grown) => {
+                                PartitionL0GrowthOutcome::OutputConflict
+                            }
+                            Ok(grown) => {
+                                result = grown;
+                                PartitionL0GrowthOutcome::Accepted
+                            }
+                            Err(reason) => reason,
+                        };
+                        stats.partition_l0_growth.outcomes[outcome as usize] += 1;
+                    }
+                }
+            }
             return Some(result);
+        }
+
+        if skipped_pending_target {
+            stats.skip_by_pending_files += 1;
         }
         None
     }
 
-    /// Combine independently valid L0 overlap closures within one fixed vnode partition. The
-    /// caller must still verify that the combined key range does not pull in another Base SST.
-    fn merge_partition_l0_inputs(
+    /// Union independently closed candidates from one fixed partition, preserving the Base set.
+    /// This is optional amortization, not a new closure builder. Pending checks have already run
+    /// on both L0 closures and on the frozen Base inputs. Do not verify the union as one L0 hull:
+    /// disjoint valid closures may leave an unselected key-range hole between them.
+    fn try_grow_partition_l0_input(
+        &self,
+        selected: &CompactionInput,
+        donor: &SubLevelSstables,
         candidate_levels: &[Level],
-        selected: &SubLevelSstables,
-        candidate: &SubLevelSstables,
-        max_compaction_bytes: u64,
-        max_file_count: u64,
-        max_level_count: usize,
-    ) -> Option<SubLevelSstables> {
-        let mut selected_ids = HashSet::new();
-        selected_ids.extend(
-            selected
+        target_level: &Level,
+    ) -> Result<CompactionInput, PartitionL0GrowthOutcome> {
+        use PartitionL0GrowthOutcome as Rejected;
+        let mut ids = selected
+            .input_levels
+            .iter()
+            .filter(|level| level.level_idx == 0)
+            .flat_map(|level| level.table_infos.iter().map(|sst| sst.sst_id))
+            .collect::<HashSet<_>>();
+        let old_count = ids.len();
+        ids.extend(
+            donor
                 .sstable_infos
                 .iter()
                 .flat_map(|(_, ssts)| ssts.iter().map(|sst| sst.sst_id)),
         );
-        let old_file_count = selected_ids.len();
-        selected_ids.extend(
-            candidate
-                .sstable_infos
-                .iter()
-                .flat_map(|(_, ssts)| ssts.iter().map(|sst| sst.sst_id)),
-        );
-        if selected_ids.len() == old_file_count {
-            return None;
+        if ids.len() == old_count {
+            return Err(Rejected::NoNewSst);
         }
-
-        let mut merged = SubLevelSstables::default();
+        if ids.len() as u64 > self.config.level0_max_compact_file_number {
+            return Err(Rejected::Files);
+        }
+        let mut input_levels = vec![];
+        let mut l0_size = 0;
         for level in candidate_levels {
-            let ssts = level
+            let table_infos = level
                 .table_infos
                 .iter()
-                .filter(|sst| selected_ids.contains(&sst.sst_id))
+                .filter(|sst| ids.contains(&sst.sst_id))
                 .cloned()
                 .collect_vec();
-            if ssts.is_empty() {
-                continue;
+            if !table_infos.is_empty() {
+                l0_size += table_infos.iter().map(|sst| sst.sst_size).sum::<u64>();
+                input_levels.push(InputLevel {
+                    level_idx: 0,
+                    level_type: LevelType::Nonoverlapping,
+                    table_infos,
+                });
             }
-            merged.total_file_count += ssts.len();
-            merged.total_file_size += ssts.iter().map(|sst| sst.sst_size).sum::<u64>();
-            merged.sstable_infos.push((level.sub_level_id, ssts));
         }
-
-        if merged.total_file_count != selected_ids.len()
-            || merged.total_file_size > max_compaction_bytes
-            || merged.total_file_count as u64 > max_file_count
-            || merged.sstable_infos.len() > max_level_count
+        let max_levels =
+            self.config
+                .max_l0_compact_level_count
+                .unwrap_or(compaction_config::max_l0_compact_level_count()) as usize;
+        if input_levels.len() > max_levels {
+            return Err(Rejected::Levels);
+        }
+        let max_l0_bytes = self
+            .config
+            .max_bytes_for_level_base
+            .max(self.config.max_compaction_bytes / 2);
+        if l0_size > max_l0_bytes
+            || l0_size.saturating_add(selected.target_input_size) > self.config.max_compaction_bytes
         {
-            return None;
+            return Err(Rejected::Bytes);
         }
-        merged.expected = selected.expected;
-        Some(merged)
-    }
-
-    fn same_sst_ids(left: &[SstableInfo], right: &[SstableInfo]) -> bool {
-        left.len() == right.len()
-            && left
-                .iter()
-                .zip(right)
-                .all(|(left, right)| left.sst_id == right.sst_id)
+        let l0_ssts = input_levels
+            .iter()
+            .flat_map(|level| level.table_infos.iter().cloned())
+            .collect_vec();
+        let target_ssts = create_overlap_strategy(self.config.compaction_mode())
+            .check_base_level_overlap(&l0_ssts, &target_level.table_infos);
+        let selected_base = selected.input_levels.last().unwrap();
+        if !target_ssts
+            .iter()
+            .map(|sst| sst.sst_id)
+            .eq(selected_base.table_infos.iter().map(|sst| sst.sst_id))
+        {
+            return Err(Rejected::BaseSetChange);
+        }
+        input_levels.reverse();
+        input_levels.push(selected_base.clone());
+        Ok(CompactionInput {
+            input_levels,
+            target_level: self.target_level,
+            select_input_size: l0_size,
+            target_input_size: selected.target_input_size,
+            total_file_count: (ids.len() + target_ssts.len()) as u64,
+            vnode_partition_count: selected.vnode_partition_count,
+            ..Default::default()
+        })
     }
 }
 
@@ -514,6 +524,47 @@ pub mod tests {
         ret.add_pending_task(1, &mut handlers);
         assert!(
             picker
+                .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_trivial_move_only_does_not_fall_back_to_rewrite() {
+        let config = Arc::new(CompactionConfigBuilder::new().build());
+        let levels = Levels {
+            l0: generate_l0_nonoverlapping_multi_sublevels(vec![vec![generate_table(
+                1, 1, 0, 10, 1,
+            )]]),
+            levels: vec![generate_level(1, vec![generate_table(10, 1, 0, 10, 0)])],
+            ..Default::default()
+        };
+        let handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+
+        let mut rewrite_picker = LevelCompactionPicker::new_with_mode(
+            1,
+            config.clone(),
+            Arc::new(CompactionTaskValidator::unused()),
+            Arc::new(CompactionDeveloperConfig::default()),
+            L0PickerMode::SingleTablePartition {
+                min_l0_level_count: 1,
+            },
+        );
+        assert!(
+            rewrite_picker
+                .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
+                .is_some()
+        );
+
+        let mut trivial_move_picker = LevelCompactionPicker::new_with_mode(
+            1,
+            config,
+            Arc::new(CompactionTaskValidator::unused()),
+            Arc::new(CompactionDeveloperConfig::default()),
+            L0PickerMode::SingleTablePartitionTrivialMove,
+        );
+        assert!(
+            trivial_move_picker
                 .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
                 .is_none()
         );
@@ -986,10 +1037,164 @@ pub mod tests {
         assert!(stats.skip_by_count_limit > 0);
     }
 
-    fn free_growth_test_levels(base_tables: Vec<SstableInfo>) -> Levels {
-        Levels {
-            levels: vec![generate_level(1, base_tables)],
+    #[test]
+    fn partition_to_base_retries_after_deepest_seed_hits_pending_base() {
+        let config = Arc::new(
+            CompactionConfigBuilder::new()
+                .max_compaction_bytes(10_000)
+                .max_bytes_for_level_base(1_000)
+                .level0_sub_level_compact_level_count(3)
+                .build(),
+        );
+        let mut picker = LevelCompactionPicker::new_with_mode(
+            1,
+            config,
+            Arc::new(CompactionTaskValidator::unused()),
+            Arc::new(CompactionDeveloperConfig {
+                enable_trivial_move: false,
+                ..Default::default()
+            }),
+            L0PickerMode::SingleTablePartition {
+                min_l0_level_count: 3,
+            },
+        );
+        let levels = Levels {
+            levels: vec![generate_level(
+                1,
+                vec![
+                    generate_table(100, 1, 0, 10, 0),
+                    generate_table(101, 1, 20, 30, 0),
+                ],
+            )],
             l0: generate_l0_nonoverlapping_multi_sublevels(vec![
+                vec![
+                    generate_table(1, 1, 0, 10, 1),
+                    generate_table(2, 1, 20, 30, 1),
+                ],
+                vec![
+                    generate_table(3, 1, 0, 10, 2),
+                    generate_table(4, 1, 20, 30, 2),
+                ],
+                vec![
+                    generate_table(5, 1, 0, 10, 3),
+                    generate_table(6, 1, 20, 30, 3),
+                ],
+                vec![generate_table(7, 1, 0, 10, 4)],
+            ]),
+            ..Default::default()
+        };
+        let mut handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        handlers[1].add_pending_task(99, 2, levels.levels[0].table_infos.iter().take(1));
+
+        let input = picker
+            .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
+            .expect("a later valid seed must be tried after the deepest seed hits pending Base");
+        let selected_l0_ids = input
+            .input_levels
+            .iter()
+            .filter(|level| level.level_idx == 0)
+            .flat_map(|level| level.table_infos.iter())
+            .map(|sst| sst.sst_id.as_raw_id())
+            .sorted()
+            .collect_vec();
+
+        assert_eq!(selected_l0_ids, vec![2, 4, 6]);
+    }
+
+    #[test]
+    fn partition_to_base_ignores_fully_pending_oldest_disjoint_sub_level() {
+        let config = Arc::new(
+            CompactionConfigBuilder::new()
+                .max_compaction_bytes(10_000)
+                .max_bytes_for_level_base(1_000)
+                .level0_sub_level_compact_level_count(3)
+                .build(),
+        );
+        let mut picker = LevelCompactionPicker::new_with_mode(
+            1,
+            config,
+            Arc::new(CompactionTaskValidator::unused()),
+            Arc::new(CompactionDeveloperConfig {
+                enable_trivial_move: false,
+                ..Default::default()
+            }),
+            L0PickerMode::SingleTablePartition {
+                min_l0_level_count: 3,
+            },
+        );
+        let levels = Levels {
+            levels: vec![generate_level(
+                1,
+                vec![
+                    generate_table(100, 1, 0, 10, 0),
+                    generate_table(101, 1, 20, 30, 0),
+                ],
+            )],
+            l0: generate_l0_nonoverlapping_multi_sublevels(vec![
+                vec![generate_table(1, 1, 0, 10, 1)],
+                vec![generate_table(2, 1, 20, 30, 2)],
+                vec![generate_table(3, 1, 20, 30, 3)],
+                vec![generate_table(4, 1, 20, 30, 4)],
+                vec![generate_table(5, 1, 20, 30, 5)],
+            ]),
+            ..Default::default()
+        };
+        let mut handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        handlers[0].add_pending_task(99, 1, &levels.l0.sub_levels[0].table_infos);
+
+        let input = picker
+            .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
+            .expect("a pending disjoint oldest sub-level must not block a runnable newer stack");
+        let selected_l0_ids = input
+            .input_levels
+            .iter()
+            .filter(|level| level.level_idx == 0)
+            .flat_map(|level| level.table_infos.iter())
+            .map(|sst| sst.sst_id.as_raw_id())
+            .sorted()
+            .collect_vec();
+
+        assert_eq!(selected_l0_ids, vec![2, 3, 4, 5]);
+
+        picker.mode = L0PickerMode::Legacy;
+        assert!(
+            picker
+                .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
+                .is_none()
+        );
+
+        // Skipping the early return must not skip a pending SST in the actual closure.
+        picker.mode = L0PickerMode::SingleTablePartition {
+            min_l0_level_count: 3,
+        };
+        let mut overlapping = levels.clone();
+        overlapping.l0.sub_levels[0].table_infos[0] = generate_table(1, 1, 20, 30, 1);
+        assert!(
+            picker
+                .pick_compaction(
+                    &overlapping,
+                    &handlers,
+                    &mut LocalPickerStatistic::default()
+                )
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn partition_growth_amortizes_base_and_preserves_seed_on_rejection() {
+        use risingwave_hummock_sdk::compact_task::{CompactTask, CompactTaskAssignment};
+
+        use crate::hummock::compaction::InProgressCompactionView;
+
+        for scenario in [
+            "accepted",
+            "accepted-then-rejected",
+            "shallow-donor",
+            "base-set-change",
+            "output-conflict",
+            "legacy",
+        ] {
+            let mut l0 = vec![
                 vec![
                     generate_table(1, 1, 10, 20, 1),
                     generate_table(2, 1, 60, 70, 1),
@@ -998,91 +1203,216 @@ pub mod tests {
                     generate_table(3, 1, 10, 20, 2),
                     generate_table(4, 1, 60, 70, 2),
                 ],
-            ]),
-            ..Default::default()
+            ];
+            if scenario == "shallow-donor" {
+                l0[1].pop();
+            }
+            if scenario == "accepted-then-rejected" {
+                l0[0].push(generate_table(5, 1, 100, 110, 1));
+                l0[1].push(generate_table(6, 1, 100, 110, 2));
+            }
+            let narrow_base = matches!(scenario, "base-set-change" | "output-conflict");
+            let mut base = vec![if narrow_base {
+                generate_table(100, 1, 10, 20, 0)
+            } else {
+                // Both disjoint L0 closures would otherwise rewrite this same Base SST.
+                generate_table(100, 1, 0, 90, 0)
+            }];
+            if scenario == "base-set-change" {
+                base.push(generate_table(101, 1, 60, 70, 0));
+            }
+            if scenario == "accepted-then-rejected" {
+                base.push(generate_table(101, 1, 100, 110, 0));
+            }
+            let levels = Levels {
+                levels: vec![generate_level(1, base)],
+                l0: generate_l0_nonoverlapping_multi_sublevels(l0),
+                ..Default::default()
+            };
+            let config = CompactionConfig {
+                // Growth within the existing levels is allowed even at the level limit.
+                max_l0_compact_level_count: Some(2),
+                ..CompactionConfigBuilder::new()
+                    .max_compaction_bytes(10_000)
+                    .build()
+            };
+            let mut picker = LevelCompactionPicker::new_with_mode(
+                1,
+                Arc::new(config),
+                Arc::new(CompactionTaskValidator::unused()),
+                Arc::new(CompactionDeveloperConfig {
+                    enable_trivial_move: false,
+                    ..Default::default()
+                }),
+                if scenario == "legacy" {
+                    L0PickerMode::Legacy
+                } else {
+                    L0PickerMode::SingleTablePartition {
+                        min_l0_level_count: 2,
+                    }
+                },
+            );
+            // The pending output lies in the hole between the two L0 closures, and touches
+            // neither Base SST. Only the grown output hull conflicts with it.
+            let assignments = [CompactTaskAssignment {
+                compact_task: CompactTask {
+                    task_id: 99,
+                    compaction_group_id: 1.into(),
+                    target_level: 1,
+                    input_ssts: vec![InputLevel {
+                        level_idx: 0,
+                        level_type: LevelType::Nonoverlapping,
+                        table_infos: vec![generate_table(999, 1, 40, 50, 0)],
+                    }],
+                    ..Default::default()
+                },
+                context_id: 1.into(),
+            }];
+            let in_progress = InProgressCompactionView::for_group(&assignments, 1.into());
+            let handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+            let mut stats = LocalPickerStatistic::default();
+            let input = picker
+                .pick_compaction_with_output_conflict_check(
+                    &levels,
+                    &handlers,
+                    &mut stats,
+                    |input| {
+                        scenario == "output-conflict" && in_progress.has_conflict_with_input(input)
+                    },
+                )
+                .unwrap();
+            let expected_l0_files = match scenario {
+                "accepted" | "accepted-then-rejected" => 4,
+                "shallow-donor" => 3,
+                _ => 2,
+            };
+            assert_eq!(input.total_file_count, expected_l0_files + 1, "{scenario}");
+            assert_eq!(
+                input.select_input_size,
+                expected_l0_files * 11,
+                "{scenario}"
+            );
+            assert_eq!(
+                input.target_input_size,
+                if narrow_base { 11 } else { 91 },
+                "{scenario}"
+            );
+            assert_eq!(
+                input.input_levels.last().unwrap().table_infos[0].sst_id,
+                100
+            );
+            if scenario != "legacy" {
+                assert_eq!(stats.partition_l0_growth.initial_l0_size, 22);
+                let outcome = match scenario {
+                    "accepted" | "accepted-then-rejected" | "shallow-donor" => {
+                        PartitionL0GrowthOutcome::Accepted
+                    }
+                    "base-set-change" => PartitionL0GrowthOutcome::BaseSetChange,
+                    _ => PartitionL0GrowthOutcome::OutputConflict,
+                };
+                assert_eq!(
+                    stats.partition_l0_growth.outcomes[outcome as usize], 1,
+                    "{scenario}"
+                );
+                if scenario == "accepted-then-rejected" {
+                    assert_eq!(
+                        stats.partition_l0_growth.outcomes
+                            [PartitionL0GrowthOutcome::BaseSetChange as usize],
+                        1
+                    );
+                }
+            } else {
+                assert_eq!(stats.partition_l0_growth.outcomes, [0; 7]);
+            }
         }
     }
 
-    fn free_growth_test_picker(mode: L0PickerMode) -> LevelCompactionPicker {
-        let config = Arc::new(
-            CompactionConfigBuilder::new()
-                .max_compaction_bytes(10_000)
-                .sub_level_max_compaction_bytes(1)
-                .max_bytes_for_level_base(1_000)
-                .level0_sub_level_compact_level_count(2)
-                .build(),
-        );
-        LevelCompactionPicker::new_with_mode(
-            1,
-            config,
-            Arc::new(CompactionTaskValidator::unused()),
-            Arc::new(CompactionDeveloperConfig {
-                enable_trivial_move: false,
-                ..Default::default()
-            }),
-            mode,
-        )
-    }
-
-    fn l0_input_count(input: &CompactionInput) -> usize {
-        input
-            .input_levels
-            .iter()
-            .filter(|level| level.level_idx == 0)
-            .map(|level| level.table_infos.len())
-            .sum()
-    }
-
     #[test]
-    fn partition_to_base_grows_l0_without_new_target() {
-        let levels = free_growth_test_levels(vec![generate_table(100, 1, 0, 100, 0)]);
-        let handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
-        let mut picker = free_growth_test_picker(L0PickerMode::SingleTablePartition {
-            min_l0_level_count: 2,
-        });
-
-        let input = picker
-            .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
-            .unwrap();
-
-        assert_eq!(l0_input_count(&input), 4);
-        assert_eq!(input.input_levels.last().unwrap().table_infos.len(), 1);
-        assert_eq!(
-            input.input_levels.last().unwrap().table_infos[0].sst_id,
-            100
-        );
-    }
-
-    #[test]
-    fn partition_to_base_does_not_grow_across_new_target() {
-        let levels = free_growth_test_levels(vec![
-            generate_table(100, 1, 0, 40, 0),
-            generate_table(101, 1, 50, 100, 0),
+    fn partition_growth_distinguishes_duplicate_and_limit_rejections() {
+        use PartitionL0GrowthOutcome as Outcome;
+        let levels = generate_l0_nonoverlapping_multi_sublevels(vec![
+            vec![
+                generate_table(1, 1, 10, 20, 1),
+                generate_table(2, 1, 60, 70, 1),
+            ],
+            vec![generate_table(3, 1, 10, 20, 2)],
+            vec![generate_table(4, 1, 60, 70, 3)],
         ]);
-        let handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
-        let mut picker = free_growth_test_picker(L0PickerMode::SingleTablePartition {
-            min_l0_level_count: 2,
-        });
-
-        let input = picker
-            .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
-            .unwrap();
-
-        assert_eq!(l0_input_count(&input), 2);
-        assert_eq!(input.input_levels.last().unwrap().table_infos.len(), 1);
-    }
-
-    #[test]
-    fn legacy_to_base_does_not_use_partition_free_growth() {
-        let levels = free_growth_test_levels(vec![generate_table(100, 1, 0, 100, 0)]);
-        let handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
-        let mut picker = free_growth_test_picker(L0PickerMode::Legacy);
-
-        let input = picker
-            .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
-            .unwrap();
-
-        assert_eq!(l0_input_count(&input), 2);
+        let base = generate_level(1, vec![generate_table(100, 1, 10, 20, 0)]);
+        let selected = CompactionInput {
+            input_levels: vec![
+                InputLevel {
+                    level_idx: 0,
+                    level_type: LevelType::Nonoverlapping,
+                    table_infos: vec![levels.sub_levels[1].table_infos[0].clone()],
+                },
+                InputLevel {
+                    level_idx: 0,
+                    level_type: LevelType::Nonoverlapping,
+                    table_infos: vec![levels.sub_levels[0].table_infos[0].clone()],
+                },
+                InputLevel {
+                    level_idx: 1,
+                    level_type: LevelType::Nonoverlapping,
+                    table_infos: base.table_infos.clone(),
+                },
+            ],
+            select_input_size: 22,
+            target_input_size: 11,
+            total_file_count: 3,
+            target_level: 1,
+            ..Default::default()
+        };
+        for outcome in [
+            Outcome::NoNewSst,
+            Outcome::Files,
+            Outcome::Levels,
+            Outcome::Bytes,
+        ] {
+            let mut picker = create_compaction_picker_for_test();
+            let config = Arc::make_mut(&mut picker.config);
+            config.max_l0_compact_level_count = Some(if matches!(outcome, Outcome::Levels) {
+                2
+            } else {
+                10
+            });
+            config.level0_max_compact_file_number = if matches!(outcome, Outcome::Files) {
+                3
+            } else {
+                100
+            };
+            config.max_compaction_bytes = if matches!(outcome, Outcome::Bytes) {
+                44
+            } else {
+                10_000
+            };
+            let donor = SubLevelSstables {
+                sstable_infos: if matches!(outcome, Outcome::NoNewSst) {
+                    vec![(
+                        levels.sub_levels[0].sub_level_id,
+                        vec![levels.sub_levels[0].table_infos[0].clone()],
+                    )]
+                } else {
+                    vec![
+                        (
+                            levels.sub_levels[0].sub_level_id,
+                            vec![levels.sub_levels[0].table_infos[1].clone()],
+                        ),
+                        (
+                            levels.sub_levels[2].sub_level_id,
+                            vec![levels.sub_levels[2].table_infos[0].clone()],
+                        ),
+                    ]
+                },
+                ..Default::default()
+            };
+            let reason = picker
+                .try_grow_partition_l0_input(&selected, &donor, &levels.sub_levels, &base)
+                .unwrap_err();
+            assert_eq!(reason as usize, outcome as usize);
+            assert_eq!(selected.select_input_size, 22);
+            assert_eq!(selected.total_file_count, 3);
+        }
     }
 
     #[test]

--- a/src/meta/src/hummock/compaction/picker/base_level_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/base_level_compaction_picker.rs
@@ -13,14 +13,16 @@
 // limitations under the License.
 
 use std::cell::RefCell;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use itertools::Itertools;
 use risingwave_common::config::meta::default::compaction_config;
 use risingwave_hummock_sdk::level::{InputLevel, Level, Levels, OverlappingLevel};
+use risingwave_hummock_sdk::sstable_info::SstableInfo;
 use risingwave_pb::hummock::{CompactionConfig, LevelType};
 
-use super::non_overlap_sub_level_picker::NonOverlapSubLevelPicker;
+use super::non_overlap_sub_level_picker::{NonOverlapSubLevelPicker, SubLevelSstables};
 use super::{
     CompactionInput, CompactionPicker, CompactionTaskValidator, L0PickerMode, LocalPickerStatistic,
     ValidationRuleType,
@@ -185,24 +187,34 @@ impl LevelCompactionPicker {
         stats: &mut LocalPickerStatistic,
     ) -> Option<CompactionInput> {
         let overlap_strategy = create_overlap_strategy(self.config.compaction_mode());
-        let min_compaction_bytes = self.config.sub_level_max_compaction_bytes;
+        // Partition admission is based on runnable stack depth. Reusing the legacy sub-level byte
+        // target here only changes candidate ordering (unexpected plans are still returned), and
+        // couples ToBase selection to an Intra/Tier sizing knob.
+        let min_compaction_bytes = if self.mode.is_single_table_partition() {
+            0
+        } else {
+            self.config.sub_level_max_compaction_bytes
+        };
         let min_expected_level_count = self.mode.min_l0_level_count();
+        let max_l0_compaction_bytes = std::cmp::max(
+            self.config.max_bytes_for_level_base,
+            self.config.max_compaction_bytes / 2,
+        );
+        let max_l0_level_count =
+            self.config
+                .max_l0_compact_level_count
+                .unwrap_or(compaction_config::max_l0_compact_level_count()) as usize;
         let non_overlap_sub_level_picker = NonOverlapSubLevelPicker::new(
             min_compaction_bytes,
             // divide by 2 because we need to select files of base level and it need use the other
             // half quota.
-            std::cmp::max(
-                self.config.max_bytes_for_level_base,
-                self.config.max_compaction_bytes / 2,
-            ),
+            max_l0_compaction_bytes,
             min_expected_level_count,
             // The maximum number of sub_level compact level per task
             self.config.level0_max_compact_file_number,
             overlap_strategy.clone(),
             self.developer_config.enable_check_task_level_overlap,
-            self.config
-                .max_l0_compact_level_count
-                .unwrap_or(compaction_config::max_l0_compact_level_count()) as usize,
+            max_l0_level_count,
             self.config
                 .enable_optimize_l0_interval_selection
                 .unwrap_or(compaction_config::enable_optimize_l0_interval_selection()),
@@ -288,6 +300,42 @@ impl LevelCompactionPicker {
             return None;
         }
 
+        if self.mode.is_single_table_partition() {
+            let mut candidates = std::mem::take(&mut input_levels);
+            let (mut selected, target_level_size, target_level_ssts) = candidates.remove(0);
+            if !target_level_ssts.is_empty() {
+                for (candidate, _, _) in candidates {
+                    let Some(merged) = Self::merge_partition_l0_inputs(
+                        candidate_levels,
+                        &selected,
+                        &candidate,
+                        max_l0_compaction_bytes,
+                        self.config.level0_max_compact_file_number,
+                        max_l0_level_count,
+                    ) else {
+                        continue;
+                    };
+                    if merged.total_file_size.saturating_add(target_level_size)
+                        > self.config.max_compaction_bytes
+                    {
+                        continue;
+                    }
+
+                    let merged_l0_ssts = merged
+                        .sstable_infos
+                        .iter()
+                        .flat_map(|(_, ssts)| ssts.iter().cloned())
+                        .collect_vec();
+                    let merged_target_ssts = overlap_strategy
+                        .check_base_level_overlap(&merged_l0_ssts, &target_level.table_infos);
+                    if Self::same_sst_ids(&merged_target_ssts, &target_level_ssts) {
+                        selected = merged;
+                    }
+                }
+            }
+            input_levels.push((selected, target_level_size, target_level_ssts));
+        }
+
         for (input, target_file_size, target_level_files) in input_levels {
             let mut select_level_inputs = input
                 .sstable_infos
@@ -345,6 +393,69 @@ impl LevelCompactionPicker {
             return Some(result);
         }
         None
+    }
+
+    /// Combine independently valid L0 overlap closures within one fixed vnode partition. The
+    /// caller must still verify that the combined key range does not pull in another Base SST.
+    fn merge_partition_l0_inputs(
+        candidate_levels: &[Level],
+        selected: &SubLevelSstables,
+        candidate: &SubLevelSstables,
+        max_compaction_bytes: u64,
+        max_file_count: u64,
+        max_level_count: usize,
+    ) -> Option<SubLevelSstables> {
+        let mut selected_ids = HashSet::new();
+        selected_ids.extend(
+            selected
+                .sstable_infos
+                .iter()
+                .flat_map(|(_, ssts)| ssts.iter().map(|sst| sst.sst_id)),
+        );
+        let old_file_count = selected_ids.len();
+        selected_ids.extend(
+            candidate
+                .sstable_infos
+                .iter()
+                .flat_map(|(_, ssts)| ssts.iter().map(|sst| sst.sst_id)),
+        );
+        if selected_ids.len() == old_file_count {
+            return None;
+        }
+
+        let mut merged = SubLevelSstables::default();
+        for level in candidate_levels {
+            let ssts = level
+                .table_infos
+                .iter()
+                .filter(|sst| selected_ids.contains(&sst.sst_id))
+                .cloned()
+                .collect_vec();
+            if ssts.is_empty() {
+                continue;
+            }
+            merged.total_file_count += ssts.len();
+            merged.total_file_size += ssts.iter().map(|sst| sst.sst_size).sum::<u64>();
+            merged.sstable_infos.push((level.sub_level_id, ssts));
+        }
+
+        if merged.total_file_count != selected_ids.len()
+            || merged.total_file_size > max_compaction_bytes
+            || merged.total_file_count as u64 > max_file_count
+            || merged.sstable_infos.len() > max_level_count
+        {
+            return None;
+        }
+        merged.expected = selected.expected;
+        Some(merged)
+    }
+
+    fn same_sst_ids(left: &[SstableInfo], right: &[SstableInfo]) -> bool {
+        left.len() == right.len()
+            && left
+                .iter()
+                .zip(right)
+                .all(|(left, right)| left.sst_id == right.sst_id)
     }
 }
 
@@ -873,6 +984,166 @@ pub mod tests {
                 .is_none()
         );
         assert!(stats.skip_by_count_limit > 0);
+    }
+
+    fn free_growth_test_levels(base_tables: Vec<SstableInfo>) -> Levels {
+        Levels {
+            levels: vec![generate_level(1, base_tables)],
+            l0: generate_l0_nonoverlapping_multi_sublevels(vec![
+                vec![
+                    generate_table(1, 1, 10, 20, 1),
+                    generate_table(2, 1, 60, 70, 1),
+                ],
+                vec![
+                    generate_table(3, 1, 10, 20, 2),
+                    generate_table(4, 1, 60, 70, 2),
+                ],
+            ]),
+            ..Default::default()
+        }
+    }
+
+    fn free_growth_test_picker(mode: L0PickerMode) -> LevelCompactionPicker {
+        let config = Arc::new(
+            CompactionConfigBuilder::new()
+                .max_compaction_bytes(10_000)
+                .sub_level_max_compaction_bytes(1)
+                .max_bytes_for_level_base(1_000)
+                .level0_sub_level_compact_level_count(2)
+                .build(),
+        );
+        LevelCompactionPicker::new_with_mode(
+            1,
+            config,
+            Arc::new(CompactionTaskValidator::unused()),
+            Arc::new(CompactionDeveloperConfig {
+                enable_trivial_move: false,
+                ..Default::default()
+            }),
+            mode,
+        )
+    }
+
+    fn l0_input_count(input: &CompactionInput) -> usize {
+        input
+            .input_levels
+            .iter()
+            .filter(|level| level.level_idx == 0)
+            .map(|level| level.table_infos.len())
+            .sum()
+    }
+
+    #[test]
+    fn partition_to_base_grows_l0_without_new_target() {
+        let levels = free_growth_test_levels(vec![generate_table(100, 1, 0, 100, 0)]);
+        let handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        let mut picker = free_growth_test_picker(L0PickerMode::SingleTablePartition {
+            min_l0_level_count: 2,
+        });
+
+        let input = picker
+            .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
+            .unwrap();
+
+        assert_eq!(l0_input_count(&input), 4);
+        assert_eq!(input.input_levels.last().unwrap().table_infos.len(), 1);
+        assert_eq!(
+            input.input_levels.last().unwrap().table_infos[0].sst_id,
+            100
+        );
+    }
+
+    #[test]
+    fn partition_to_base_does_not_grow_across_new_target() {
+        let levels = free_growth_test_levels(vec![
+            generate_table(100, 1, 0, 40, 0),
+            generate_table(101, 1, 50, 100, 0),
+        ]);
+        let handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        let mut picker = free_growth_test_picker(L0PickerMode::SingleTablePartition {
+            min_l0_level_count: 2,
+        });
+
+        let input = picker
+            .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
+            .unwrap();
+
+        assert_eq!(l0_input_count(&input), 2);
+        assert_eq!(input.input_levels.last().unwrap().table_infos.len(), 1);
+    }
+
+    #[test]
+    fn legacy_to_base_does_not_use_partition_free_growth() {
+        let levels = free_growth_test_levels(vec![generate_table(100, 1, 0, 100, 0)]);
+        let handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        let mut picker = free_growth_test_picker(L0PickerMode::Legacy);
+
+        let input = picker
+            .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
+            .unwrap();
+
+        assert_eq!(l0_input_count(&input), 2);
+    }
+
+    #[test]
+    fn partition_to_base_order_is_independent_of_legacy_sub_level_bytes() {
+        let levels = Levels {
+            levels: vec![generate_level(
+                1,
+                vec![
+                    generate_table(100, 1, 0, 99, 0),
+                    generate_table(101, 1, 200, 209, 0),
+                ],
+            )],
+            l0: generate_l0_nonoverlapping_multi_sublevels(vec![
+                vec![
+                    generate_table(1, 1, 0, 99, 1),
+                    generate_table(2, 1, 200, 209, 1),
+                ],
+                vec![
+                    generate_table(3, 1, 0, 99, 2),
+                    generate_table(4, 1, 200, 209, 2),
+                ],
+                vec![generate_table(5, 1, 200, 209, 3)],
+            ]),
+            ..Default::default()
+        };
+        let handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+
+        for sub_level_bytes in [128, 512] {
+            let config = Arc::new(
+                CompactionConfigBuilder::new()
+                    .max_compaction_bytes(10_000)
+                    .sub_level_max_compaction_bytes(sub_level_bytes)
+                    .max_bytes_for_level_base(1_000)
+                    .level0_sub_level_compact_level_count(2)
+                    .build(),
+            );
+            let mut picker = LevelCompactionPicker::new_with_mode(
+                1,
+                config,
+                Arc::new(CompactionTaskValidator::unused()),
+                Arc::new(CompactionDeveloperConfig {
+                    enable_trivial_move: false,
+                    ..Default::default()
+                }),
+                L0PickerMode::SingleTablePartition {
+                    min_l0_level_count: 2,
+                },
+            );
+
+            let input = picker
+                .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
+                .unwrap();
+            let selected_ids = input
+                .input_levels
+                .iter()
+                .filter(|level| level.level_idx == 0)
+                .flat_map(|level| level.table_infos.iter())
+                .map(|sst| sst.sst_id.as_raw_id())
+                .collect_vec();
+            assert_eq!(selected_ids, vec![5, 4, 2]);
+        }
     }
 
     #[test]

--- a/src/meta/src/hummock/compaction/picker/base_level_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/base_level_compaction_picker.rs
@@ -84,6 +84,26 @@ impl LevelCompactionPicker {
             return None;
         }
 
+        // Prefer a depth-qualified batch over moving a small part of its oldest sub-level.
+        // A failed normal pick still gets the existing move fallback; legacy remains move-first.
+        let normal_first = matches!(self.mode, L0PickerMode::SingleTablePartition { .. });
+        if normal_first
+            && let Some(ret) = self.pick_multi_level_to_base(
+                l0,
+                levels.get_level(self.target_level),
+                self.config.split_weight_by_vnode,
+                level_handlers,
+                stats,
+                &has_output_conflict,
+            )
+        {
+            // The manager already recognizes one non-overlapping source level plus an empty
+            // target as a metadata-only move. Keep the observation aligned with that task shape.
+            stats.is_trivial_move =
+                ret.input_levels.len() == 2 && ret.input_levels[1].table_infos.is_empty();
+            return Some(ret);
+        }
+
         if let Some(mut ret) = self.pick_base_trivial_move(
             l0,
             levels.get_level(self.target_level),
@@ -95,7 +115,9 @@ impl LevelCompactionPicker {
             return Some(ret);
         }
 
-        if self.mode.is_trivial_move_only() {
+        // Ordinary partition ToBase already attempted its normal pick above. Shallow partitions
+        // are move-only and must not fall through to a rewrite.
+        if normal_first || self.mode.is_trivial_move_only() {
             return None;
         }
 
@@ -489,6 +511,129 @@ pub mod tests {
     }
 
     #[test]
+    fn test_partition_prefers_batch_while_legacy_and_shallow_prefer_move() {
+        let config = Arc::new(CompactionConfigBuilder::new().build());
+        // The oldest SST can move into a Base gap, but the newer SSTs overlap it and Base.
+        let levels = Levels {
+            l0: generate_l0_nonoverlapping_multi_sublevels(vec![
+                vec![generate_table(1, 1, 0, 10, 1)],
+                vec![generate_table(2, 1, 0, 100, 2)],
+                vec![generate_table(3, 1, 0, 100, 3)],
+            ]),
+            levels: vec![generate_level(1, vec![generate_table(10, 1, 50, 100, 0)])],
+            ..Default::default()
+        };
+        let handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        for mode in [
+            L0PickerMode::SingleTablePartition {
+                min_l0_level_count: 3,
+            },
+            L0PickerMode::Legacy,
+            L0PickerMode::SingleTablePartitionTrivialMove,
+        ] {
+            let mut picker = LevelCompactionPicker::new_with_mode(
+                1,
+                config.clone(),
+                Arc::new(CompactionTaskValidator::unused()),
+                Arc::new(CompactionDeveloperConfig::default()),
+                mode,
+            );
+            let mut stats = LocalPickerStatistic::default();
+            let ret = picker
+                .pick_compaction(&levels, &handlers, &mut stats)
+                .unwrap();
+            if matches!(mode, L0PickerMode::SingleTablePartition { .. }) {
+                assert_eq!(ret.input_levels.len(), 4);
+                let mut source_ids = ret.input_levels[..3]
+                    .iter()
+                    .flat_map(|level| level.table_infos.iter().map(|sst| sst.sst_id))
+                    .collect_vec();
+                source_ids.sort();
+                assert_eq!(source_ids, vec![1u64, 2, 3]);
+                assert_eq!(ret.input_levels[3].table_infos[0].sst_id, 10);
+                assert!(!stats.is_trivial_move);
+            } else {
+                assert_eq!(ret.input_levels.len(), 2);
+                assert_eq!(ret.input_levels[0].table_infos[0].sst_id, 1);
+                assert!(ret.input_levels[1].table_infos.is_empty());
+                assert_eq!(stats.is_trivial_move, mode.is_single_table_partition());
+            }
+        }
+    }
+
+    #[test]
+    fn test_partition_falls_back_to_move_when_batch_base_is_pending() {
+        let config = Arc::new(CompactionConfigBuilder::new().build());
+        let levels = Levels {
+            l0: generate_l0_nonoverlapping_multi_sublevels(vec![
+                vec![generate_table(1, 1, 0, 10, 1)],
+                vec![generate_table(2, 1, 0, 100, 2)],
+                vec![generate_table(3, 1, 0, 100, 3)],
+            ]),
+            levels: vec![generate_level(1, vec![generate_table(10, 1, 50, 100, 0)])],
+            ..Default::default()
+        };
+        let mut handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        handlers[1].add_pending_task(100, 2, &levels.levels[0].table_infos);
+        let mut picker = LevelCompactionPicker::new_with_mode(
+            1,
+            config,
+            Arc::new(CompactionTaskValidator::unused()),
+            Arc::new(CompactionDeveloperConfig::default()),
+            L0PickerMode::SingleTablePartition {
+                min_l0_level_count: 3,
+            },
+        );
+        let mut stats = LocalPickerStatistic::default();
+        let ret = picker
+            .pick_compaction(&levels, &handlers, &mut stats)
+            .unwrap();
+        assert_eq!(ret.input_levels.len(), 2);
+        assert_eq!(ret.input_levels[0].table_infos[0].sst_id, 1);
+        assert!(ret.input_levels[1].table_infos.is_empty());
+        assert!(stats.skip_by_pending_files > 0);
+        assert!(stats.is_trivial_move);
+    }
+
+    #[test]
+    fn test_partition_normal_pick_marks_natural_move() {
+        let config = Arc::new(CompactionConfigBuilder::new().build());
+        let levels = Levels {
+            l0: generate_l0_nonoverlapping_multi_sublevels(vec![vec![generate_table(
+                1, 1, 0, 10, 1,
+            )]]),
+            levels: vec![generate_level(1, vec![])],
+            ..Default::default()
+        };
+        let mut picker = LevelCompactionPicker::new_with_mode(
+            1,
+            config,
+            Arc::new(CompactionTaskValidator::unused()),
+            Arc::new(CompactionDeveloperConfig::default()),
+            L0PickerMode::SingleTablePartition {
+                min_l0_level_count: 1,
+            },
+        );
+        let mut stats = LocalPickerStatistic::default();
+        let ret = picker
+            .pick_compaction(
+                &levels,
+                &[LevelHandler::new(0), LevelHandler::new(1)],
+                &mut stats,
+            )
+            .unwrap();
+        assert_eq!(ret.input_levels.len(), 2);
+        assert!(ret.input_levels[1].table_infos.is_empty());
+        // Only the normal pick records the initial L0 size; this was not a move fallback.
+        assert_eq!(
+            stats.partition_l0_growth.initial_l0_size,
+            ret.select_input_size
+        );
+        assert!(stats.partition_l0_growth.initial_l0_size > 0);
+        assert!(stats.is_trivial_move);
+    }
+
+    #[test]
     fn test_small_trivial_moves_ignore_legacy_min_size_and_count_all_files() {
         let config = Arc::new(CompactionConfig {
             split_weight_by_vnode: 8,
@@ -502,9 +647,7 @@ pub mod tests {
             config,
             Arc::new(CompactionTaskValidator::unused()),
             Arc::new(CompactionDeveloperConfig::default()),
-            L0PickerMode::SingleTablePartition {
-                min_l0_level_count: 1,
-            },
+            L0PickerMode::SingleTablePartitionTrivialMove,
         );
         let levels = Levels {
             l0: generate_l0_nonoverlapping_multi_sublevels(vec![vec![

--- a/src/meta/src/hummock/compaction/picker/emergency_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/emergency_compaction_picker.rs
@@ -114,3 +114,37 @@ impl EmergencyCompactionPicker {
         tier_compaction_picker.pick_compaction(levels, level_handlers, stats)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hummock::compaction::compaction_config::CompactionConfigBuilder;
+    use crate::hummock::compaction::selector::tests::{
+        generate_l0_nonoverlapping_sublevels, generate_level, generate_table,
+    };
+
+    #[test]
+    fn test_legacy_unpartitioned_levels_use_whole_level_in_emergency() {
+        let config = Arc::new(CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new().build()
+        });
+        let picker = EmergencyCompactionPicker::new(
+            1,
+            config,
+            Arc::new(CompactionDeveloperConfig::default()),
+        );
+        let levels = Levels {
+            l0: generate_l0_nonoverlapping_sublevels(
+                (1..=3).map(|id| generate_table(id, 1, 0, 10, id)).collect(),
+            ),
+            levels: vec![generate_level(1, vec![])],
+            ..Default::default()
+        };
+        let handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        let ret = picker
+            .pick_compaction(&levels, &handlers, &mut LocalPickerStatistic::default())
+            .unwrap();
+        assert_eq!(ret.target_level, 0);
+    }
+}

--- a/src/meta/src/hummock/compaction/picker/intra_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/intra_compaction_picker.rs
@@ -19,7 +19,7 @@ use risingwave_hummock_sdk::level::{InputLevel, Levels, OverlappingLevel};
 use risingwave_pb::hummock::{CompactionConfig, LevelType};
 
 use super::{
-    CompactionInput, CompactionPicker, CompactionTaskValidator, LocalPickerStatistic,
+    CompactionInput, CompactionPicker, CompactionTaskValidator, L0PickerMode, LocalPickerStatistic,
     ValidationRuleType,
 };
 use crate::hummock::compaction::picker::{NonOverlapSubLevelPicker, TrivialMovePicker};
@@ -31,6 +31,7 @@ pub struct IntraCompactionPicker {
     compaction_task_validator: Arc<CompactionTaskValidator>,
 
     developer_config: Arc<CompactionDeveloperConfig>,
+    mode: L0PickerMode,
 }
 
 impl CompactionPicker for IntraCompactionPicker {
@@ -49,31 +50,24 @@ impl CompactionPicker for IntraCompactionPicker {
             return Some(ret);
         }
 
-        let vnode_partition_count = self.config.split_weight_by_vnode;
-
-        if let Some(ret) =
-            self.pick_whole_level(l0, &level_handlers[0], vnode_partition_count, stats)
+        if !self.mode.is_single_table_partition()
+            && let Some(ret) = self.pick_whole_level(
+                l0,
+                &level_handlers[0],
+                self.config.split_weight_by_vnode,
+                stats,
+            )
         {
             if ret.input_levels.len() < 2 {
-                tracing::error!(
-                    ?ret,
-                    vnode_partition_count,
-                    "pick_whole_level failed to pick enough levels"
-                );
+                tracing::error!(?ret, "pick_whole_level failed to pick enough levels");
                 return None;
             }
-
             return Some(ret);
         }
 
-        if let Some(ret) = self.pick_l0_intra(l0, &level_handlers[0], vnode_partition_count, stats)
-        {
+        if let Some(ret) = self.pick_l0_intra(l0, &level_handlers[0], stats) {
             if ret.input_levels.len() < 2 {
-                tracing::error!(
-                    ?ret,
-                    vnode_partition_count,
-                    "pick_l0_intra failed to pick enough levels"
-                );
+                tracing::error!(?ret, "pick_l0_intra failed to pick enough levels");
                 return None;
             }
 
@@ -94,6 +88,7 @@ impl IntraCompactionPicker {
             compaction_task_validator: Arc::new(CompactionTaskValidator::new(config.clone())),
             config,
             developer_config,
+            mode: L0PickerMode::Legacy,
         }
     }
 
@@ -102,11 +97,26 @@ impl IntraCompactionPicker {
         compaction_task_validator: Arc<CompactionTaskValidator>,
         developer_config: Arc<CompactionDeveloperConfig>,
     ) -> IntraCompactionPicker {
+        Self::new_with_mode(
+            config,
+            compaction_task_validator,
+            developer_config,
+            L0PickerMode::Legacy,
+        )
+    }
+
+    pub(crate) fn new_with_mode(
+        config: Arc<CompactionConfig>,
+        compaction_task_validator: Arc<CompactionTaskValidator>,
+        developer_config: Arc<CompactionDeveloperConfig>,
+        mode: L0PickerMode,
+    ) -> IntraCompactionPicker {
         assert!(config.level0_sub_level_compact_level_count > 1);
         IntraCompactionPicker {
             config,
             compaction_task_validator,
             developer_config,
+            mode,
         }
     }
 
@@ -117,29 +127,29 @@ impl IntraCompactionPicker {
         partition_count: u32,
         stats: &mut LocalPickerStatistic,
     ) -> Option<CompactionInput> {
-        let picker = WholeLevelCompactionPicker::new(
-            self.config.clone(),
-            self.compaction_task_validator.clone(),
-        );
-        picker.pick_whole_level(l0, level_handler, partition_count, stats)
+        WholeLevelCompactionPicker::new(self.config.clone(), self.compaction_task_validator.clone())
+            .pick_whole_level(l0, level_handler, partition_count, stats)
     }
 
     fn pick_l0_intra(
         &self,
         l0: &OverlappingLevel,
         level_handler: &LevelHandler,
-        vnode_partition_count: u32,
         stats: &mut LocalPickerStatistic,
     ) -> Option<CompactionInput> {
         let overlap_strategy = create_overlap_strategy(self.config.compaction_mode());
-        let mut max_vnode_partition_idx = 0;
-        for (idx, level) in l0.sub_levels.iter().enumerate() {
-            if level.vnode_partition_count < vnode_partition_count {
-                break;
+        let legacy_max_partition_idx = if self.mode.is_single_table_partition() {
+            None
+        } else {
+            let mut max_idx = 0;
+            for (idx, level) in l0.sub_levels.iter().enumerate() {
+                if level.vnode_partition_count < self.config.split_weight_by_vnode {
+                    break;
+                }
+                max_idx = idx;
             }
-            max_vnode_partition_idx = idx;
-        }
-
+            Some(max_idx)
+        };
         for (idx, level) in l0.sub_levels.iter().enumerate() {
             if level.level_type != LevelType::Nonoverlapping
                 || level.total_file_size > self.config.sub_level_max_compaction_bytes
@@ -147,7 +157,7 @@ impl IntraCompactionPicker {
                 continue;
             }
 
-            if idx > max_vnode_partition_idx {
+            if legacy_max_partition_idx.is_some_and(|max_idx| idx > max_idx) {
                 break;
             }
 
@@ -176,10 +186,19 @@ impl IntraCompactionPicker {
                     .unwrap_or(compaction_config::enable_optimize_l0_interval_selection()),
             );
 
-            let candidate_l0_plans = non_overlap_sub_level_picker.pick_l0_multi_non_overlap_level(
-                &l0.sub_levels[idx..=max_vnode_partition_idx],
-                level_handler,
-            );
+            let candidate_levels = if let Some(max_idx) = legacy_max_partition_idx {
+                &l0.sub_levels[idx..=max_idx]
+            } else {
+                // Do not cross an overlapping sub-level that still needs Tier compaction.
+                let candidate_levels = &l0.sub_levels[idx..];
+                let non_overlapping_count = candidate_levels
+                    .iter()
+                    .take_while(|level| level.level_type == LevelType::Nonoverlapping)
+                    .count();
+                &candidate_levels[..non_overlapping_count]
+            };
+            let candidate_l0_plans = non_overlap_sub_level_picker
+                .pick_l0_multi_non_overlap_level(candidate_levels, level_handler);
 
             if candidate_l0_plans.is_empty() {
                 continue;
@@ -258,8 +277,9 @@ impl IntraCompactionPicker {
                 continue;
             }
 
-            if l0.sub_levels[idx + 1].vnode_partition_count
-                != l0.sub_levels[idx].vnode_partition_count
+            if !self.mode.is_single_table_partition()
+                && l0.sub_levels[idx + 1].vnode_partition_count
+                    != l0.sub_levels[idx].vnode_partition_count
             {
                 continue;
             }
@@ -356,11 +376,9 @@ impl WholeLevelCompactionPicker {
             let max_compaction_bytes = std::cmp::max(
                 self.config.max_bytes_for_level_base,
                 self.config.sub_level_max_compaction_bytes
-                    * (self.config.level0_sub_level_compact_level_count as u64),
+                    * self.config.level0_sub_level_compact_level_count as u64,
             );
-
             let mut select_input_size = 0;
-
             let mut select_level_inputs = vec![];
             let mut total_file_count = 0;
             let mut wait_enough = false;
@@ -380,7 +398,6 @@ impl WholeLevelCompactionPicker {
 
                 select_input_size += next_level.total_file_size;
                 total_file_count += next_level.table_infos.len() as u64;
-
                 select_level_inputs.push(InputLevel {
                     level_idx: 0,
                     level_type: next_level.level_type,
@@ -414,13 +431,13 @@ impl WholeLevelCompactionPicker {
                 }
             }
         }
-
         None
     }
 }
 
 #[cfg(test)]
 pub mod tests {
+    use risingwave_common::util::iter_util::ZipEqFast;
     use risingwave_hummock_sdk::level::Level;
 
     use super::*;
@@ -738,12 +755,7 @@ pub mod tests {
             );
             let mut local_stats = LocalPickerStatistic::default();
             let ret = picker
-                .pick_l0_intra(
-                    &levels.l0,
-                    &levels_handler[0],
-                    levels.l0.sub_levels[0].vnode_partition_count,
-                    &mut local_stats,
-                )
+                .pick_l0_intra(&levels.l0, &levels_handler[0], &mut local_stats)
                 .unwrap();
 
             // Ensure we can pick a candidate and the returned size/count matches the tables chosen.
@@ -854,7 +866,7 @@ pub mod tests {
             let base = epoch * 100;
             let mut ssts = vec![];
             for i in 1..50 {
-                let left = (i as usize) * 100;
+                let left = i as usize * 100;
                 let right = left + 100;
                 ssts.push(generate_table(base + i, 1, left, right, epoch));
             }
@@ -869,6 +881,59 @@ pub mod tests {
             .pick_whole_level(&l0, &level_handler, 4, &mut LocalPickerStatistic::default())
             .unwrap();
         assert_eq!(ret.input_levels.len(), 2);
+    }
+
+    #[test]
+    fn test_partition_intra_ignores_markers_but_stops_at_overlapping_level() {
+        let config = Arc::new(CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .level0_sub_level_compact_level_count(3)
+                .sub_level_max_compaction_bytes(1000)
+                .build()
+        });
+        let mut l0 = generate_l0_nonoverlapping_multi_sublevels(
+            (1..=3)
+                .map(|epoch| {
+                    vec![
+                        generate_table(epoch * 2, 1, 0, 10, epoch),
+                        generate_table(epoch * 2 + 1, 1, 100, 110, epoch),
+                    ]
+                })
+                .collect(),
+        );
+        for (level, count) in l0.sub_levels.iter_mut().zip_eq_fast([0, 2, 4]) {
+            level.vnode_partition_count = count;
+        }
+        let picker = IntraCompactionPicker::new_with_mode(
+            config,
+            Arc::new(CompactionTaskValidator::unused()),
+            Arc::new(CompactionDeveloperConfig::default()),
+            L0PickerMode::SingleTablePartition {
+                min_l0_level_count: 1,
+            },
+        );
+        let level_handler = LevelHandler::new(0);
+        let ret = picker
+            .pick_l0_intra(&l0, &level_handler, &mut LocalPickerStatistic::default())
+            .unwrap();
+        assert_eq!(ret.input_levels.len(), 3);
+        assert!(
+            ret.input_levels
+                .iter()
+                .all(|level| level.table_infos.len() == 1)
+        );
+        assert_eq!(ret.target_sub_level_id, l0.sub_levels[0].sub_level_id);
+        assert_eq!(ret.vnode_partition_count, 0);
+        assert!(!ret.skip_target_range_conflict_check);
+
+        // An overlapping sub-level cannot be bypassed.
+        l0.sub_levels[1].level_type = LevelType::Overlapping;
+        assert!(
+            picker
+                .pick_l0_intra(&l0, &level_handler, &mut LocalPickerStatistic::default())
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/meta/src/hummock/compaction/picker/min_overlap_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/min_overlap_compaction_picker.rs
@@ -94,7 +94,9 @@ impl MinOverlappingPicker {
             for (idx, range) in select_file_ranges.iter().skip(left) {
                 if select_file_size > self.max_select_bytes
                     || *idx > end_idx
-                    || range.start >= target_level_overlap_range.end
+                    // Adjacent target indices are safe to combine; a gap would include SSTs
+                    // that were not covered by the per-source pending checks above.
+                    || range.start > target_level_overlap_range.end
                 {
                     break;
                 }
@@ -110,7 +112,7 @@ impl MinOverlappingPicker {
                     .unwrap_or(total_file_size);
                 end_idx = idx + 1;
                 if score < min_score
-                    || (score == min_score && select_file_size < min_score_select_file_size)
+                    || (score == min_score && select_file_size > min_score_select_file_size)
                 {
                     min_score = score;
                     min_score_select_range = start_idx..end_idx;
@@ -170,9 +172,11 @@ impl CompactionPicker for MinOverlappingPicker {
 
 #[cfg(test)]
 pub mod tests {
+    use risingwave_hummock_sdk::compact_task::{CompactTask, CompactTaskAssignment};
     use risingwave_hummock_sdk::level::Level;
 
     use super::*;
+    use crate::hummock::compaction::in_progress_compaction::InProgressCompactionView;
     use crate::hummock::compaction::overlap_strategy::RangeOverlapStrategy;
     use crate::hummock::compaction::selector::tests::{
         generate_l0_nonoverlapping_sublevels, generate_table,
@@ -235,19 +239,20 @@ pub mod tests {
             .unwrap();
         assert_eq!(ret.input_levels[0].level_idx, 1);
         assert_eq!(ret.target_level, 2);
-        assert_eq!(ret.input_levels[0].table_infos.len(), 1);
+        assert_eq!(ret.input_levels[0].table_infos.len(), 2);
         assert_eq!(ret.input_levels[0].table_infos[0].sst_id, 0);
-        assert_eq!(ret.input_levels[1].table_infos.len(), 1);
+        assert_eq!(ret.input_levels[0].table_infos[1].sst_id, 1);
+        assert_eq!(ret.input_levels[1].table_infos.len(), 3);
         assert_eq!(ret.input_levels[1].table_infos[0].sst_id, 4);
+        assert_eq!(ret.input_levels[1].table_infos[1].sst_id, 5);
+        assert_eq!(ret.input_levels[1].table_infos[2].sst_id, 6);
         ret.add_pending_task(1, &mut level_handlers);
 
-        let ret = picker
-            .pick_compaction(&levels, &level_handlers, &mut local_stats)
-            .unwrap();
-        assert_eq!(ret.input_levels[0].table_infos.len(), 1);
-        assert_eq!(ret.input_levels[0].table_infos[0].sst_id, 1);
-        assert_eq!(ret.input_levels[1].table_infos.len(), 2);
-        assert_eq!(ret.input_levels[1].table_infos[0].sst_id, 5);
+        assert!(
+            picker
+                .pick_compaction(&levels, &level_handlers, &mut local_stats)
+                .is_none()
+        );
     }
 
     #[test]
@@ -307,6 +312,73 @@ pub mod tests {
     }
 
     #[test]
+    fn test_batch_equal_ratio_adjacent_target_ranges() {
+        let picker =
+            MinOverlappingPicker::new(5, 6, 1000, 0, Arc::new(RangeOverlapStrategy::default()));
+        // Key gaps are allowed when there are no extra target SSTs between the ranges.
+        let source = vec![
+            generate_table(0, 1, 0, 99, 2),
+            generate_table(1, 1, 200, 299, 2),
+            generate_table(2, 1, 400, 499, 2),
+        ];
+        let target = vec![
+            generate_table(3, 1, 0, 99, 1),
+            generate_table(4, 1, 200, 299, 1),
+            generate_table(5, 1, 400, 499, 1),
+        ];
+        let handlers: Vec<_> = (0..=6).map(LevelHandler::new).collect();
+        assert_eq!(
+            picker.pick_tables(&source, &target, &handlers),
+            (source, target)
+        );
+    }
+
+    #[test]
+    fn test_does_not_cross_uncovered_target_even_when_score_rounds_equal() {
+        let picker =
+            MinOverlappingPicker::new(5, 6, 1000, 0, Arc::new(RangeOverlapStrategy::default()));
+        let source = vec![
+            generate_table(0, 1, 0, 99, 2),
+            generate_table(1, 1, 200, 299, 2),
+        ];
+        let target = vec![
+            generate_table(2, 1, 0, 99, 1),
+            generate_table(3, 1, 150, 150, 1),
+            generate_table(4, 1, 200, 299, 1),
+        ];
+        // Including the gap SST would still round to score 100: 201 * 100 / 200.
+        // Its pending state is not checked by either source SST's overlap range.
+        for pending in [false, true] {
+            let mut handlers: Vec<_> = (0..=7).map(LevelHandler::new).collect();
+            if pending {
+                handlers[6].add_pending_task(1, 7, [&target[1]]);
+            }
+            assert_eq!(
+                picker.pick_tables(&source, &target, &handlers),
+                (vec![source[0].clone()], vec![target[0].clone()])
+            );
+        }
+    }
+
+    #[test]
+    fn test_does_not_cross_pending_source() {
+        let picker =
+            MinOverlappingPicker::new(5, 6, 1000, 0, Arc::new(RangeOverlapStrategy::default()));
+        let source = vec![
+            generate_table(0, 1, 0, 99, 2),
+            generate_table(1, 1, 100, 199, 2),
+            generate_table(2, 1, 200, 299, 2),
+        ];
+        let target = vec![generate_table(3, 1, 0, 299, 1)];
+        let mut handlers: Vec<_> = (0..=6).map(LevelHandler::new).collect();
+        handlers[5].add_pending_task(1, 6, [&source[1]]);
+        assert_eq!(
+            picker.pick_tables(&source, &target, &handlers),
+            (vec![source[0].clone()], target)
+        );
+    }
+
+    #[test]
     fn test_trivial_move_bug() {
         let levels = [
             Level {
@@ -358,8 +430,53 @@ pub mod tests {
             overlap_info.update(&sst.key_range);
         }
         let range = overlap_info.check_multiple_overlap(&levels[0].table_infos);
-        assert!(range.is_empty());
-        assert_eq!(select_files.len(), 1);
-        assert_eq!(target_files.len(), 1);
+        assert!(!range.is_empty());
+        assert_eq!(select_files.len(), 2);
+        assert_eq!(target_files.len(), 2);
+
+        let in_progress = InProgressCompactionView::for_group(
+            &[CompactTaskAssignment {
+                compact_task: CompactTask {
+                    task_id: 1,
+                    compaction_group_id: 1.into(),
+                    target_level: 3,
+                    input_ssts: vec![
+                        InputLevel {
+                            level_idx: 2,
+                            level_type: LevelType::Nonoverlapping,
+                            table_infos: select_files,
+                        },
+                        InputLevel {
+                            level_idx: 3,
+                            level_type: LevelType::Nonoverlapping,
+                            table_infos: target_files,
+                        },
+                    ],
+                    ..Default::default()
+                },
+                context_id: 1.into(),
+            }],
+            1.into(),
+        );
+        // After moving from L1 into L2, the gap SST looks trivial-movable to L3 by
+        // input IDs alone. The target guard must reject it while the wide task runs.
+        let (gap_source, gap_target) = picker.pick_tables(
+            &levels[0].table_infos,
+            &levels[2].table_infos,
+            &levels_handlers,
+        );
+        assert_eq!(gap_source.len(), 1);
+        assert!(gap_target.is_empty());
+        let gap_input = CompactionInput {
+            target_level: 3,
+            input_levels: vec![InputLevel {
+                level_idx: 2,
+                level_type: LevelType::Nonoverlapping,
+                table_infos: gap_source,
+            }],
+            ..Default::default()
+        };
+        assert!(in_progress.has_conflict_with_input(&gap_input));
+        assert!(!InProgressCompactionView::default().has_conflict_with_input(&gap_input));
     }
 }

--- a/src/meta/src/hummock/compaction/picker/mod.rs
+++ b/src/meta/src/hummock/compaction/picker/mod.rs
@@ -53,20 +53,19 @@ pub(crate) enum L0PickerMode {
     SingleTablePartition {
         min_l0_level_count: usize,
     },
+    SingleTablePartitionTrivialMove,
 }
 
 impl L0PickerMode {
     pub(crate) fn is_single_table_partition(self) -> bool {
-        matches!(self, Self::SingleTablePartition { .. })
+        matches!(
+            self,
+            Self::SingleTablePartition { .. } | Self::SingleTablePartitionTrivialMove
+        )
     }
 
-    pub(crate) fn min_l0_level_count(self) -> usize {
-        match self {
-            Self::Legacy => 1,
-            Self::SingleTablePartition { min_l0_level_count } => {
-                std::cmp::max(1, min_l0_level_count)
-            }
-        }
+    pub(crate) fn is_trivial_move_only(self) -> bool {
+        matches!(self, Self::SingleTablePartitionTrivialMove)
     }
 }
 
@@ -76,6 +75,37 @@ pub struct LocalPickerStatistic {
     pub skip_by_count_limit: u64,
     pub skip_by_pending_files: u64,
     pub skip_by_overlapping: u64,
+    pub is_trivial_move: bool,
+    pub partition_l0_growth: PartitionL0GrowthStatistic,
+}
+
+#[derive(Clone, Copy, Default, Debug)]
+pub struct PartitionL0GrowthStatistic {
+    pub initial_l0_size: u64,
+    pub outcomes: [u64; 7],
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum PartitionL0GrowthOutcome {
+    Accepted,
+    NoNewSst,
+    BaseSetChange,
+    Bytes,
+    Files,
+    Levels,
+    OutputConflict,
+}
+
+impl PartitionL0GrowthOutcome {
+    pub(crate) const LABELS: [&'static str; 7] = [
+        "growth-accepted",
+        "growth-no-new-sst",
+        "growth-base-set-change",
+        "growth-bytes",
+        "growth-files",
+        "growth-levels",
+        "growth-output-conflict",
+    ];
 }
 
 #[derive(Default, Debug)]

--- a/src/meta/src/hummock/compaction/picker/mod.rs
+++ b/src/meta/src/hummock/compaction/picker/mod.rs
@@ -46,6 +46,30 @@ pub use vnode_watermark_picker::VnodeWatermarkCompactionPicker;
 
 use crate::hummock::level_handler::LevelHandler;
 
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) enum L0PickerMode {
+    #[default]
+    Legacy,
+    SingleTablePartition {
+        min_l0_level_count: usize,
+    },
+}
+
+impl L0PickerMode {
+    pub(crate) fn is_single_table_partition(self) -> bool {
+        matches!(self, Self::SingleTablePartition { .. })
+    }
+
+    pub(crate) fn min_l0_level_count(self) -> usize {
+        match self {
+            Self::Legacy => 1,
+            Self::SingleTablePartition { min_l0_level_count } => {
+                std::cmp::max(1, min_l0_level_count)
+            }
+        }
+    }
+}
+
 #[derive(Default, Debug)]
 pub struct LocalPickerStatistic {
     pub skip_by_write_amp_limit: u64,

--- a/src/meta/src/hummock/compaction/selector/level_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/level_selector.rs
@@ -20,17 +20,18 @@
 use std::sync::Arc;
 
 use risingwave_hummock_sdk::HummockCompactionTaskId;
-use risingwave_hummock_sdk::level::Levels;
+use risingwave_hummock_sdk::level::{Levels, OverlappingLevel};
 use risingwave_pb::hummock::compact_task::PbTaskType;
 use risingwave_pb::hummock::{CompactionConfig, LevelType};
 
+use super::single_table_compaction::{SingleTableCompactionGroup, SingleTableL0PickerType};
 use super::{
     CompactionSelector, LevelCompactionPicker, TierCompactionPicker, create_compaction_task,
 };
 use crate::hummock::compaction::overlap_strategy::OverlapStrategy;
 use crate::hummock::compaction::picker::{
-    CompactionPicker, CompactionTaskValidator, IntraCompactionPicker, LocalPickerStatistic,
-    MinOverlappingPicker,
+    CompactionPicker, CompactionTaskValidator, IntraCompactionPicker, L0PickerMode,
+    LocalPickerStatistic, MinOverlappingPicker,
 };
 use crate::hummock::compaction::selector::CompactionSelectorContext;
 use crate::hummock::compaction::{
@@ -60,12 +61,57 @@ impl std::fmt::Display for PickerType {
     }
 }
 
+impl PickerType {
+    fn sort_rank(&self) -> u8 {
+        match self {
+            PickerType::Tier => 0,
+            PickerType::ToBase => 1,
+            PickerType::Intra => 2,
+            PickerType::BottomLevel => 3,
+        }
+    }
+}
+
 #[derive(Default, Debug)]
 pub struct PickerInfo {
     pub score: u64,
     pub select_level: usize,
     pub target_level: usize,
     pub picker_type: PickerType,
+    input: PickerInput,
+}
+
+#[derive(Default, Debug)]
+enum PickerInput {
+    #[default]
+    Global,
+    SingleTablePartition {
+        partition_score: u64,
+        l0: Arc<OverlappingLevel>,
+        min_l0_level_count: usize,
+    },
+}
+
+impl PickerInput {
+    fn partition_score(&self) -> u64 {
+        match self {
+            Self::Global => 0,
+            Self::SingleTablePartition {
+                partition_score, ..
+            } => *partition_score,
+        }
+    }
+
+    fn picker_mode(&self) -> L0PickerMode {
+        match self {
+            Self::Global => L0PickerMode::Legacy,
+            Self::SingleTablePartition {
+                min_l0_level_count, ..
+            } => L0PickerMode::SingleTablePartition {
+                min_l0_level_count: *min_l0_level_count,
+            },
+        }
+    }
 }
 
 #[derive(Default, Debug)]
@@ -109,17 +155,32 @@ impl DynamicLevelSelectorCore {
         overlap_strategy: Arc<dyn OverlapStrategy>,
         compaction_task_validator: Arc<CompactionTaskValidator>,
     ) -> Box<dyn CompactionPicker> {
+        let picker_mode = picker_info.input.picker_mode();
+        let compaction_task_validator = if picker_mode.is_single_table_partition() {
+            Arc::new(CompactionTaskValidator::unused())
+        } else {
+            compaction_task_validator
+        };
         match picker_info.picker_type {
             PickerType::Tier => Box::new(TierCompactionPicker::new_with_validator(
                 self.config.clone(),
                 compaction_task_validator,
             )),
-            PickerType::ToBase => Box::new(LevelCompactionPicker::new_with_validator(
+            PickerType::ToBase => Box::new(LevelCompactionPicker::new_with_mode(
                 picker_info.target_level,
                 self.config.clone(),
                 compaction_task_validator,
                 self.developer_config.clone(),
+                picker_mode,
             )),
+            PickerType::Intra if picker_mode.is_single_table_partition() => {
+                Box::new(IntraCompactionPicker::new_with_mode(
+                    self.config.clone(),
+                    compaction_task_validator,
+                    self.developer_config.clone(),
+                    picker_mode,
+                ))
+            }
             PickerType::Intra => Box::new(IntraCompactionPicker::new_with_validator(
                 self.config.clone(),
                 compaction_task_validator,
@@ -204,6 +265,15 @@ impl DynamicLevelSelectorCore {
         levels: &Levels,
         handlers: &[LevelHandler],
     ) -> SelectContext {
+        self.get_priority_levels_with_single_table_strategy(levels, handlers, None)
+    }
+
+    fn get_priority_levels_with_single_table_strategy(
+        &self,
+        levels: &Levels,
+        handlers: &[LevelHandler],
+        single_table_compaction_group: Option<SingleTableCompactionGroup>,
+    ) -> SelectContext {
         let mut ctx = self.calculate_level_base_size(levels);
 
         let l0_file_count = levels
@@ -255,64 +325,34 @@ impl DynamicLevelSelectorCore {
                     select_level: 0,
                     target_level: 0,
                     picker_type: PickerType::Tier,
+                    input: PickerInput::Global,
                 })
             }
 
-            // The read query at the non-overlapping level only selects ssts that match the query
-            // range at each level, so the number of levels is the most important factor affecting
-            // the read performance. At the same time, the size factor is also added to the score
-            // calculation rule to avoid unbalanced compact task due to large size.
-            let total_size = levels
-                .l0
-                .sub_levels
-                .iter()
-                .filter(|level| {
-                    level.vnode_partition_count == self.config.split_weight_by_vnode
-                        && level.level_type == LevelType::Nonoverlapping
-                })
-                .map(|level| level.total_file_size)
-                .sum::<u64>()
-                .saturating_sub(handlers[0].pending_output_file_size(ctx.base_level as u32));
-            let base_level_size = levels.get_level(ctx.base_level).total_file_size;
-            let base_level_sst_count = levels.get_level(ctx.base_level).table_infos.len() as u64;
-
-            // size limit
-            let non_overlapping_size_score = total_size * SCORE_BASE
-                / std::cmp::max(self.config.max_bytes_for_level_base, base_level_size);
-            // level count limit
-            let non_overlapping_level_count = levels
-                .l0
-                .sub_levels
-                .iter()
-                .filter(|level| level.level_type == LevelType::Nonoverlapping)
-                .count() as u64;
-            let non_overlapping_level_score = non_overlapping_level_count * SCORE_BASE
-                / std::cmp::max(
-                    base_level_sst_count / 16,
-                    self.config.level0_sub_level_compact_level_count as u64,
-                );
-
-            let non_overlapping_score =
-                std::cmp::max(non_overlapping_size_score, non_overlapping_level_score);
-
-            // Reduce the level num of l0 non-overlapping sub_level
-            if non_overlapping_size_score > SCORE_BASE {
-                ctx.score_levels.push(PickerInfo {
-                    score: non_overlapping_score + 1,
-                    select_level: 0,
-                    target_level: ctx.base_level,
-                    picker_type: PickerType::ToBase,
-                });
-            }
-
-            if non_overlapping_level_score > SCORE_BASE {
-                // FIXME: more accurate score calculation algorithm will be introduced (#11903)
-                ctx.score_levels.push(PickerInfo {
-                    score: non_overlapping_score,
-                    select_level: 0,
-                    target_level: 0,
-                    picker_type: PickerType::Intra,
-                });
+            let single_table_candidates = single_table_compaction_group.and_then(|group| {
+                group.build_l0_candidates(&self.config, &levels.l0, &handlers[0])
+            });
+            if let Some(candidates) = single_table_candidates {
+                ctx.score_levels
+                    .extend(candidates.into_iter().map(|candidate| PickerInfo {
+                        score: candidate.score,
+                        select_level: 0,
+                        target_level: match candidate.picker_type {
+                            SingleTableL0PickerType::ToBase => ctx.base_level,
+                            SingleTableL0PickerType::Intra => 0,
+                        },
+                        picker_type: match candidate.picker_type {
+                            SingleTableL0PickerType::ToBase => PickerType::ToBase,
+                            SingleTableL0PickerType::Intra => PickerType::Intra,
+                        },
+                        input: PickerInput::SingleTablePartition {
+                            partition_score: candidate.partition_score,
+                            l0: candidate.l0,
+                            min_l0_level_count: candidate.min_l0_level_count,
+                        },
+                    }));
+            } else {
+                self.add_legacy_l0_candidates(levels, handlers, &mut ctx);
             }
         }
 
@@ -335,6 +375,7 @@ impl DynamicLevelSelectorCore {
                     select_level: level_idx,
                     target_level: level_idx + 1,
                     picker_type: PickerType::BottomLevel,
+                    input: PickerInput::Global,
                 }
             });
         }
@@ -344,8 +385,67 @@ impl DynamicLevelSelectorCore {
             b.score
                 .cmp(&a.score)
                 .then_with(|| a.target_level.cmp(&b.target_level))
+                .then_with(|| a.picker_type.sort_rank().cmp(&b.picker_type.sort_rank()))
+                .then_with(|| b.input.partition_score().cmp(&a.input.partition_score()))
         });
         ctx
+    }
+
+    fn add_legacy_l0_candidates(
+        &self,
+        levels: &Levels,
+        handlers: &[LevelHandler],
+        ctx: &mut SelectContext,
+    ) {
+        // Keep this path equivalent to the original dynamic-level selector. It is used by every
+        // non-single-table compaction group and while a single-table group still contains SSTs
+        // that cannot be represented by the fixed vnode partition layout.
+        let total_size = levels
+            .l0
+            .sub_levels
+            .iter()
+            .filter(|level| {
+                level.vnode_partition_count == self.config.split_weight_by_vnode
+                    && level.level_type == LevelType::Nonoverlapping
+            })
+            .map(|level| level.total_file_size)
+            .sum::<u64>()
+            .saturating_sub(handlers[0].pending_output_file_size(ctx.base_level as u32));
+        let base_level_size = levels.get_level(ctx.base_level).total_file_size;
+        let base_level_sst_count = levels.get_level(ctx.base_level).table_infos.len() as u64;
+        let size_score = total_size * SCORE_BASE
+            / std::cmp::max(self.config.max_bytes_for_level_base, base_level_size);
+        let non_overlapping_level_count = levels
+            .l0
+            .sub_levels
+            .iter()
+            .filter(|level| level.level_type == LevelType::Nonoverlapping)
+            .count() as u64;
+        let level_score = non_overlapping_level_count * SCORE_BASE
+            / std::cmp::max(
+                base_level_sst_count / 16,
+                self.config.level0_sub_level_compact_level_count as u64,
+            );
+        let score = std::cmp::max(size_score, level_score);
+
+        if size_score > SCORE_BASE {
+            ctx.score_levels.push(PickerInfo {
+                score: score + 1,
+                select_level: 0,
+                target_level: ctx.base_level,
+                picker_type: PickerType::ToBase,
+                input: PickerInput::Global,
+            });
+        }
+        if level_score > SCORE_BASE {
+            ctx.score_levels.push(PickerInfo {
+                score,
+                select_level: 0,
+                target_level: 0,
+                picker_type: PickerType::Intra,
+                input: PickerInput::Global,
+            });
+        }
     }
 
     /// `compact_pending_bytes_needed` calculates the number of compact bytes needed to balance the
@@ -435,6 +535,7 @@ impl CompactionSelector for DynamicLevelSelector {
             selector_stats,
             developer_config,
             in_progress_compactions,
+            single_table_compaction_group,
             ..
         } = context;
         let dynamic_level_core = DynamicLevelSelectorCore::new(
@@ -443,7 +544,11 @@ impl CompactionSelector for DynamicLevelSelector {
         );
         let overlap_strategy =
             create_overlap_strategy(compaction_group.compaction_config.compaction_mode());
-        let ctx = dynamic_level_core.get_priority_levels(levels, level_handlers);
+        let ctx = dynamic_level_core.get_priority_levels_with_single_table_strategy(
+            levels,
+            level_handlers,
+            single_table_compaction_group,
+        );
         // TODO: Determine which rule to enable by write limit
         let compaction_task_validator = Arc::new(CompactionTaskValidator::new(
             compaction_group.compaction_config.clone(),
@@ -457,9 +562,20 @@ impl CompactionSelector for DynamicLevelSelector {
                 overlap_strategy.clone(),
                 compaction_task_validator.clone(),
             );
+            let single_table_levels;
+            let picker_levels = match &picker_info.input {
+                PickerInput::Global => levels,
+                PickerInput::SingleTablePartition { l0, .. } => {
+                    single_table_levels = Levels {
+                        l0: l0.as_ref().clone(),
+                        ..levels.clone()
+                    };
+                    &single_table_levels
+                }
+            };
 
             let mut stats = LocalPickerStatistic::default();
-            if let Some(ret) = picker.pick_compaction(levels, level_handlers, &mut stats) {
+            if let Some(ret) = picker.pick_compaction(picker_levels, level_handlers, &mut stats) {
                 if !ret.skip_target_range_conflict_check
                     && in_progress_compactions.has_conflict_with_input(&ret)
                 {
@@ -509,8 +625,8 @@ pub mod tests {
     use risingwave_hummock_sdk::compact_task::{CompactTask, CompactTaskAssignment};
     use risingwave_hummock_sdk::level::{InputLevel, Levels};
     use risingwave_hummock_sdk::version::HummockVersionStateTableInfo;
-    use risingwave_pb::hummock::LevelType;
     use risingwave_pb::hummock::compaction_config::CompactionMode;
+    use risingwave_pb::hummock::{CompactionConfig, LevelType};
 
     use crate::hummock::compaction::compaction_config::CompactionConfigBuilder;
     use crate::hummock::compaction::in_progress_compaction::InProgressCompactionView;
@@ -520,7 +636,7 @@ pub mod tests {
     };
     use crate::hummock::compaction::selector::{
         CompactionSelector, CompactionSelectorContext, DynamicLevelSelector,
-        DynamicLevelSelectorCore, LocalSelectorStatistic,
+        DynamicLevelSelectorCore, LocalSelectorStatistic, SingleTableCompactionGroup,
     };
     use crate::hummock::compaction::{CompactionDeveloperConfig, CompactionTask};
     use crate::hummock::level_handler::LevelHandler;
@@ -535,6 +651,7 @@ pub mod tests {
         level_handlers: &mut [LevelHandler],
         selector_stats: &mut LocalSelectorStatistic,
         in_progress_compactions: &InProgressCompactionView,
+        single_table_compaction_group: Option<SingleTableCompactionGroup>,
     ) -> Option<CompactionTask> {
         selector.pick_compaction(
             task_id,
@@ -542,6 +659,7 @@ pub mod tests {
                 group,
                 levels,
                 member_table_ids: &BTreeSet::new(),
+                single_table_compaction_group,
                 level_handlers,
                 selector_stats,
                 table_id_to_options: &HashMap::default(),
@@ -551,6 +669,60 @@ pub mod tests {
                 in_progress_compactions,
             },
         )
+    }
+
+    #[test]
+    fn test_legacy_depth_pressure_uses_intra_without_size_pressure() {
+        let config = CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .max_level(1)
+                .max_bytes_for_level_base(1024)
+                .level0_sub_level_compact_level_count(3)
+                .sst_allowed_trivial_move_min_size(Some(u64::MAX))
+                .build()
+        };
+        let group = CompactionGroup::new(1, config.clone());
+        let levels = Levels {
+            levels: vec![generate_level(1, vec![])],
+            l0: generate_l0_nonoverlapping_sublevels(
+                (1..=4).map(|id| generate_table(id, 1, 0, 10, id)).collect(),
+            ),
+            ..Default::default()
+        };
+        assert!(levels.l0.total_file_size < config.max_bytes_for_level_base);
+        let mut handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        let core = DynamicLevelSelectorCore::new(
+            Arc::new(config),
+            Arc::new(CompactionDeveloperConfig::default()),
+        );
+        let priorities = core.get_priority_levels(&levels, &handlers);
+        assert!(
+            !priorities
+                .score_levels
+                .iter()
+                .any(|p| matches!(p.picker_type, super::PickerType::ToBase))
+        );
+        assert!(
+            priorities
+                .score_levels
+                .iter()
+                .any(|p| matches!(p.picker_type, super::PickerType::Intra))
+        );
+        let mut selector = DynamicLevelSelector::default();
+        let task = pick_compaction_with_in_progress(
+            &mut selector,
+            1,
+            &group,
+            &levels,
+            &mut handlers,
+            &mut LocalSelectorStatistic::default(),
+            &InProgressCompactionView::default(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(task.input.target_level, 0);
+        assert_compaction_task(&task, &handlers);
     }
 
     #[test]
@@ -834,6 +1006,7 @@ pub mod tests {
             &mut levels_handlers,
             &mut local_stats,
             &empty_in_progress,
+            None,
         )
         .unwrap();
         assert_eq!(compaction.input.target_level, 4);
@@ -857,6 +1030,7 @@ pub mod tests {
                 &mut levels_handlers,
                 &mut local_stats,
                 &in_progress,
+                None,
             )
             .is_none()
         );

--- a/src/meta/src/hummock/compaction/selector/level_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/level_selector.rs
@@ -26,7 +26,8 @@ use risingwave_pb::hummock::{CompactionConfig, LevelType};
 
 use super::single_table_compaction::{SingleTableCompactionGroup, SingleTableL0PickerType};
 use super::{
-    CompactionSelector, LevelCompactionPicker, TierCompactionPicker, create_compaction_task,
+    CompactionSelector, LevelCompactionPicker, PartitionL0CandidateInfo,
+    PartitionL0CompactionObservation, TierCompactionPicker, create_compaction_task,
 };
 use crate::hummock::compaction::overlap_strategy::OverlapStrategy;
 use crate::hummock::compaction::picker::{
@@ -46,6 +47,7 @@ pub enum PickerType {
     Tier,
     Intra,
     ToBase,
+    TrivialMove,
     #[default]
     BottomLevel,
 }
@@ -56,18 +58,30 @@ impl std::fmt::Display for PickerType {
             PickerType::Tier => "Tier",
             PickerType::Intra => "Intra",
             PickerType::ToBase => "ToBase",
+            PickerType::TrivialMove => "TrivialMove",
             PickerType::BottomLevel => "BottomLevel",
         })
     }
 }
 
 impl PickerType {
+    fn label(&self) -> &'static str {
+        match self {
+            PickerType::Tier => "tier",
+            PickerType::Intra => "intra",
+            PickerType::ToBase => "to-base",
+            PickerType::TrivialMove => "trivial-move",
+            PickerType::BottomLevel => "bottom-level",
+        }
+    }
+
     fn sort_rank(&self) -> u8 {
         match self {
             PickerType::Tier => 0,
             PickerType::ToBase => 1,
-            PickerType::Intra => 2,
-            PickerType::BottomLevel => 3,
+            PickerType::TrivialMove => 2,
+            PickerType::Intra => 3,
+            PickerType::BottomLevel => 4,
         }
     }
 }
@@ -87,7 +101,7 @@ enum PickerInput {
     #[default]
     Global,
     SingleTablePartition {
-        partition_score: u64,
+        candidate: PartitionL0CandidateInfo,
         l0: Arc<OverlappingLevel>,
         min_l0_level_count: usize,
     },
@@ -97,15 +111,16 @@ impl PickerInput {
     fn partition_score(&self) -> u64 {
         match self {
             Self::Global => 0,
-            Self::SingleTablePartition {
-                partition_score, ..
-            } => *partition_score,
+            Self::SingleTablePartition { candidate, .. } => candidate.partition_score,
         }
     }
 
-    fn picker_mode(&self) -> L0PickerMode {
+    fn picker_mode(&self, picker_type: &PickerType) -> L0PickerMode {
         match self {
             Self::Global => L0PickerMode::Legacy,
+            Self::SingleTablePartition { .. } if matches!(picker_type, PickerType::TrivialMove) => {
+                L0PickerMode::SingleTablePartitionTrivialMove
+            }
             Self::SingleTablePartition {
                 min_l0_level_count, ..
             } => L0PickerMode::SingleTablePartition {
@@ -113,6 +128,108 @@ impl PickerInput {
             },
         }
     }
+
+    fn partition_observation(
+        &self,
+        picker_type: &PickerType,
+        outcome: &'static str,
+        input: Option<&crate::hummock::compaction::picker::CompactionInput>,
+        stats: &LocalPickerStatistic,
+    ) -> Option<PartitionL0CompactionObservation> {
+        let Self::SingleTablePartition {
+            candidate,
+            min_l0_level_count,
+            ..
+        } = self
+        else {
+            return None;
+        };
+
+        let selected_l0_level_count = input
+            .map(|input| {
+                input
+                    .input_levels
+                    .iter()
+                    .filter(|level| level.level_idx == 0)
+                    .count() as u64
+            })
+            .unwrap_or_default();
+        let selected_l0_sst_ref_count = input
+            .map(|input| {
+                input
+                    .input_levels
+                    .iter()
+                    .filter(|level| level.level_idx == 0)
+                    .map(|level| level.table_infos.len() as u64)
+                    .sum()
+            })
+            .unwrap_or_default();
+        let target_sst_ref_count = input
+            .map(|input| {
+                input
+                    .input_levels
+                    .iter()
+                    .filter(|level| level.level_idx != 0)
+                    .map(|level| level.table_infos.len() as u64)
+                    .sum()
+            })
+            .unwrap_or_default();
+
+        let picker = if stats.is_trivial_move {
+            "trivial-move"
+        } else {
+            picker_type.label()
+        };
+        let selected_l0_referenced_object_size = input
+            .map(|input| {
+                input
+                    .input_levels
+                    .iter()
+                    .filter(|level| level.level_idx == 0)
+                    .flat_map(|level| &level.table_infos)
+                    .map(|sst| sst.file_size)
+                    .sum()
+            })
+            .unwrap_or_default();
+        let target_referenced_object_size = input
+            .map(|input| {
+                input
+                    .input_levels
+                    .iter()
+                    .filter(|level| level.level_idx != 0)
+                    .flat_map(|level| &level.table_infos)
+                    .map(|sst| sst.file_size)
+                    .sum()
+            })
+            .unwrap_or_default();
+
+        Some(PartitionL0CompactionObservation {
+            candidate: *candidate,
+            picker,
+            outcome,
+            min_seed_depth: *min_l0_level_count as u64,
+            selected_l0_level_count,
+            selected_l0_sst_ref_count,
+            selected_l0_size: input
+                .map(|input| input.select_input_size)
+                .unwrap_or_default(),
+            selected_l0_referenced_object_size,
+            target_sst_ref_count,
+            target_size: input
+                .map(|input| input.target_input_size)
+                .unwrap_or_default(),
+            target_referenced_object_size,
+            growth: stats.partition_l0_growth,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct EffectiveLevelSize {
+    pub(super) current: u64,
+    pub(super) incoming: u64,
+    pub(super) outgoing: u64,
+    pub(super) effective: u64,
 }
 
 #[derive(Default, Debug)]
@@ -127,7 +244,11 @@ pub struct SelectContext {
     pub score_levels: Vec<PickerInfo>,
 }
 
-fn effective_level_size(levels: &Levels, handlers: &[LevelHandler], level: usize) -> u64 {
+fn effective_level_size_info(
+    levels: &Levels,
+    handlers: &[LevelHandler],
+    level: usize,
+) -> EffectiveLevelSize {
     let target_level = level as u32;
     let incoming_size = handlers
         .iter()
@@ -140,11 +261,19 @@ fn effective_level_size(levels: &Levels, handlers: &[LevelHandler], level: usize
         .pending_file_size()
         .saturating_sub(handlers[level].pending_output_file_size(target_level));
 
-    levels
-        .get_level(level)
-        .total_file_size
-        .saturating_sub(outgoing_size)
-        .saturating_add(incoming_size)
+    let current = levels.get_level(level).total_file_size;
+    EffectiveLevelSize {
+        current,
+        incoming: incoming_size,
+        outgoing: outgoing_size,
+        effective: current
+            .saturating_sub(outgoing_size)
+            .saturating_add(incoming_size),
+    }
+}
+
+fn effective_level_size(levels: &Levels, handlers: &[LevelHandler], level: usize) -> u64 {
+    effective_level_size_info(levels, handlers, level).effective
 }
 
 fn fill_score(level_size: u64, level_target_size: u64) -> u64 {
@@ -199,7 +328,7 @@ impl DynamicLevelSelectorCore {
         overlap_strategy: Arc<dyn OverlapStrategy>,
         compaction_task_validator: Arc<CompactionTaskValidator>,
     ) -> Box<dyn CompactionPicker> {
-        let picker_mode = picker_info.input.picker_mode();
+        let picker_mode = picker_info.input.picker_mode(&picker_info.picker_type);
         let compaction_task_validator = if picker_mode.is_single_table_partition() {
             Arc::new(CompactionTaskValidator::unused())
         } else {
@@ -210,13 +339,15 @@ impl DynamicLevelSelectorCore {
                 self.config.clone(),
                 compaction_task_validator,
             )),
-            PickerType::ToBase => Box::new(LevelCompactionPicker::new_with_mode(
-                picker_info.target_level,
-                self.config.clone(),
-                compaction_task_validator,
-                self.developer_config.clone(),
-                picker_mode,
-            )),
+            PickerType::ToBase | PickerType::TrivialMove => {
+                Box::new(LevelCompactionPicker::new_with_mode(
+                    picker_info.target_level,
+                    self.config.clone(),
+                    compaction_task_validator,
+                    self.developer_config.clone(),
+                    picker_mode,
+                ))
+            }
             PickerType::Intra if picker_mode.is_single_table_partition() => {
                 Box::new(IntraCompactionPicker::new_with_mode(
                     self.config.clone(),
@@ -379,7 +510,7 @@ impl DynamicLevelSelectorCore {
                     &self.config,
                     &levels.l0,
                     &handlers[0],
-                    effective_level_size(levels, handlers, ctx.base_level),
+                    effective_level_size_info(levels, handlers, ctx.base_level),
                     ctx.level_max_bytes[ctx.base_level],
                 )
             });
@@ -389,16 +520,18 @@ impl DynamicLevelSelectorCore {
                         score: candidate.score,
                         select_level: 0,
                         target_level: match candidate.picker_type {
-                            SingleTableL0PickerType::ToBase => ctx.base_level,
+                            SingleTableL0PickerType::ToBase
+                            | SingleTableL0PickerType::TrivialMove => ctx.base_level,
                             SingleTableL0PickerType::Intra => 0,
                         },
                         picker_type: match candidate.picker_type {
                             SingleTableL0PickerType::ToBase => PickerType::ToBase,
+                            SingleTableL0PickerType::TrivialMove => PickerType::TrivialMove,
                             SingleTableL0PickerType::Intra => PickerType::Intra,
                         },
                         eligible: true,
                         input: PickerInput::SingleTablePartition {
-                            partition_score: candidate.partition_score,
+                            candidate: candidate.info,
                             l0: candidate.l0,
                             min_l0_level_count: candidate.min_l0_level_count,
                         },
@@ -627,14 +760,25 @@ impl CompactionSelector for DynamicLevelSelector {
             compaction_group.compaction_config.clone(),
         ));
         for picker_info in &ctx.score_levels {
+            if !matches!(
+                picker_info.picker_type,
+                PickerType::ToBase | PickerType::TrivialMove
+            ) {
+                continue;
+            }
+            if let Some(observation) = picker_info.input.partition_observation(
+                &picker_info.picker_type,
+                "candidate",
+                None,
+                &LocalPickerStatistic::default(),
+            ) {
+                selector_stats.record_partition_l0(observation);
+            }
+        }
+        for picker_info in &ctx.score_levels {
             if !picker_info.eligible {
                 continue;
             }
-            let mut picker = dynamic_level_core.create_compaction_picker(
-                picker_info,
-                overlap_strategy.clone(),
-                compaction_task_validator.clone(),
-            );
             let single_table_levels;
             let picker_levels = match &picker_info.input {
                 PickerInput::Global => levels,
@@ -648,31 +792,83 @@ impl CompactionSelector for DynamicLevelSelector {
             };
 
             let mut stats = LocalPickerStatistic::default();
-            if let Some(ret) = picker.pick_compaction(picker_levels, level_handlers, &mut stats) {
-                if !ret.skip_target_range_conflict_check
-                    && in_progress_compactions.has_conflict_with_input(&ret)
-                {
-                    stats.skip_by_overlapping += 1;
-                    selector_stats.skip_picker.push((
-                        picker_info.select_level,
-                        picker_info.target_level,
-                        stats,
-                    ));
-                    continue;
+            let ret = if matches!(picker_info.input, PickerInput::SingleTablePartition { .. })
+                && matches!(picker_info.picker_type, PickerType::ToBase)
+            {
+                // Only partition ToBase growth needs to test a wider output before replacing
+                // its accepted seed. Legacy/Intra retain the common picker interface and route.
+                LevelCompactionPicker::new_with_mode(
+                    picker_info.target_level,
+                    dynamic_level_core.config.clone(),
+                    Arc::new(CompactionTaskValidator::unused()),
+                    dynamic_level_core.developer_config.clone(),
+                    picker_info.input.picker_mode(&picker_info.picker_type),
+                )
+                .pick_compaction_with_output_conflict_check(
+                    picker_levels,
+                    level_handlers,
+                    &mut stats,
+                    |input| in_progress_compactions.has_conflict_with_input(input),
+                )
+            } else {
+                dynamic_level_core
+                    .create_compaction_picker(
+                        picker_info,
+                        overlap_strategy.clone(),
+                        compaction_task_validator.clone(),
+                    )
+                    .pick_compaction(picker_levels, level_handlers, &mut stats)
+            };
+            let Some(ret) = ret else {
+                if let Some(observation) = picker_info.input.partition_observation(
+                    &picker_info.picker_type,
+                    "picker-empty",
+                    None,
+                    &stats,
+                ) {
+                    selector_stats.record_partition_l0(observation);
                 }
-
-                ret.add_pending_task(task_id, level_handlers);
-                return Some(create_compaction_task(
-                    dynamic_level_core.get_config(),
-                    ret,
-                    ctx.base_level,
-                    self.task_type(),
+                selector_stats.skip_picker.push((
+                    picker_info.select_level,
+                    picker_info.target_level,
+                    stats,
                 ));
+                continue;
+            };
+            if !ret.skip_target_range_conflict_check
+                && in_progress_compactions.has_conflict_with_input(&ret)
+            {
+                stats.skip_by_overlapping += 1;
+                if let Some(observation) = picker_info.input.partition_observation(
+                    &picker_info.picker_type,
+                    "range-conflict",
+                    Some(&ret),
+                    &stats,
+                ) {
+                    selector_stats.record_partition_l0(observation);
+                }
+                selector_stats.skip_picker.push((
+                    picker_info.select_level,
+                    picker_info.target_level,
+                    stats,
+                ));
+                continue;
             }
-            selector_stats.skip_picker.push((
-                picker_info.select_level,
-                picker_info.target_level,
-                stats,
+
+            if let Some(observation) = picker_info.input.partition_observation(
+                &picker_info.picker_type,
+                "selected",
+                Some(&ret),
+                &stats,
+            ) {
+                selector_stats.record_partition_l0(observation);
+            }
+            ret.add_pending_task(task_id, level_handlers);
+            return Some(create_compaction_task(
+                dynamic_level_core.get_config(),
+                ret,
+                ctx.base_level,
+                self.task_type(),
             ));
         }
         None

--- a/src/meta/src/hummock/compaction/selector/level_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/level_selector.rs
@@ -1289,7 +1289,7 @@ pub mod tests {
                 .iter()
                 .map(|sst| sst.sst_id)
                 .collect_vec(),
-            vec![5]
+            vec![5, 6]
         );
         assert_eq!(
             compaction.input.input_levels[1]
@@ -1297,7 +1297,7 @@ pub mod tests {
                 .iter()
                 .map(|sst| sst.sst_id)
                 .collect_vec(),
-            vec![10]
+            vec![10, 11]
         );
         assert_eq!(
             compaction.target_file_size,

--- a/src/meta/src/hummock/compaction/selector/level_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/level_selector.rs
@@ -78,6 +78,7 @@ pub struct PickerInfo {
     pub select_level: usize,
     pub target_level: usize,
     pub picker_type: PickerType,
+    eligible: bool,
     input: PickerInput,
 }
 
@@ -124,6 +125,49 @@ pub struct SelectContext {
     // level, which equals to `base_level -= 1;`.
     pub base_level: usize,
     pub score_levels: Vec<PickerInfo>,
+}
+
+fn effective_level_size(levels: &Levels, handlers: &[LevelHandler], level: usize) -> u64 {
+    let target_level = level as u32;
+    let incoming_size = handlers
+        .iter()
+        .enumerate()
+        .filter(|(source_level, _)| *source_level != level)
+        .fold(0u64, |size, (_, handler)| {
+            size.saturating_add(handler.pending_output_file_size(target_level))
+        });
+    let outgoing_size = handlers[level]
+        .pending_file_size()
+        .saturating_sub(handlers[level].pending_output_file_size(target_level));
+
+    levels
+        .get_level(level)
+        .total_file_size
+        .saturating_sub(outgoing_size)
+        .saturating_add(incoming_size)
+}
+
+fn fill_score(level_size: u64, level_target_size: u64) -> u64 {
+    let score =
+        (level_size as u128) * (SCORE_BASE as u128) / (std::cmp::max(1, level_target_size) as u128);
+    std::cmp::min(score, u64::MAX as u128) as u64
+}
+
+/// Scale a source-level fill score by the fill of its output level.
+///
+/// The 1% floor matches Pebble's protection against an unbounded priority when the output level is
+/// empty. Admission remains separate: L0 must pass this adjusted score, while positive levels only
+/// need their own fill score to exceed the configured target.
+pub(super) fn adjust_score_for_output_level(
+    source_score: u64,
+    output_level_size: u64,
+    output_level_target_size: u64,
+) -> u64 {
+    let output_target = std::cmp::max(1, output_level_target_size);
+    let min_output_size = std::cmp::max(1, output_target / SCORE_BASE);
+    let denominator = std::cmp::max(min_output_size, output_level_size);
+    let score = (source_score as u128) * (output_target as u128) / (denominator as u128);
+    std::cmp::min(score, u64::MAX as u128) as u64
 }
 
 pub struct DynamicLevelSelectorCore {
@@ -325,12 +369,19 @@ impl DynamicLevelSelectorCore {
                     select_level: 0,
                     target_level: 0,
                     picker_type: PickerType::Tier,
+                    eligible: true,
                     input: PickerInput::Global,
                 })
             }
 
             let single_table_candidates = single_table_compaction_group.and_then(|group| {
-                group.build_l0_candidates(&self.config, &levels.l0, &handlers[0])
+                group.build_l0_candidates(
+                    &self.config,
+                    &levels.l0,
+                    &handlers[0],
+                    effective_level_size(levels, handlers, ctx.base_level),
+                    ctx.level_max_bytes[ctx.base_level],
+                )
             });
             if let Some(candidates) = single_table_candidates {
                 ctx.score_levels
@@ -345,6 +396,7 @@ impl DynamicLevelSelectorCore {
                             SingleTableL0PickerType::ToBase => PickerType::ToBase,
                             SingleTableL0PickerType::Intra => PickerType::Intra,
                         },
+                        eligible: true,
                         input: PickerInput::SingleTablePartition {
                             partition_score: candidate.partition_score,
                             l0: candidate.l0,
@@ -364,17 +416,36 @@ impl DynamicLevelSelectorCore {
             }
             let output_file_size =
                 handlers[level_idx].pending_output_file_size(level.level_idx + 1);
-            let total_size = level.total_file_size.saturating_sub(output_file_size);
-            if total_size == 0 {
+            let legacy_level_size = level.total_file_size.saturating_sub(output_file_size);
+            let use_inter_level_score = single_table_compaction_group.is_some();
+            let level_size = if use_inter_level_score {
+                effective_level_size(levels, handlers, level_idx)
+            } else {
+                legacy_level_size
+            };
+            if level_size == 0 {
                 continue;
             }
 
+            let raw_score = fill_score(level_size, ctx.level_max_bytes[level_idx]);
+            let eligible = raw_score > SCORE_BASE;
+            let score = if use_inter_level_score && eligible {
+                let output_level = level_idx + 1;
+                adjust_score_for_output_level(
+                    raw_score,
+                    effective_level_size(levels, handlers, output_level),
+                    ctx.level_max_bytes[output_level],
+                )
+            } else {
+                raw_score
+            };
             ctx.score_levels.push({
                 PickerInfo {
-                    score: total_size * SCORE_BASE / ctx.level_max_bytes[level_idx],
+                    score,
                     select_level: level_idx,
                     target_level: level_idx + 1,
                     picker_type: PickerType::BottomLevel,
+                    eligible,
                     input: PickerInput::Global,
                 }
             });
@@ -434,6 +505,7 @@ impl DynamicLevelSelectorCore {
                 select_level: 0,
                 target_level: ctx.base_level,
                 picker_type: PickerType::ToBase,
+                eligible: true,
                 input: PickerInput::Global,
             });
         }
@@ -443,6 +515,7 @@ impl DynamicLevelSelectorCore {
                 select_level: 0,
                 target_level: 0,
                 picker_type: PickerType::Intra,
+                eligible: true,
                 input: PickerInput::Global,
             });
         }
@@ -554,8 +627,8 @@ impl CompactionSelector for DynamicLevelSelector {
             compaction_group.compaction_config.clone(),
         ));
         for picker_info in &ctx.score_levels {
-            if picker_info.score <= SCORE_BASE {
-                return None;
+            if !picker_info.eligible {
+                continue;
             }
             let mut picker = dynamic_level_core.create_compaction_picker(
                 picker_info,
@@ -620,6 +693,7 @@ pub mod tests {
     use std::sync::Arc;
 
     use itertools::Itertools;
+    use risingwave_common::catalog::TableId;
     use risingwave_common::constants::hummock::CompactionFilterFlag;
     use risingwave_hummock_sdk::HummockCompactionTaskId;
     use risingwave_hummock_sdk::compact_task::{CompactTask, CompactTaskAssignment};
@@ -669,6 +743,116 @@ pub mod tests {
                 in_progress_compactions,
             },
         )
+    }
+
+    #[test]
+    fn effective_level_size_accounts_for_pending_flow() {
+        let base_sst = generate_table(1, 1, 0, 99, 1);
+        let incoming_l0_sst = generate_table(2, 1, 0, 19, 2);
+        let levels = Levels {
+            levels: vec![generate_level(1, vec![base_sst.clone()])],
+            ..Default::default()
+        };
+        let mut handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+
+        assert_eq!(super::effective_level_size(&levels, &handlers, 1), 100);
+
+        handlers[1].add_pending_task(1, 2, [&base_sst]);
+        handlers[0].add_pending_task(2, 1, [&incoming_l0_sst]);
+        assert_eq!(super::effective_level_size(&levels, &handlers, 1), 20);
+    }
+
+    #[test]
+    fn inter_level_score_uses_output_fill() {
+        assert_eq!(super::fill_score(200, 100), 200);
+        assert_eq!(super::adjust_score_for_output_level(200, 400, 100), 50);
+        assert_eq!(super::adjust_score_for_output_level(200, 50, 100), 400);
+        assert_eq!(super::adjust_score_for_output_level(200, 0, 100), 20_000);
+    }
+
+    #[test]
+    fn single_table_strategy_adjusts_positive_level_priority_only() {
+        let config = CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .max_bytes_for_level_base(100)
+                .max_bytes_for_level_multiplier(10)
+                .max_level(3)
+                .build()
+        };
+        let core = DynamicLevelSelectorCore::new(
+            Arc::new(config),
+            Arc::new(CompactionDeveloperConfig::default()),
+        );
+        let levels = Levels {
+            levels: vec![
+                generate_level(1, generate_tables(1..2, 0..100, 1, 200)),
+                generate_level(2, generate_tables(2..3, 0..100, 1, 4_000)),
+                generate_level(3, generate_tables(3..4, 0..100, 1, 10_000)),
+            ],
+            ..Default::default()
+        };
+        let handlers = (0..=3).map(LevelHandler::new).collect_vec();
+
+        let legacy = core.get_priority_levels(&levels, &handlers);
+        let legacy_l1 = legacy
+            .score_levels
+            .iter()
+            .find(|candidate| candidate.select_level == 1)
+            .unwrap();
+        assert_eq!(legacy_l1.score, 200);
+        assert!(legacy_l1.eligible);
+
+        let partition = core.get_priority_levels_with_single_table_strategy(
+            &levels,
+            &handlers,
+            Some(SingleTableCompactionGroup::new(TableId::new(1), 256)),
+        );
+        let partition_l1 = partition
+            .score_levels
+            .iter()
+            .find(|candidate| candidate.select_level == 1)
+            .unwrap();
+        assert_eq!(partition_l1.score, 50);
+        // Positive levels stay eligible based on their own fill even when a fuller output level
+        // lowers their scheduling priority below 1.0.
+        assert!(partition_l1.eligible);
+    }
+
+    #[test]
+    fn adjusted_positive_level_below_one_remains_runnable() {
+        let config = CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .max_bytes_for_level_base(100)
+                .max_bytes_for_level_multiplier(10)
+                .max_level(2)
+                .build()
+        };
+        let group = CompactionGroup::new(1, config);
+        let levels = Levels {
+            levels: vec![
+                generate_level(1, generate_tables(1..2, 0..100, 1, 200)),
+                generate_level(2, generate_tables(2..3, 0..100, 1, 4_000)),
+            ],
+            ..Default::default()
+        };
+        let mut handlers = (0..=2).map(LevelHandler::new).collect_vec();
+        let mut selector = DynamicLevelSelector::default();
+        let task = pick_compaction_with_in_progress(
+            &mut selector,
+            1,
+            &group,
+            &levels,
+            &mut handlers,
+            &mut LocalSelectorStatistic::default(),
+            &InProgressCompactionView::default(),
+            Some(SingleTableCompactionGroup::new(TableId::new(1), 256)),
+        )
+        .unwrap();
+
+        assert_eq!(task.input.input_levels[0].level_idx, 1);
+        assert_eq!(task.input.target_level, 2);
     }
 
     #[test]

--- a/src/meta/src/hummock/compaction/selector/mod.rs
+++ b/src/meta/src/hummock/compaction/selector/mod.rs
@@ -20,6 +20,7 @@
 mod emergency_selector;
 pub(crate) mod level_selector;
 mod manual_selector;
+mod partition_l0_observability;
 mod single_table_compaction;
 mod space_reclaim_selector;
 mod tombstone_compaction_selector;
@@ -32,6 +33,9 @@ use std::sync::Arc;
 pub use emergency_selector::EmergencySelector;
 pub use level_selector::{DynamicLevelSelector, DynamicLevelSelectorCore};
 pub use manual_selector::{ManualCompactionOption, ManualCompactionSelector};
+use partition_l0_observability::{
+    PartitionL0CandidateInfo, PartitionL0CompactionObservation, report_partition_l0_observations,
+};
 use risingwave_common::catalog::{TableId, TableOption};
 use risingwave_hummock_sdk::level::Levels;
 use risingwave_hummock_sdk::table_watermark::TableWatermarks;
@@ -89,9 +93,14 @@ pub fn default_compaction_selector() -> Box<dyn CompactionSelector> {
 #[derive(Default)]
 pub struct LocalSelectorStatistic {
     skip_picker: Vec<(usize, usize, LocalPickerStatistic)>,
+    partition_l0: Vec<PartitionL0CompactionObservation>,
 }
 
 impl LocalSelectorStatistic {
+    fn record_partition_l0(&mut self, observation: PartitionL0CompactionObservation) {
+        self.partition_l0.push(observation);
+    }
+
     pub fn report_to_metrics(&self, group_id: CompactionGroupId, metrics: &MetaMetrics) {
         for (start_level, target_level, stats) in &self.skip_picker {
             let level_label = format!("cg{}-{}-to-{}", group_id, start_level, target_level);
@@ -124,6 +133,8 @@ impl LocalSelectorStatistic {
                 .with_label_values(&[level_label.as_str(), "picker"])
                 .inc();
         }
+
+        report_partition_l0_observations(group_id, metrics, &self.partition_l0);
     }
 }
 

--- a/src/meta/src/hummock/compaction/selector/mod.rs
+++ b/src/meta/src/hummock/compaction/selector/mod.rs
@@ -20,6 +20,7 @@
 mod emergency_selector;
 pub(crate) mod level_selector;
 mod manual_selector;
+mod single_table_compaction;
 mod space_reclaim_selector;
 mod tombstone_compaction_selector;
 mod ttl_selector;
@@ -37,6 +38,7 @@ use risingwave_hummock_sdk::table_watermark::TableWatermarks;
 use risingwave_hummock_sdk::version::HummockVersionStateTableInfo;
 use risingwave_hummock_sdk::{CompactionGroupId, HummockCompactionTaskId};
 use risingwave_pb::hummock::compact_task;
+pub use single_table_compaction::SingleTableCompactionGroup;
 pub use space_reclaim_selector::SpaceReclaimCompactionSelector;
 pub use tombstone_compaction_selector::TombstoneCompactionSelector;
 pub use ttl_selector::TtlCompactionSelector;
@@ -56,6 +58,7 @@ pub struct CompactionSelectorContext<'a> {
     pub group: &'a CompactionGroup,
     pub levels: &'a Levels,
     pub member_table_ids: &'a BTreeSet<TableId>,
+    pub single_table_compaction_group: Option<SingleTableCompactionGroup>,
     pub level_handlers: &'a mut [LevelHandler],
     pub selector_stats: &'a mut LocalSelectorStatistic,
     pub table_id_to_options: &'a HashMap<TableId, TableOption>,

--- a/src/meta/src/hummock/compaction/selector/partition_l0_observability.rs
+++ b/src/meta/src/hummock/compaction/selector/partition_l0_observability.rs
@@ -1,0 +1,268 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_hummock_sdk::CompactionGroupId;
+
+use crate::hummock::compaction::picker::{PartitionL0GrowthOutcome, PartitionL0GrowthStatistic};
+use crate::rpc::metrics::MetaMetrics;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct PartitionL0CandidateInfo {
+    pub(super) partition_index: usize,
+    pub(super) partition_depth: u64,
+    pub(super) max_overlap_depth: u64,
+    pub(super) total_sst_ref_count: u64,
+    pub(super) total_object_count: u64,
+    pub(super) runnable_sst_ref_count: u64,
+    pub(super) runnable_object_count: u64,
+    pub(super) total_file_size: u64,
+    pub(super) runnable_file_size: u64,
+    pub(super) total_referenced_object_size: u64,
+    pub(super) runnable_referenced_object_size: u64,
+    pub(super) raw_global_l0_score: u64,
+    pub(super) adjusted_global_l0_score: u64,
+    pub(super) partition_score: u64,
+    pub(super) base_current_size: u64,
+    pub(super) base_incoming_size: u64,
+    pub(super) base_outgoing_size: u64,
+    pub(super) base_effective_size: u64,
+    pub(super) base_target_size: u64,
+}
+
+#[derive(Debug)]
+pub(super) struct PartitionL0CompactionObservation {
+    pub(super) candidate: PartitionL0CandidateInfo,
+    pub(super) picker: &'static str,
+    pub(super) outcome: &'static str,
+    pub(super) min_seed_depth: u64,
+    pub(super) selected_l0_level_count: u64,
+    pub(super) selected_l0_sst_ref_count: u64,
+    pub(super) selected_l0_size: u64,
+    pub(super) selected_l0_referenced_object_size: u64,
+    pub(super) target_sst_ref_count: u64,
+    pub(super) target_size: u64,
+    pub(super) target_referenced_object_size: u64,
+    pub(super) growth: PartitionL0GrowthStatistic,
+}
+
+pub(super) fn report_partition_l0_observations(
+    group_id: CompactionGroupId,
+    metrics: &MetaMetrics,
+    observations: &[PartitionL0CompactionObservation],
+) {
+    let group_label = group_id.to_string();
+    for observation in observations {
+        metrics
+            .partition_l0_compaction_total
+            .with_label_values(&[&group_label, observation.picker, observation.outcome])
+            .inc();
+
+        if observation.outcome == "candidate" {
+            observe_candidate(metrics, &group_label, observation);
+            continue;
+        }
+
+        // Attempted inputs are useful in debug logs, but only scheduled tasks belong in task-shape
+        // histograms. Otherwise a range-conflict retry would be counted as executed compaction.
+        if observation.outcome == "selected" {
+            observe_selected_task(metrics, &group_label, observation);
+            log_selected_task(group_id, observation);
+        } else {
+            tracing::debug!(
+                target: "risingwave_meta::hummock::partition_l0",
+                compaction_group_id = %group_id,
+                ?observation,
+                "partition-aware L0 compaction attempt did not produce a task"
+            );
+        }
+    }
+}
+
+fn observe_candidate(
+    metrics: &MetaMetrics,
+    group_label: &str,
+    observation: &PartitionL0CompactionObservation,
+) {
+    let mut byte_observations = vec![
+        ("partition-total", observation.candidate.total_file_size),
+        (
+            "partition-runnable",
+            observation.candidate.runnable_file_size,
+        ),
+        (
+            "partition-referenced-object-total",
+            observation.candidate.total_referenced_object_size,
+        ),
+        (
+            "partition-referenced-object-runnable",
+            observation.candidate.runnable_referenced_object_size,
+        ),
+        ("base-current", observation.candidate.base_current_size),
+        ("base-incoming", observation.candidate.base_incoming_size),
+        ("base-outgoing", observation.candidate.base_outgoing_size),
+        ("base-effective", observation.candidate.base_effective_size),
+    ];
+    // `u64::MAX` means that the dynamic base level has no finite target yet. It is not a byte
+    // observation and must not poison the histogram sum.
+    if observation.candidate.base_target_size != u64::MAX {
+        byte_observations.push(("base-target", observation.candidate.base_target_size));
+    }
+    for (kind, value) in byte_observations {
+        metrics
+            .partition_l0_compaction_bytes
+            .with_label_values(&[group_label, kind])
+            .observe(value as f64);
+    }
+    for (kind, value) in [
+        ("partition-depth", observation.candidate.partition_depth),
+        ("max-overlap-depth", observation.candidate.max_overlap_depth),
+        (
+            "partition-sst-refs",
+            observation.candidate.total_sst_ref_count,
+        ),
+        (
+            "partition-objects",
+            observation.candidate.total_object_count,
+        ),
+        (
+            "runnable-sst-refs",
+            observation.candidate.runnable_sst_ref_count,
+        ),
+        (
+            "runnable-objects",
+            observation.candidate.runnable_object_count,
+        ),
+    ] {
+        metrics
+            .partition_l0_compaction_count
+            .with_label_values(&[group_label, kind])
+            .observe(value as f64);
+    }
+    for (kind, value) in [
+        ("raw-global", observation.candidate.raw_global_l0_score),
+        (
+            "adjusted-global",
+            observation.candidate.adjusted_global_l0_score,
+        ),
+        ("partition", observation.candidate.partition_score),
+    ] {
+        metrics
+            .partition_l0_compaction_score
+            .with_label_values(&[group_label, kind])
+            .observe(value as f64);
+    }
+}
+
+fn observe_selected_task(
+    metrics: &MetaMetrics,
+    group_label: &str,
+    observation: &PartitionL0CompactionObservation,
+) {
+    // Only ordinary ToBase has an initial seed and optional donors. The outcome sum is the
+    // number of donor attempts, including duplicate/subset plans that add no new SST.
+    if observation.picker == "to-base" {
+        for (kind, value) in PartitionL0GrowthOutcome::LABELS
+            .iter()
+            .zip(observation.growth.outcomes)
+        {
+            metrics
+                .partition_l0_compaction_count
+                .with_label_values(&[group_label, kind])
+                .observe(value as f64);
+        }
+        for (kind, value) in [
+            ("initial-l0", observation.growth.initial_l0_size),
+            (
+                "growth-added",
+                observation
+                    .selected_l0_size
+                    .saturating_sub(observation.growth.initial_l0_size),
+            ),
+        ] {
+            metrics
+                .partition_l0_compaction_bytes
+                .with_label_values(&[group_label, kind])
+                .observe(value as f64);
+        }
+    }
+    for (kind, value) in [
+        ("selected-l0", observation.selected_l0_size),
+        (
+            "selected-l0-referenced-object",
+            observation.selected_l0_referenced_object_size,
+        ),
+        ("target", observation.target_size),
+        (
+            "target-referenced-object",
+            observation.target_referenced_object_size,
+        ),
+    ] {
+        metrics
+            .partition_l0_compaction_bytes
+            .with_label_values(&[group_label, kind])
+            .observe(value as f64);
+    }
+    for (kind, value) in [
+        ("min-seed-depth", observation.min_seed_depth),
+        ("selected-l0-levels", observation.selected_l0_level_count),
+        (
+            "selected-l0-sst-refs",
+            observation.selected_l0_sst_ref_count,
+        ),
+        ("target-sst-refs", observation.target_sst_ref_count),
+        (
+            "selected-partition-depth",
+            observation.candidate.partition_depth,
+        ),
+        (
+            "selected-max-overlap-depth",
+            observation.candidate.max_overlap_depth,
+        ),
+    ] {
+        metrics
+            .partition_l0_compaction_count
+            .with_label_values(&[group_label, kind])
+            .observe(value as f64);
+    }
+}
+
+fn log_selected_task(group_id: CompactionGroupId, observation: &PartitionL0CompactionObservation) {
+    tracing::info!(
+        target: "risingwave_meta::hummock::partition_l0",
+        compaction_group_id = %group_id,
+        picker = observation.picker,
+        partition_index = observation.candidate.partition_index,
+        partition_depth = observation.candidate.partition_depth,
+        max_overlap_depth = observation.candidate.max_overlap_depth,
+        min_seed_depth = observation.min_seed_depth,
+        raw_global_l0_score = observation.candidate.raw_global_l0_score,
+        adjusted_global_l0_score = observation.candidate.adjusted_global_l0_score,
+        partition_score = observation.candidate.partition_score,
+        partition_total_bytes = observation.candidate.total_file_size,
+        partition_runnable_bytes = observation.candidate.runnable_file_size,
+        partition_sst_refs = observation.candidate.total_sst_ref_count,
+        partition_objects = observation.candidate.total_object_count,
+        selected_l0_levels = observation.selected_l0_level_count,
+        selected_l0_sst_refs = observation.selected_l0_sst_ref_count,
+        selected_l0_bytes = observation.selected_l0_size,
+        selected_l0_referenced_object_bytes = observation.selected_l0_referenced_object_size,
+        target_sst_refs = observation.target_sst_ref_count,
+        target_bytes = observation.target_size,
+        target_referenced_object_bytes = observation.target_referenced_object_size,
+        growth_initial_l0_bytes = observation.growth.initial_l0_size,
+        growth_outcomes = ?PartitionL0GrowthOutcome::LABELS.iter()
+            .zip(observation.growth.outcomes).collect::<Vec<_>>(),
+        "partition-aware L0 compaction selected"
+    );
+}

--- a/src/meta/src/hummock/compaction/selector/single_table_compaction.rs
+++ b/src/meta/src/hummock/compaction/selector/single_table_compaction.rs
@@ -1,0 +1,367 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use risingwave_common::catalog::TableId;
+use risingwave_hummock_sdk::level::OverlappingLevel;
+use risingwave_pb::hummock::CompactionConfig;
+
+use super::level_selector::SCORE_BASE;
+use crate::hummock::compaction::vnode_partition::L0VnodePartitionView;
+use crate::hummock::level_handler::LevelHandler;
+
+/// The immutable table metadata required by the partition-aware L0 strategy.
+///
+/// The manager only constructs this value for a compaction group containing exactly one table.
+/// Keeping it as a distinct type prevents the generic selector from inferring single-table
+/// eligibility from partial inputs.
+#[derive(Clone, Copy, Debug)]
+pub struct SingleTableCompactionGroup {
+    table_id: TableId,
+    vnode_count: usize,
+}
+
+impl SingleTableCompactionGroup {
+    pub(crate) fn new(table_id: TableId, vnode_count: usize) -> Self {
+        Self {
+            table_id,
+            vnode_count,
+        }
+    }
+
+    /// Build partition-local candidates from the current L0 and pending state.
+    ///
+    /// `None` means that the current L0 cannot be represented by the fixed vnode layout and the
+    /// caller must use the legacy global L0 strategy. `Some([])` means the partition strategy is
+    /// active but no partition has reached the configured depth threshold.
+    pub(super) fn build_l0_candidates(
+        self,
+        config: &CompactionConfig,
+        l0: &OverlappingLevel,
+        l0_handler: &LevelHandler,
+    ) -> Option<Vec<SingleTableL0Candidate>> {
+        let partition_view = L0VnodePartitionView::build(
+            self.table_id,
+            self.vnode_count,
+            config.split_weight_by_vnode as usize,
+            l0,
+            l0_handler,
+        )?;
+        let min_l0_level_count = config.level0_sub_level_compact_level_count as usize;
+        let partitions = partition_view
+            .into_partitions(min_l0_level_count as u64, SCORE_BASE)
+            .filter(|(score, partition_l0)| {
+                *score > SCORE_BASE && !partition_l0.sub_levels.is_empty()
+            })
+            .map(|(score, partition_l0)| SingleTableL0Partition {
+                score,
+                l0: Arc::new(partition_l0),
+            })
+            .collect::<Vec<_>>();
+
+        let Some(global_l0_score) = partitions.iter().map(|partition| partition.score).max() else {
+            return Some(vec![]);
+        };
+
+        let mut candidates = Vec::with_capacity(partitions.len() * 2);
+        for partition in &partitions {
+            candidates.push(SingleTableL0Candidate {
+                score: global_l0_score.saturating_add(1),
+                partition_score: partition.score,
+                picker_type: SingleTableL0PickerType::ToBase,
+                l0: partition.l0.clone(),
+                min_l0_level_count,
+            });
+        }
+        for partition in partitions {
+            candidates.push(SingleTableL0Candidate {
+                score: global_l0_score,
+                partition_score: partition.score,
+                picker_type: SingleTableL0PickerType::Intra,
+                l0: partition.l0,
+                min_l0_level_count: 1,
+            });
+        }
+        Some(candidates)
+    }
+}
+
+struct SingleTableL0Partition {
+    score: u64,
+    l0: Arc<OverlappingLevel>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) enum SingleTableL0PickerType {
+    ToBase,
+    Intra,
+}
+
+#[derive(Debug)]
+pub(super) struct SingleTableL0Candidate {
+    pub(super) score: u64,
+    pub(super) partition_score: u64,
+    pub(super) picker_type: SingleTableL0PickerType,
+    pub(super) l0: Arc<OverlappingLevel>,
+    pub(super) min_l0_level_count: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeSet, HashMap};
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use itertools::Itertools;
+    use risingwave_common::hash::VirtualNode;
+    use risingwave_hummock_sdk::HummockCompactionTaskId;
+    use risingwave_hummock_sdk::key::{FullKey, TableKey};
+    use risingwave_hummock_sdk::key_range::KeyRange;
+    use risingwave_hummock_sdk::level::{Levels, OverlappingLevel};
+    use risingwave_hummock_sdk::sstable_info::SstableInfo;
+    use risingwave_hummock_sdk::version::HummockVersionStateTableInfo;
+    use risingwave_pb::hummock::CompactionConfig;
+
+    use super::*;
+    use crate::hummock::compaction::compaction_config::CompactionConfigBuilder;
+    use crate::hummock::compaction::in_progress_compaction::InProgressCompactionView;
+    use crate::hummock::compaction::selector::level_selector::DynamicLevelSelector;
+    use crate::hummock::compaction::selector::tests::{
+        generate_l0_nonoverlapping_multi_sublevels, generate_l0_nonoverlapping_sublevels,
+        generate_level, generate_table,
+    };
+    use crate::hummock::compaction::selector::{
+        CompactionSelector, CompactionSelectorContext, LocalSelectorStatistic,
+    };
+    use crate::hummock::compaction::{CompactionDeveloperConfig, CompactionTask};
+    use crate::hummock::level_handler::LevelHandler;
+    use crate::hummock::model::CompactionGroup;
+
+    fn vnode_key(vnode: usize) -> Bytes {
+        FullKey::new(
+            TableId::new(1),
+            TableKey(VirtualNode::from_index(vnode).to_be_bytes().to_vec()),
+            u64::MAX,
+        )
+        .encode()
+        .into()
+    }
+
+    fn vnode_sst(id: u64, left_vnode: usize, right_vnode: usize) -> SstableInfo {
+        let mut sst = generate_table(id, 1, 0, 1, id);
+        let mut inner = sst.get_inner();
+        inner.key_range = KeyRange {
+            left: vnode_key(left_vnode),
+            right: vnode_key(right_vnode),
+            right_exclusive: true,
+        };
+        sst.set_inner(inner);
+        sst
+    }
+
+    fn two_partition_l0(first_depth: usize, second_depth: usize) -> OverlappingLevel {
+        generate_l0_nonoverlapping_multi_sublevels(
+            (0..std::cmp::max(first_depth, second_depth))
+                .map(|level| {
+                    let mut ssts = vec![];
+                    if level < first_depth {
+                        ssts.push(vnode_sst(level as u64 + 1, 0, 32));
+                    }
+                    if level < second_depth {
+                        ssts.push(vnode_sst(level as u64 + 101, 32, 64));
+                    }
+                    ssts
+                })
+                .collect(),
+        )
+    }
+
+    fn pick_compaction(
+        task_id: HummockCompactionTaskId,
+        group: &CompactionGroup,
+        levels: &Levels,
+        level_handlers: &mut [LevelHandler],
+        in_progress_compactions: &InProgressCompactionView,
+    ) -> Option<CompactionTask> {
+        DynamicLevelSelector::default().pick_compaction(
+            task_id,
+            CompactionSelectorContext {
+                group,
+                levels,
+                member_table_ids: &BTreeSet::from([TableId::new(1)]),
+                single_table_compaction_group: Some(SingleTableCompactionGroup::new(
+                    TableId::new(1),
+                    256,
+                )),
+                level_handlers,
+                selector_stats: &mut LocalSelectorStatistic::default(),
+                table_id_to_options: &HashMap::default(),
+                developer_config: Arc::new(CompactionDeveloperConfig::default()),
+                table_watermarks: &HashMap::default(),
+                state_table_info: &HummockVersionStateTableInfo::empty(),
+                in_progress_compactions,
+            },
+        )
+    }
+
+    #[test]
+    fn local_depth_does_not_sum_across_partitions() {
+        let config = CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .level0_sub_level_compact_level_count(3)
+                .build()
+        };
+        let l0 = generate_l0_nonoverlapping_sublevels(
+            (0..8)
+                .map(|partition| {
+                    vnode_sst(partition as u64 + 1, partition * 32, (partition + 1) * 32)
+                })
+                .collect(),
+        );
+        let candidates = SingleTableCompactionGroup::new(TableId::new(1), 256)
+            .build_l0_candidates(&config, &l0, &LevelHandler::new(0))
+            .unwrap();
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn pending_partition_does_not_block_another_partition() {
+        let config = CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .max_level(1)
+                .max_bytes_for_level_base(1024)
+                .level0_sub_level_compact_level_count(2)
+                .build()
+        };
+        let group = CompactionGroup::new(1, config);
+        let levels = Levels {
+            levels: vec![generate_level(1, vec![])],
+            l0: generate_l0_nonoverlapping_multi_sublevels(
+                (1..=3)
+                    .map(|id| vec![vnode_sst(id, 0, 32), vnode_sst(id + 100, 32, 64)])
+                    .collect(),
+            ),
+            ..Default::default()
+        };
+        let mut handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        handlers[0].add_pending_task(
+            100,
+            0,
+            levels
+                .l0
+                .sub_levels
+                .iter()
+                .map(|level| &level.table_infos[0]),
+        );
+
+        let task = pick_compaction(
+            1,
+            &group,
+            &levels,
+            &mut handlers,
+            &InProgressCompactionView::default(),
+        )
+        .unwrap();
+        let selected_l0_ids = task
+            .input
+            .input_levels
+            .iter()
+            .filter(|level| level.level_idx == 0)
+            .flat_map(|level| level.table_infos.iter())
+            .map(|sst| sst.sst_id.as_raw_id())
+            .collect_vec();
+        assert!(!selected_l0_ids.is_empty());
+        assert!(selected_l0_ids.iter().all(|sst_id| *sst_id > 100));
+    }
+
+    #[test]
+    fn to_base_prefers_the_deeper_partition() {
+        let config = CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .max_level(1)
+                .max_bytes_for_level_base(1024)
+                .level0_sub_level_compact_level_count(2)
+                .build()
+        };
+        let group = CompactionGroup::new(1, config);
+        let levels = Levels {
+            levels: vec![generate_level(1, vec![])],
+            l0: two_partition_l0(4, 2),
+            ..Default::default()
+        };
+        let mut handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+
+        let task = pick_compaction(
+            1,
+            &group,
+            &levels,
+            &mut handlers,
+            &InProgressCompactionView::default(),
+        )
+        .unwrap();
+        assert_eq!(task.input.target_level, 1);
+        assert!(
+            task.input
+                .input_levels
+                .iter()
+                .filter(|level| level.level_idx == 0)
+                .flat_map(|level| level.table_infos.iter())
+                .all(|sst| sst.sst_id.as_raw_id() < 100)
+        );
+    }
+
+    #[test]
+    fn intra_is_used_only_after_partition_to_base_is_blocked() {
+        let config = CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .max_level(1)
+                .max_bytes_for_level_base(1024)
+                .level0_sub_level_compact_level_count(2)
+                .build()
+        };
+        let group = CompactionGroup::new(1, config);
+        let levels = Levels {
+            levels: vec![generate_level(
+                1,
+                vec![vnode_sst(1000, 0, 32), vnode_sst(1001, 32, 64)],
+            )],
+            l0: two_partition_l0(4, 2),
+            ..Default::default()
+        };
+        let mut handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        handlers[1].add_pending_task(100, 1, &levels.levels[0].table_infos);
+
+        let task = pick_compaction(
+            1,
+            &group,
+            &levels,
+            &mut handlers,
+            &InProgressCompactionView::default(),
+        )
+        .unwrap();
+        assert_eq!(task.input.target_level, 0);
+        assert!(
+            task.input
+                .input_levels
+                .iter()
+                .flat_map(|level| level.table_infos.iter())
+                .all(|sst| sst.sst_id.as_raw_id() < 100)
+        );
+    }
+}

--- a/src/meta/src/hummock/compaction/selector/single_table_compaction.rs
+++ b/src/meta/src/hummock/compaction/selector/single_table_compaction.rs
@@ -23,6 +23,14 @@ use super::level_selector::{EffectiveLevelSize, SCORE_BASE, adjust_score_for_out
 use crate::hummock::compaction::vnode_partition::L0VnodePartitionView;
 use crate::hummock::level_handler::LevelHandler;
 
+const GLOBAL_L0_DEPTH_SCORE_MULTIPLIER: u64 = 2;
+
+fn global_l0_depth_score(depth: u64, threshold: u64) -> u64 {
+    let score = (depth as u128) * (GLOBAL_L0_DEPTH_SCORE_MULTIPLIER as u128) * (SCORE_BASE as u128)
+        / (std::cmp::max(1, threshold) as u128);
+    std::cmp::min(score, u64::MAX as u128) as u64
+}
+
 /// The immutable table metadata required by the partition-aware L0 strategy.
 ///
 /// The manager only constructs this value for a compaction group containing exactly one table.
@@ -92,16 +100,26 @@ impl SingleTableCompactionGroup {
             })
             .collect::<Vec<_>>();
 
-        let Some(raw_global_l0_score) = partitions.iter().map(|partition| partition.score).max()
+        let Some(max_partition_depth) = partitions
+            .iter()
+            .map(|partition| partition.info.partition_depth)
+            .max()
         else {
             return Some(vec![]);
         };
         // At least one partition must independently exceed the configured depth threshold.
         // Output-level pressure only orders an already-eligible L0; it must not make a shallow L0
         // eligible by itself.
-        if raw_global_l0_score <= SCORE_BASE {
+        if partitions
+            .iter()
+            .all(|partition| partition.score <= SCORE_BASE)
+        {
             return Some(vec![]);
         }
+        // Match Pebble's L0 depth-pressure scale without changing the partition-local batching
+        // threshold. Compute from depth directly so integer rounding happens only once.
+        let raw_global_l0_score =
+            global_l0_depth_score(max_partition_depth, min_l0_level_count as u64);
         let global_l0_score = adjust_score_for_output_level(
             raw_global_l0_score,
             effective_base_level_size.effective,
@@ -319,7 +337,7 @@ mod tests {
         let l0 = two_partition_l0(4, 0);
         let group = SingleTableCompactionGroup::new(TableId::new(1), 256);
 
-        // Raw depth score is 2.0. A healthy Base keeps the score unchanged.
+        // Local depth score is 2.0. The global depth-pressure multiplier raises it to 4.0.
         let candidates = group
             .build_l0_candidates(
                 &config,
@@ -334,7 +352,7 @@ mod tests {
             )
             .unwrap();
         assert_eq!(candidates.len(), 2);
-        assert_eq!(candidates[0].score, 201);
+        assert_eq!(candidates[0].score, 401);
 
         // An underfilled Base raises L0 priority relative to lower-level work.
         let candidates = group
@@ -350,7 +368,7 @@ mod tests {
                 100,
             )
             .unwrap();
-        assert_eq!(candidates[0].score, 401);
+        assert_eq!(candidates[0].score, 801);
 
         // An adjusted score exactly at the admission threshold remains eligible.
         let candidates = group
@@ -359,8 +377,8 @@ mod tests {
                 &l0,
                 &LevelHandler::new(0),
                 EffectiveLevelSize {
-                    current: 200,
-                    effective: 200,
+                    current: 400,
+                    effective: 400,
                     ..Default::default()
                 },
                 100,
@@ -369,7 +387,7 @@ mod tests {
         assert_eq!(candidates.len(), 2);
         assert_eq!(candidates[0].score, 101);
 
-        // Once Base grows beyond 2x its target, the adjusted score no longer passes the
+        // Once Base grows beyond 4x its target, the adjusted score no longer passes the
         // admission threshold, so neither ToBase nor its Intra fallback is scheduled.
         let candidates = group
             .build_l0_candidates(
@@ -377,14 +395,83 @@ mod tests {
                 &l0,
                 &LevelHandler::new(0),
                 EffectiveLevelSize {
-                    current: 201,
-                    effective: 201,
+                    current: 401,
+                    effective: 401,
                     ..Default::default()
                 },
                 100,
             )
             .unwrap();
         assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn global_depth_pressure_does_not_change_local_batching_threshold() {
+        let config = CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .level0_sub_level_compact_level_count(16)
+                .build()
+        };
+        let group = SingleTableCompactionGroup::new(TableId::new(1), 256);
+
+        // D=32 gives global raw score 4.0. A Base at 4x target lowers it to exactly 1.0,
+        // while the selected task still has the original 16-level minimum.
+        let candidates = group
+            .build_l0_candidates(
+                &config,
+                &two_partition_l0(32, 0),
+                &LevelHandler::new(0),
+                EffectiveLevelSize {
+                    current: 400,
+                    effective: 400,
+                    ..Default::default()
+                },
+                100,
+            )
+            .unwrap();
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].info.partition_score, 200);
+        assert_eq!(candidates[0].info.raw_global_l0_score, 400);
+        assert_eq!(candidates[0].info.adjusted_global_l0_score, 100);
+        assert_eq!(candidates[0].score, 101);
+        assert_eq!(candidates[0].min_l0_level_count, 16);
+
+        // The global multiplier must not make a partition at the local batching threshold
+        // eligible for an ordinary ToBase or Intra task.
+        let candidates = group
+            .build_l0_candidates(
+                &config,
+                &two_partition_l0(16, 0),
+                &LevelHandler::new(0),
+                EffectiveLevelSize {
+                    current: 100,
+                    effective: 100,
+                    ..Default::default()
+                },
+                100,
+            )
+            .unwrap();
+        assert!(candidates.is_empty());
+
+        // Compute from depth before rounding: 2 * 18 / 16 = 2.25. With Base at 2.25x target,
+        // the adjusted score is exactly 1.0 and remains eligible.
+        let candidates = group
+            .build_l0_candidates(
+                &config,
+                &two_partition_l0(18, 0),
+                &LevelHandler::new(0),
+                EffectiveLevelSize {
+                    current: 225,
+                    effective: 225,
+                    ..Default::default()
+                },
+                100,
+            )
+            .unwrap();
+        assert_eq!(candidates[0].info.partition_score, 112);
+        assert_eq!(candidates[0].info.raw_global_l0_score, 225);
+        assert_eq!(candidates[0].info.adjusted_global_l0_score, 100);
     }
 
     #[test]

--- a/src/meta/src/hummock/compaction/selector/single_table_compaction.rs
+++ b/src/meta/src/hummock/compaction/selector/single_table_compaction.rs
@@ -18,7 +18,8 @@ use risingwave_common::catalog::TableId;
 use risingwave_hummock_sdk::level::OverlappingLevel;
 use risingwave_pb::hummock::CompactionConfig;
 
-use super::level_selector::{SCORE_BASE, adjust_score_for_output_level};
+use super::PartitionL0CandidateInfo;
+use super::level_selector::{EffectiveLevelSize, SCORE_BASE, adjust_score_for_output_level};
 use crate::hummock::compaction::vnode_partition::L0VnodePartitionView;
 use crate::hummock::level_handler::LevelHandler;
 
@@ -45,13 +46,13 @@ impl SingleTableCompactionGroup {
     ///
     /// `None` means that the current L0 cannot be represented by the fixed vnode layout and the
     /// caller must use the legacy global L0 strategy. `Some([])` means the partition strategy is
-    /// active but no partition has reached the configured depth threshold.
+    /// active but the global L0 pressure has not reached the configured depth threshold.
     pub(super) fn build_l0_candidates(
         self,
         config: &CompactionConfig,
         l0: &OverlappingLevel,
         l0_handler: &LevelHandler,
-        effective_base_level_size: u64,
+        effective_base_level_size: EffectiveLevelSize,
         base_level_target_size: u64,
     ) -> Option<Vec<SingleTableL0Candidate>> {
         let partition_view = L0VnodePartitionView::build(
@@ -64,12 +65,30 @@ impl SingleTableCompactionGroup {
         let min_l0_level_count = config.level0_sub_level_compact_level_count as usize;
         let partitions = partition_view
             .into_partitions(min_l0_level_count as u64, SCORE_BASE)
-            .filter(|(score, partition_l0)| {
-                *score > SCORE_BASE && !partition_l0.sub_levels.is_empty()
-            })
-            .map(|(score, partition_l0)| SingleTableL0Partition {
+            .filter(|(_, partition)| !partition.l0.sub_levels.is_empty())
+            .map(|(score, partition)| SingleTableL0Partition {
                 score,
-                l0: Arc::new(partition_l0),
+                info: PartitionL0CandidateInfo {
+                    partition_index: partition.index,
+                    partition_depth: partition.depth,
+                    max_overlap_depth: partition.max_overlap_depth,
+                    total_sst_ref_count: partition.total_sst_ref_count,
+                    total_object_count: partition.total_object_count,
+                    runnable_sst_ref_count: partition.runnable_sst_ref_count,
+                    runnable_object_count: partition.runnable_object_count,
+                    total_file_size: partition.l0.total_file_size,
+                    runnable_file_size: partition.runnable_file_size,
+                    total_referenced_object_size: partition.total_referenced_object_size,
+                    runnable_referenced_object_size: partition.runnable_referenced_object_size,
+                    partition_score: score,
+                    base_current_size: effective_base_level_size.current,
+                    base_incoming_size: effective_base_level_size.incoming,
+                    base_outgoing_size: effective_base_level_size.outgoing,
+                    base_effective_size: effective_base_level_size.effective,
+                    base_target_size: base_level_target_size,
+                    ..Default::default()
+                },
+                l0: Arc::new(partition.l0),
             })
             .collect::<Vec<_>>();
 
@@ -77,9 +96,15 @@ impl SingleTableCompactionGroup {
         else {
             return Some(vec![]);
         };
+        // At least one partition must independently exceed the configured depth threshold.
+        // Output-level pressure only orders an already-eligible L0; it must not make a shallow L0
+        // eligible by itself.
+        if raw_global_l0_score <= SCORE_BASE {
+            return Some(vec![]);
+        }
         let global_l0_score = adjust_score_for_output_level(
             raw_global_l0_score,
-            effective_base_level_size,
+            effective_base_level_size.effective,
             base_level_target_size,
         );
         if global_l0_score <= SCORE_BASE {
@@ -87,22 +112,49 @@ impl SingleTableCompactionGroup {
         }
 
         let mut candidates = Vec::with_capacity(partitions.len() * 2);
-        for partition in &partitions {
+        for partition in partitions
+            .iter()
+            .filter(|partition| partition.score > SCORE_BASE)
+        {
+            let mut info = partition.info;
+            info.raw_global_l0_score = raw_global_l0_score;
+            info.adjusted_global_l0_score = global_l0_score;
             candidates.push(SingleTableL0Candidate {
                 score: global_l0_score.saturating_add(1),
-                partition_score: partition.score,
+                info,
                 picker_type: SingleTableL0PickerType::ToBase,
                 l0: partition.l0.clone(),
                 min_l0_level_count,
             });
         }
-        for partition in partitions {
+        for partition in partitions
+            .iter()
+            .filter(|partition| partition.score <= SCORE_BASE)
+        {
+            let mut info = partition.info;
+            info.raw_global_l0_score = raw_global_l0_score;
+            info.adjusted_global_l0_score = global_l0_score;
+            candidates.push(SingleTableL0Candidate {
+                score: global_l0_score.saturating_add(1),
+                info,
+                picker_type: SingleTableL0PickerType::TrivialMove,
+                l0: partition.l0.clone(),
+                min_l0_level_count: 1,
+            });
+        }
+        for partition in partitions
+            .into_iter()
+            .filter(|partition| partition.score > SCORE_BASE)
+        {
+            let mut info = partition.info;
+            info.raw_global_l0_score = raw_global_l0_score;
+            info.adjusted_global_l0_score = global_l0_score;
             candidates.push(SingleTableL0Candidate {
                 score: global_l0_score,
-                partition_score: partition.score,
+                info,
                 picker_type: SingleTableL0PickerType::Intra,
                 l0: partition.l0,
-                min_l0_level_count: 1,
+                min_l0_level_count,
             });
         }
         Some(candidates)
@@ -111,19 +163,21 @@ impl SingleTableCompactionGroup {
 
 struct SingleTableL0Partition {
     score: u64,
+    info: PartitionL0CandidateInfo,
     l0: Arc<OverlappingLevel>,
 }
 
 #[derive(Clone, Copy, Debug)]
 pub(super) enum SingleTableL0PickerType {
     ToBase,
+    TrivialMove,
     Intra,
 }
 
 #[derive(Debug)]
 pub(super) struct SingleTableL0Candidate {
     pub(super) score: u64,
-    pub(super) partition_score: u64,
+    pub(super) info: PartitionL0CandidateInfo,
     pub(super) picker_type: SingleTableL0PickerType,
     pub(super) l0: Arc<OverlappingLevel>,
     pub(super) min_l0_level_count: usize,
@@ -243,7 +297,13 @@ mod tests {
                 .collect(),
         );
         let candidates = SingleTableCompactionGroup::new(TableId::new(1), 256)
-            .build_l0_candidates(&config, &l0, &LevelHandler::new(0), 0, u64::MAX)
+            .build_l0_candidates(
+                &config,
+                &l0,
+                &LevelHandler::new(0),
+                EffectiveLevelSize::default(),
+                u64::MAX,
+            )
             .unwrap();
         assert!(candidates.is_empty());
     }
@@ -261,23 +321,109 @@ mod tests {
 
         // Raw depth score is 2.0. A healthy Base keeps the score unchanged.
         let candidates = group
-            .build_l0_candidates(&config, &l0, &LevelHandler::new(0), 100, 100)
+            .build_l0_candidates(
+                &config,
+                &l0,
+                &LevelHandler::new(0),
+                EffectiveLevelSize {
+                    current: 100,
+                    effective: 100,
+                    ..Default::default()
+                },
+                100,
+            )
             .unwrap();
         assert_eq!(candidates.len(), 2);
         assert_eq!(candidates[0].score, 201);
 
         // An underfilled Base raises L0 priority relative to lower-level work.
         let candidates = group
-            .build_l0_candidates(&config, &l0, &LevelHandler::new(0), 50, 100)
+            .build_l0_candidates(
+                &config,
+                &l0,
+                &LevelHandler::new(0),
+                EffectiveLevelSize {
+                    current: 50,
+                    effective: 50,
+                    ..Default::default()
+                },
+                100,
+            )
             .unwrap();
         assert_eq!(candidates[0].score, 401);
 
         // Once Base grows beyond 2x its target, the adjusted score no longer passes the strict
         // admission threshold, so neither ToBase nor its Intra fallback is scheduled.
         let candidates = group
-            .build_l0_candidates(&config, &l0, &LevelHandler::new(0), 201, 100)
+            .build_l0_candidates(
+                &config,
+                &l0,
+                &LevelHandler::new(0),
+                EffectiveLevelSize {
+                    current: 201,
+                    effective: 201,
+                    ..Default::default()
+                },
+                100,
+            )
             .unwrap();
         assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn global_admission_limits_shallow_partitions_to_trivial_move() {
+        let config = CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .level0_sub_level_compact_level_count(3)
+                .build()
+        };
+        let l0 = two_partition_l0(4, 2);
+        let candidates = SingleTableCompactionGroup::new(TableId::new(1), 256)
+            .build_l0_candidates(
+                &config,
+                &l0,
+                &LevelHandler::new(0),
+                EffectiveLevelSize {
+                    current: 100,
+                    effective: 100,
+                    ..Default::default()
+                },
+                100,
+            )
+            .unwrap();
+
+        let to_base = candidates
+            .iter()
+            .filter(|candidate| matches!(candidate.picker_type, SingleTableL0PickerType::ToBase))
+            .collect_vec();
+        assert_eq!(to_base.len(), 1);
+        assert!(
+            to_base
+                .iter()
+                .all(|candidate| candidate.min_l0_level_count == 3)
+        );
+
+        let trivial_move = candidates
+            .iter()
+            .filter(|candidate| {
+                matches!(candidate.picker_type, SingleTableL0PickerType::TrivialMove)
+            })
+            .collect_vec();
+        assert_eq!(trivial_move.len(), 1);
+        assert_eq!(trivial_move[0].min_l0_level_count, 1);
+        assert!(to_base[0].info.partition_score > trivial_move[0].info.partition_score);
+
+        let intra = candidates
+            .iter()
+            .filter(|candidate| matches!(candidate.picker_type, SingleTableL0PickerType::Intra))
+            .collect_vec();
+        assert_eq!(intra.len(), 1);
+        assert_eq!(
+            intra[0].info.partition_score,
+            to_base[0].info.partition_score
+        );
+        assert_eq!(intra[0].min_l0_level_count, 3);
     }
 
     #[test]
@@ -329,6 +475,49 @@ mod tests {
             .collect_vec();
         assert!(!selected_l0_ids.is_empty());
         assert!(selected_l0_ids.iter().all(|sst_id| *sst_id > 100));
+    }
+
+    #[test]
+    fn blocked_deep_to_base_does_not_rewrite_shallow_partition() {
+        let config = CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .max_level(1)
+                .max_bytes_for_level_base(1024)
+                .level0_sub_level_compact_level_count(2)
+                .build()
+        };
+        let group = CompactionGroup::new(1, config);
+        let levels = Levels {
+            levels: vec![generate_level(
+                1,
+                vec![vnode_sst(1000, 0, 32), vnode_sst(1001, 32, 64)],
+            )],
+            l0: two_partition_l0(3, 1),
+            ..Default::default()
+        };
+        let mut handlers = vec![LevelHandler::new(0), LevelHandler::new(1)];
+        handlers[1].add_pending_task(100, 1, [&levels.levels[0].table_infos[0]]);
+
+        let task = pick_compaction(
+            1,
+            &group,
+            &levels,
+            &mut handlers,
+            &InProgressCompactionView::default(),
+        )
+        .unwrap();
+        let selected_l0_ids = task
+            .input
+            .input_levels
+            .iter()
+            .filter(|level| level.level_idx == 0)
+            .flat_map(|level| level.table_infos.iter())
+            .map(|sst| sst.sst_id.as_raw_id())
+            .collect_vec();
+        assert_eq!(task.input.target_level, 0);
+        assert!(!selected_l0_ids.is_empty());
+        assert!(selected_l0_ids.iter().all(|sst_id| *sst_id < 100));
     }
 
     #[test]

--- a/src/meta/src/hummock/compaction/selector/single_table_compaction.rs
+++ b/src/meta/src/hummock/compaction/selector/single_table_compaction.rs
@@ -18,7 +18,7 @@ use risingwave_common::catalog::TableId;
 use risingwave_hummock_sdk::level::OverlappingLevel;
 use risingwave_pb::hummock::CompactionConfig;
 
-use super::level_selector::SCORE_BASE;
+use super::level_selector::{SCORE_BASE, adjust_score_for_output_level};
 use crate::hummock::compaction::vnode_partition::L0VnodePartitionView;
 use crate::hummock::level_handler::LevelHandler;
 
@@ -51,6 +51,8 @@ impl SingleTableCompactionGroup {
         config: &CompactionConfig,
         l0: &OverlappingLevel,
         l0_handler: &LevelHandler,
+        effective_base_level_size: u64,
+        base_level_target_size: u64,
     ) -> Option<Vec<SingleTableL0Candidate>> {
         let partition_view = L0VnodePartitionView::build(
             self.table_id,
@@ -71,9 +73,18 @@ impl SingleTableCompactionGroup {
             })
             .collect::<Vec<_>>();
 
-        let Some(global_l0_score) = partitions.iter().map(|partition| partition.score).max() else {
+        let Some(raw_global_l0_score) = partitions.iter().map(|partition| partition.score).max()
+        else {
             return Some(vec![]);
         };
+        let global_l0_score = adjust_score_for_output_level(
+            raw_global_l0_score,
+            effective_base_level_size,
+            base_level_target_size,
+        );
+        if global_l0_score <= SCORE_BASE {
+            return Some(vec![]);
+        }
 
         let mut candidates = Vec::with_capacity(partitions.len() * 2);
         for partition in &partitions {
@@ -232,7 +243,39 @@ mod tests {
                 .collect(),
         );
         let candidates = SingleTableCompactionGroup::new(TableId::new(1), 256)
-            .build_l0_candidates(&config, &l0, &LevelHandler::new(0))
+            .build_l0_candidates(&config, &l0, &LevelHandler::new(0), 0, u64::MAX)
+            .unwrap();
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn base_pressure_controls_partition_l0_admission() {
+        let config = CompactionConfig {
+            split_weight_by_vnode: 8,
+            ..CompactionConfigBuilder::new()
+                .level0_sub_level_compact_level_count(2)
+                .build()
+        };
+        let l0 = two_partition_l0(4, 0);
+        let group = SingleTableCompactionGroup::new(TableId::new(1), 256);
+
+        // Raw depth score is 2.0. A healthy Base keeps the score unchanged.
+        let candidates = group
+            .build_l0_candidates(&config, &l0, &LevelHandler::new(0), 100, 100)
+            .unwrap();
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].score, 201);
+
+        // An underfilled Base raises L0 priority relative to lower-level work.
+        let candidates = group
+            .build_l0_candidates(&config, &l0, &LevelHandler::new(0), 50, 100)
+            .unwrap();
+        assert_eq!(candidates[0].score, 401);
+
+        // Once Base grows beyond 2x its target, the adjusted score no longer passes the strict
+        // admission threshold, so neither ToBase nor its Intra fallback is scheduled.
+        let candidates = group
+            .build_l0_candidates(&config, &l0, &LevelHandler::new(0), 201, 100)
             .unwrap();
         assert!(candidates.is_empty());
     }

--- a/src/meta/src/hummock/compaction/selector/single_table_compaction.rs
+++ b/src/meta/src/hummock/compaction/selector/single_table_compaction.rs
@@ -107,7 +107,7 @@ impl SingleTableCompactionGroup {
             effective_base_level_size.effective,
             base_level_target_size,
         );
-        if global_l0_score <= SCORE_BASE {
+        if global_l0_score < SCORE_BASE {
             return Some(vec![]);
         }
 
@@ -352,7 +352,24 @@ mod tests {
             .unwrap();
         assert_eq!(candidates[0].score, 401);
 
-        // Once Base grows beyond 2x its target, the adjusted score no longer passes the strict
+        // An adjusted score exactly at the admission threshold remains eligible.
+        let candidates = group
+            .build_l0_candidates(
+                &config,
+                &l0,
+                &LevelHandler::new(0),
+                EffectiveLevelSize {
+                    current: 200,
+                    effective: 200,
+                    ..Default::default()
+                },
+                100,
+            )
+            .unwrap();
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].score, 101);
+
+        // Once Base grows beyond 2x its target, the adjusted score no longer passes the
         // admission threshold, so neither ToBase nor its Intra fallback is scheduled.
         let candidates = group
             .build_l0_candidates(

--- a/src/meta/src/hummock/compaction/vnode_partition.rs
+++ b/src/meta/src/hummock/compaction/vnode_partition.rs
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::{BTreeMap, HashSet};
+
+use bytes::Bytes;
 use risingwave_common::catalog::TableId;
+use risingwave_hummock_sdk::key::FullKey;
 use risingwave_hummock_sdk::key_range::{KeyRange, KeyRangeCommon};
 use risingwave_hummock_sdk::level::{Level, OverlappingLevel};
 use risingwave_hummock_sdk::vnode_partition::{
@@ -23,9 +27,20 @@ use risingwave_pb::hummock::LevelType;
 use crate::hummock::level_handler::LevelHandler;
 
 #[derive(Debug)]
-struct VnodePartition {
-    depth: u64,
-    l0: OverlappingLevel,
+pub(crate) struct VnodePartition {
+    pub(crate) index: usize,
+    /// Number of non-empty runnable non-overlapping sub-levels in this partition.
+    pub(crate) depth: u64,
+    /// Maximum number of runnable SST key ranges covering the same key.
+    pub(crate) max_overlap_depth: u64,
+    pub(crate) total_sst_ref_count: u64,
+    pub(crate) total_object_count: u64,
+    pub(crate) runnable_sst_ref_count: u64,
+    pub(crate) runnable_object_count: u64,
+    pub(crate) runnable_file_size: u64,
+    pub(crate) total_referenced_object_size: u64,
+    pub(crate) runnable_referenced_object_size: u64,
+    pub(crate) l0: OverlappingLevel,
 }
 
 /// A transient, fixed vnode-partition view of runnable L0 stack depth.
@@ -98,7 +113,8 @@ impl L0VnodePartitionView {
 
         let partitions = partition_levels
             .into_iter()
-            .map(|sub_levels| {
+            .enumerate()
+            .map(|(index, sub_levels)| {
                 // Empty sub-levels only contain SSTs from other disjoint vnode partitions. Drop
                 // them so the existing picker sees the same ordered L0 stack for this partition
                 // without being blocked by unrelated levels.
@@ -116,14 +132,53 @@ impl L0VnodePartitionView {
                                 .any(|sst| !l0_handler.is_pending_compact(&sst.sst_id))
                     })
                     .count() as u64;
+                let max_overlap_depth = max_runnable_overlap_depth(&sub_levels, l0_handler);
+                let total_sst_ref_count = sub_levels
+                    .iter()
+                    .map(|level| level.table_infos.len() as u64)
+                    .sum();
+                let total_object_count = sub_levels
+                    .iter()
+                    .flat_map(|level| level.table_infos.iter().map(|sst| sst.object_id))
+                    .collect::<HashSet<_>>()
+                    .len() as u64;
+                let runnable_ssts = sub_levels
+                    .iter()
+                    .filter(|level| level.level_type == LevelType::Nonoverlapping)
+                    .flat_map(|level| level.table_infos.iter())
+                    .filter(|sst| !l0_handler.is_pending_compact(&sst.sst_id))
+                    .collect::<Vec<_>>();
+                let runnable_sst_ref_count = runnable_ssts.len() as u64;
+                let runnable_object_count = runnable_ssts
+                    .iter()
+                    .map(|sst| sst.object_id)
+                    .collect::<HashSet<_>>()
+                    .len() as u64;
+                let runnable_file_size = runnable_ssts.iter().map(|sst| sst.sst_size).sum();
+                let runnable_referenced_object_size =
+                    runnable_ssts.iter().map(|sst| sst.file_size).sum();
                 let total_file_size = sub_levels.iter().map(|level| level.total_file_size).sum();
+                let total_referenced_object_size = sub_levels
+                    .iter()
+                    .flat_map(|level| level.table_infos.iter())
+                    .map(|sst| sst.file_size)
+                    .sum();
                 let uncompressed_file_size = sub_levels
                     .iter()
                     .map(|level| level.uncompressed_file_size)
                     .sum();
 
                 VnodePartition {
+                    index,
                     depth,
+                    max_overlap_depth,
+                    total_sst_ref_count,
+                    total_object_count,
+                    runnable_sst_ref_count,
+                    runnable_object_count,
+                    runnable_file_size,
+                    total_referenced_object_size,
+                    runnable_referenced_object_size,
                     l0: OverlappingLevel {
                         sub_levels,
                         total_file_size,
@@ -140,11 +195,11 @@ impl L0VnodePartitionView {
         self,
         min_level_count: u64,
         score_base: u64,
-    ) -> impl Iterator<Item = (u64, OverlappingLevel)> {
+    ) -> impl Iterator<Item = (u64, VnodePartition)> {
         let threshold = std::cmp::max(1, min_level_count);
         self.partitions
             .into_iter()
-            .map(move |partition| (partition.depth * score_base / threshold, partition.l0))
+            .map(move |partition| (partition.depth * score_base / threshold, partition))
     }
 
     #[cfg(test)]
@@ -153,6 +208,94 @@ impl L0VnodePartitionView {
             .iter()
             .map(|partition| partition.depth)
             .collect()
+    }
+
+    #[cfg(test)]
+    fn max_overlap_depths(&self) -> Vec<u64> {
+        self.partitions
+            .iter()
+            .map(|partition| partition.max_overlap_depth)
+            .collect()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum RangeEventKind {
+    ExclusiveEnd,
+    Start,
+    InclusiveEnd,
+}
+
+#[derive(Debug)]
+struct RangeEvent {
+    key: Bytes,
+    kind: RangeEventKind,
+    level_index: usize,
+}
+
+/// Point-overlap depth is observability only, not an admission or seed-discovery rule.
+fn max_runnable_overlap_depth(sub_levels: &[Level], l0_handler: &LevelHandler) -> u64 {
+    let mut events = vec![];
+    for (level_index, level) in sub_levels.iter().enumerate() {
+        if level.level_type != LevelType::Nonoverlapping {
+            continue;
+        }
+        for sst in &level.table_infos {
+            if l0_handler.is_pending_compact(&sst.sst_id) {
+                continue;
+            }
+            events.push(RangeEvent {
+                key: sst.key_range.left.clone(),
+                kind: RangeEventKind::Start,
+                level_index,
+            });
+            // An empty right boundary means positive infinity.
+            if !sst.key_range.right.is_empty() {
+                events.push(RangeEvent {
+                    key: sst.key_range.right.clone(),
+                    kind: if sst.key_range.right_exclusive {
+                        RangeEventKind::ExclusiveEnd
+                    } else {
+                        RangeEventKind::InclusiveEnd
+                    },
+                    level_index,
+                });
+            }
+        }
+    }
+    events.sort_unstable_by(|a, b| {
+        compare_boundary_keys(&a.key, &b.key).then_with(|| a.kind.cmp(&b.kind))
+    });
+
+    // Count active sub-levels, even if adjacent SST full-key boundaries share a user key.
+    let mut active = BTreeMap::<usize, usize>::new();
+    let mut max_depth = 0;
+    for event in events {
+        match event.kind {
+            RangeEventKind::Start => {
+                *active.entry(event.level_index).or_default() += 1;
+                max_depth = max_depth.max(active.len() as u64);
+            }
+            RangeEventKind::ExclusiveEnd | RangeEventKind::InclusiveEnd => {
+                let count = active.get_mut(&event.level_index).unwrap();
+                *count -= 1;
+                if *count == 0 {
+                    active.remove(&event.level_index);
+                }
+            }
+        }
+    }
+    max_depth
+}
+
+fn compare_boundary_keys(left: &[u8], right: &[u8]) -> std::cmp::Ordering {
+    match (left.is_empty(), right.is_empty()) {
+        (true, true) => std::cmp::Ordering::Equal,
+        (true, false) => std::cmp::Ordering::Less,
+        (false, true) => std::cmp::Ordering::Greater,
+        (false, false) => FullKey::decode(left)
+            .user_key
+            .cmp(&FullKey::decode(right).user_key),
     }
 }
 
@@ -188,9 +331,18 @@ mod tests {
     use super::*;
 
     fn sst(id: u64, left_vnode: usize, right_vnode: usize) -> SstableInfo {
+        sst_with_object(id, id, left_vnode, right_vnode)
+    }
+
+    fn sst_with_object(
+        id: u64,
+        object_id: u64,
+        left_vnode: usize,
+        right_vnode: usize,
+    ) -> SstableInfo {
         let table_id = TableId::new(1);
         SstableInfoInner {
-            object_id: id.into(),
+            object_id: object_id.into(),
             sst_id: id.into(),
             key_range: KeyRange {
                 left: vnode_boundary_full_key(table_id, left_vnode),
@@ -198,6 +350,7 @@ mod tests {
                 right_exclusive: true,
             },
             table_ids: vec![table_id],
+            file_size: 10,
             sst_size: 1,
             ..Default::default()
         }
@@ -237,6 +390,45 @@ mod tests {
             .unwrap();
 
         assert_eq!(view.depths()[0], 2);
+        assert_eq!(view.max_overlap_depths()[0], 1);
+    }
+
+    #[test]
+    fn max_overlap_depth_counts_actual_key_range_stack() {
+        let l0 = l0(vec![vec![sst(1, 0, 12)], vec![sst(2, 8, 16)]]);
+        let view = L0VnodePartitionView::build(TableId::new(1), 256, 8, &l0, &LevelHandler::new(0))
+            .unwrap();
+
+        assert_eq!(view.depths()[0], 2);
+        assert_eq!(view.max_overlap_depths()[0], 2);
+    }
+
+    #[test]
+    fn exclusive_adjacent_ranges_do_not_overlap() {
+        let l0 = l0(vec![vec![sst(1, 0, 8)], vec![sst(2, 8, 16)]]);
+        let view = L0VnodePartitionView::build(TableId::new(1), 256, 8, &l0, &LevelHandler::new(0))
+            .unwrap();
+
+        assert_eq!(view.depths()[0], 2);
+        assert_eq!(view.max_overlap_depths()[0], 1);
+    }
+
+    #[test]
+    fn logical_references_are_separate_from_objects() {
+        let l0 = l0(vec![
+            vec![sst_with_object(1, 100, 0, 8)],
+            vec![sst_with_object(2, 100, 8, 16)],
+        ]);
+        let view = L0VnodePartitionView::build(TableId::new(1), 256, 8, &l0, &LevelHandler::new(0))
+            .unwrap();
+
+        let partition = &view.partitions[0];
+        assert_eq!(partition.total_sst_ref_count, 2);
+        assert_eq!(partition.total_object_count, 1);
+        assert_eq!(partition.runnable_sst_ref_count, 2);
+        assert_eq!(partition.runnable_object_count, 1);
+        assert_eq!(partition.total_referenced_object_size, 20);
+        assert_eq!(partition.runnable_referenced_object_size, 20);
     }
 
     #[test]
@@ -247,6 +439,9 @@ mod tests {
         let view = L0VnodePartitionView::build(TableId::new(1), 256, 8, &l0, &handler).unwrap();
 
         assert_eq!(view.depths()[0], 3);
+        assert_eq!(view.max_overlap_depths()[0], 3);
+        assert_eq!(view.partitions[0].total_sst_ref_count, 4);
+        assert_eq!(view.partitions[0].runnable_sst_ref_count, 3);
     }
 
     #[test]

--- a/src/meta/src/hummock/compaction/vnode_partition.rs
+++ b/src/meta/src/hummock/compaction/vnode_partition.rs
@@ -1,0 +1,286 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::catalog::TableId;
+use risingwave_hummock_sdk::key_range::{KeyRange, KeyRangeCommon};
+use risingwave_hummock_sdk::level::{Level, OverlappingLevel};
+use risingwave_hummock_sdk::vnode_partition::{
+    build_vnode_partition_boundary_keys, vnode_boundary_full_key,
+};
+use risingwave_pb::hummock::LevelType;
+
+use crate::hummock::level_handler::LevelHandler;
+
+#[derive(Debug)]
+struct VnodePartition {
+    depth: u64,
+    l0: OverlappingLevel,
+}
+
+/// A transient, fixed vnode-partition view of runnable L0 stack depth.
+///
+/// Partition boundaries come from table metadata and compaction-group config, while depth is
+/// rebuilt from the current version and pending-file state for every selection. Empty vnode ranges
+/// therefore remain stable partitions with zero pressure.
+#[derive(Debug)]
+pub(crate) struct L0VnodePartitionView {
+    partitions: Vec<VnodePartition>,
+}
+
+impl L0VnodePartitionView {
+    pub(crate) fn build(
+        table_id: TableId,
+        vnode_count: usize,
+        partition_count: usize,
+        l0: &OverlappingLevel,
+        l0_handler: &LevelHandler,
+    ) -> Option<Self> {
+        if partition_count <= 1 || partition_count > vnode_count {
+            return None;
+        }
+
+        let partition_ranges = build_partition_ranges(table_id, vnode_count, partition_count);
+        let mut partition_levels = (0..partition_count)
+            .map(|_| {
+                l0.sub_levels
+                    .iter()
+                    .map(|level| Level {
+                        level_idx: level.level_idx,
+                        level_type: level.level_type,
+                        table_infos: vec![],
+                        total_file_size: 0,
+                        sub_level_id: level.sub_level_id,
+                        uncompressed_file_size: 0,
+                        vnode_partition_count: 0,
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        for (level_index, level) in l0.sub_levels.iter().enumerate() {
+            for sst in &level.table_infos {
+                if sst.table_ids.as_slice() != [table_id]
+                    || sst.key_range.left.is_empty()
+                    || sst.key_range.right.is_empty()
+                {
+                    return None;
+                }
+                let mut matching_partitions = partition_ranges
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, range)| range.sstable_overlap(&sst.key_range));
+                let (partition_index, _) = matching_partitions.next()?;
+
+                // A filtered L0 view is safe only when every SST belongs to exactly one fixed
+                // partition. Old or unaligned SSTs fall back to the unpartitioned selector until
+                // compaction replaces them.
+                if matching_partitions.next().is_some() {
+                    return None;
+                }
+
+                let partition_level = &mut partition_levels[partition_index][level_index];
+                partition_level.table_infos.push(sst.clone());
+                partition_level.total_file_size += sst.sst_size;
+                partition_level.uncompressed_file_size += sst.uncompressed_file_size;
+            }
+        }
+
+        let partitions = partition_levels
+            .into_iter()
+            .map(|sub_levels| {
+                // Empty sub-levels only contain SSTs from other disjoint vnode partitions. Drop
+                // them so the existing picker sees the same ordered L0 stack for this partition
+                // without being blocked by unrelated levels.
+                let sub_levels = sub_levels
+                    .into_iter()
+                    .filter(|level| !level.table_infos.is_empty())
+                    .collect::<Vec<_>>();
+                let depth = sub_levels
+                    .iter()
+                    .filter(|level| {
+                        level.level_type == LevelType::Nonoverlapping
+                            && level
+                                .table_infos
+                                .iter()
+                                .any(|sst| !l0_handler.is_pending_compact(&sst.sst_id))
+                    })
+                    .count() as u64;
+                let total_file_size = sub_levels.iter().map(|level| level.total_file_size).sum();
+                let uncompressed_file_size = sub_levels
+                    .iter()
+                    .map(|level| level.uncompressed_file_size)
+                    .sum();
+
+                VnodePartition {
+                    depth,
+                    l0: OverlappingLevel {
+                        sub_levels,
+                        total_file_size,
+                        uncompressed_file_size,
+                    },
+                }
+            })
+            .collect();
+
+        Some(Self { partitions })
+    }
+
+    pub(crate) fn into_partitions(
+        self,
+        min_level_count: u64,
+        score_base: u64,
+    ) -> impl Iterator<Item = (u64, OverlappingLevel)> {
+        let threshold = std::cmp::max(1, min_level_count);
+        self.partitions
+            .into_iter()
+            .map(move |partition| (partition.depth * score_base / threshold, partition.l0))
+    }
+
+    #[cfg(test)]
+    fn depths(&self) -> Vec<u64> {
+        self.partitions
+            .iter()
+            .map(|partition| partition.depth)
+            .collect()
+    }
+}
+
+fn build_partition_ranges(
+    table_id: TableId,
+    vnode_count: usize,
+    partition_count: usize,
+) -> Vec<KeyRange> {
+    let mut starts = Vec::with_capacity(partition_count);
+    starts.push(vnode_boundary_full_key(table_id, 0));
+    starts.extend(build_vnode_partition_boundary_keys(
+        table_id,
+        vnode_count,
+        partition_count,
+    ));
+
+    starts
+        .iter()
+        .enumerate()
+        .map(|(idx, left)| KeyRange {
+            left: left.clone(),
+            right: starts.get(idx + 1).cloned().unwrap_or_default(),
+            right_exclusive: true,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_hummock_sdk::level::Level;
+    use risingwave_hummock_sdk::sstable_info::{SstableInfo, SstableInfoInner};
+
+    use super::*;
+
+    fn sst(id: u64, left_vnode: usize, right_vnode: usize) -> SstableInfo {
+        let table_id = TableId::new(1);
+        SstableInfoInner {
+            object_id: id.into(),
+            sst_id: id.into(),
+            key_range: KeyRange {
+                left: vnode_boundary_full_key(table_id, left_vnode),
+                right: vnode_boundary_full_key(table_id, right_vnode),
+                right_exclusive: true,
+            },
+            table_ids: vec![table_id],
+            sst_size: 1,
+            ..Default::default()
+        }
+        .into()
+    }
+
+    fn l0(levels: Vec<Vec<SstableInfo>>) -> OverlappingLevel {
+        OverlappingLevel {
+            sub_levels: levels
+                .into_iter()
+                .enumerate()
+                .map(|(idx, table_infos)| Level {
+                    level_idx: 0,
+                    level_type: LevelType::Nonoverlapping,
+                    table_infos,
+                    sub_level_id: idx as u64,
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn sparse_writes_do_not_change_partition_layout() {
+        let l0 = l0((1..=4).map(|id| vec![sst(id, 0, 16)]).collect());
+        let view = L0VnodePartitionView::build(TableId::new(1), 256, 8, &l0, &LevelHandler::new(0))
+            .unwrap();
+
+        assert_eq!(view.depths(), vec![4, 0, 0, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn depth_counts_non_empty_sub_levels_in_the_partition() {
+        let l0 = l0(vec![vec![sst(1, 0, 4)], vec![sst(2, 8, 12)]]);
+        let view = L0VnodePartitionView::build(TableId::new(1), 256, 8, &l0, &LevelHandler::new(0))
+            .unwrap();
+
+        assert_eq!(view.depths()[0], 2);
+    }
+
+    #[test]
+    fn pending_ssts_are_removed_from_runnable_depth() {
+        let l0 = l0((1..=4).map(|id| vec![sst(id, 0, 16)]).collect());
+        let mut handler = LevelHandler::new(0);
+        handler.add_pending_task(10, 1, &l0.sub_levels[0].table_infos);
+        let view = L0VnodePartitionView::build(TableId::new(1), 256, 8, &l0, &handler).unwrap();
+
+        assert_eq!(view.depths()[0], 3);
+    }
+
+    #[test]
+    fn unrelated_sub_levels_are_removed_from_the_partition_view() {
+        let mut l0 = l0(vec![
+            vec![sst(1, 0, 16)],
+            vec![sst(2, 32, 48)],
+            vec![sst(3, 0, 16)],
+        ]);
+        l0.sub_levels[1].level_type = LevelType::Overlapping;
+        let view = L0VnodePartitionView::build(TableId::new(1), 256, 8, &l0, &LevelHandler::new(0))
+            .unwrap();
+
+        assert_eq!(view.partitions[0].l0.sub_levels.len(), 2);
+        assert!(
+            view.partitions[0]
+                .l0
+                .sub_levels
+                .iter()
+                .all(|level| level.level_type == LevelType::Nonoverlapping)
+        );
+        assert_eq!(view.partitions[1].l0.sub_levels.len(), 1);
+        assert_eq!(
+            view.partitions[1].l0.sub_levels[0].level_type,
+            LevelType::Overlapping
+        );
+    }
+
+    #[test]
+    fn unaligned_sst_disables_the_partition_view() {
+        let l0 = l0(vec![vec![sst(1, 0, 64)]]);
+        assert!(
+            L0VnodePartitionView::build(TableId::new(1), 256, 8, &l0, &LevelHandler::new(0),)
+                .is_none()
+        );
+    }
+}

--- a/src/meta/src/hummock/manager/compaction/mod.rs
+++ b/src/meta/src/hummock/manager/compaction/mod.rs
@@ -29,6 +29,7 @@ use rand::rng as thread_rng;
 use rand::seq::SliceRandom;
 use risingwave_common::catalog::TableId;
 use risingwave_common::config::meta::default::compaction_config;
+use risingwave_common::hash::VnodeCountCompat;
 use risingwave_common::util::epoch::Epoch;
 use risingwave_hummock_sdk::compact_task::{CompactTask, CompactTaskAssignment, ReportTask};
 use risingwave_hummock_sdk::compaction_group::StateTableId;
@@ -62,8 +63,8 @@ use crate::hummock::compaction::in_progress_compaction::InProgressCompactionView
 use crate::hummock::compaction::selector::level_selector::PickerInfo;
 use crate::hummock::compaction::selector::{
     DynamicLevelSelector, DynamicLevelSelectorCore, LocalSelectorStatistic, ManualCompactionOption,
-    ManualCompactionSelector, SpaceReclaimCompactionSelector, TombstoneCompactionSelector,
-    TtlCompactionSelector, VnodeWatermarkCompactionSelector,
+    ManualCompactionSelector, SingleTableCompactionGroup, SpaceReclaimCompactionSelector,
+    TombstoneCompactionSelector, TtlCompactionSelector, VnodeWatermarkCompactionSelector,
 };
 use crate::hummock::compaction::{
     CompactStatus, CompactionDeveloperConfig, CompactionSelector,
@@ -345,6 +346,83 @@ impl HummockManager {
             .await
     }
 
+    async fn prefetch_compaction_table_vnode_counts(
+        &self,
+        compaction_groups: &[CompactionGroupId],
+    ) {
+        let single_table_groups = {
+            let versioning = self
+                .versioning
+                .read_with_process_name("prefetch_compaction_table_vnode_counts")
+                .await;
+            compaction_groups
+                .iter()
+                .filter_map(|group_id| {
+                    let members = versioning
+                        .current_version
+                        .state_table_info
+                        .compaction_group_member_table_ids(*group_id);
+                    (members.len() == 1)
+                        .then(|| (*group_id, *members.iter().next().expect("len==1")))
+                })
+                .collect_vec()
+        };
+
+        let missing_groups = {
+            let cache = self.table_id_to_vnode_count.read();
+            single_table_groups
+                .into_iter()
+                .filter(|(_, table_id)| !cache.contains_key(table_id))
+                .collect_vec()
+        };
+        if missing_groups.is_empty() {
+            return;
+        }
+
+        let missing_table_ids = {
+            let config_manager = self
+                .compaction_group_manager
+                .read_with_process_name("prefetch_compaction_table_vnode_counts")
+                .await;
+            missing_groups
+                .into_iter()
+                .filter_map(|(group_id, table_id)| {
+                    config_manager
+                        .try_get_compaction_group_config(group_id)
+                        .is_some_and(|group| group.compaction_config.split_weight_by_vnode > 1)
+                        .then_some(table_id)
+                })
+                .collect_vec()
+        };
+        if missing_table_ids.is_empty() {
+            return;
+        }
+
+        match self
+            .metadata_manager
+            .get_table_catalog_by_ids(&missing_table_ids)
+            .await
+        {
+            Ok(tables) => {
+                let mut cache = self.table_id_to_vnode_count.write();
+                for table in tables {
+                    // A creating table may still carry the catalog placeholder `Some(0)`.
+                    if table.maybe_vnode_count == Some(0) {
+                        continue;
+                    }
+                    cache.insert(table.id, table.vnode_count());
+                }
+            }
+            Err(error) => {
+                warn!(
+                    error = %error.as_report(),
+                    ?missing_table_ids,
+                    "Failed to prefetch table vnode counts for compaction",
+                );
+            }
+        }
+    }
+
     pub async fn get_compact_tasks_impl(
         &self,
         compaction_groups: Vec<CompactionGroupId>,
@@ -352,6 +430,13 @@ impl HummockManager {
         selector: &mut dyn CompactionSelector,
     ) -> Result<(Vec<CompactTask>, Vec<CompactionGroupId>)> {
         let deterministic_mode = self.env.opts.compaction_deterministic_test;
+
+        // Do catalog I/O before taking the compaction/versioning write locks. Membership is
+        // revalidated below before a cached vnode count is passed to the selector.
+        if selector.task_type() == TaskType::Dynamic {
+            self.prefetch_compaction_table_vnode_counts(&compaction_groups)
+                .await;
+        }
 
         let mut compaction_guard = self
             .compaction
@@ -479,6 +564,18 @@ impl HummockManager {
                 compact_task_assignment.tree_ref().values(),
                 compaction_group_id,
             );
+            let single_table_compaction_group =
+                if group_config.compaction_config.split_weight_by_vnode > 1
+                    && let [table_id] = member_table_ids.as_slice()
+                {
+                    self.table_id_to_vnode_count
+                        .read()
+                        .get(table_id)
+                        .copied()
+                        .map(|vnode_count| SingleTableCompactionGroup::new(*table_id, vnode_count))
+                } else {
+                    None
+                };
 
             while let Some(picked_task) = compact_status.get_compact_task(
                 version
@@ -488,6 +585,7 @@ impl HummockManager {
                     .latest_version()
                     .state_table_info
                     .compaction_group_member_table_ids(compaction_group_id),
+                single_table_compaction_group,
                 task_id as HummockCompactionTaskId,
                 &group_config,
                 &mut stats,

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -3222,6 +3222,15 @@ async fn test_old_version_dropped_table_sst_does_not_make_new_compaction_fail() 
         .sum();
     group.l0.sub_levels = dirty_l0_sub_levels;
 
+    // Keep this as a physical compaction test after small L0 SSTs become eligible for trivial
+    // move. An overlapping base SST prevents Meta from consuming every L0 SST as metadata-only
+    // moves before the test can inspect a compactor task.
+    let base_sst = gen_sstable_info(14, vec![live_table_id.as_raw_id()], test_epoch(1));
+    let base_level = group.levels.last_mut().unwrap();
+    base_level.total_file_size = base_sst.sst_size;
+    base_level.uncompressed_file_size = base_sst.uncompressed_file_size;
+    base_level.table_infos = vec![base_sst];
+
     // Simulate the upgrade path:
     // 1. an old version wrote SST metadata containing table ids [live, dropped];
     // 2. the old version dropped one table, but the checkpoint still had stale SST table ids;

--- a/src/meta/src/hummock/metrics_utils.rs
+++ b/src/meta/src/hummock/metrics_utils.rs
@@ -798,6 +798,26 @@ fn remove_compact_task_metrics(metrics: &MetaMetrics, group_label: &str) {
         COMPACTION_GROUP_LABEL_NAME,
         group_label,
     );
+    remove_metric_series_with_label(
+        &metrics.partition_l0_compaction_total,
+        COMPACTION_GROUP_LABEL_NAME,
+        group_label,
+    );
+    remove_metric_series_with_label(
+        &metrics.partition_l0_compaction_bytes,
+        COMPACTION_GROUP_LABEL_NAME,
+        group_label,
+    );
+    remove_metric_series_with_label(
+        &metrics.partition_l0_compaction_count,
+        COMPACTION_GROUP_LABEL_NAME,
+        group_label,
+    );
+    remove_metric_series_with_label(
+        &metrics.partition_l0_compaction_score,
+        COMPACTION_GROUP_LABEL_NAME,
+        group_label,
+    );
 }
 
 pub fn trigger_compact_tasks_stat(

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -424,6 +424,7 @@ pub fn compaction_selector_context<'a>(
         group,
         levels,
         member_table_ids,
+        single_table_compaction_group: None,
         level_handlers,
         selector_stats,
         table_id_to_options,

--- a/src/meta/src/rpc/metrics.rs
+++ b/src/meta/src/rpc/metrics.rs
@@ -193,6 +193,10 @@ pub struct MetaMetrics {
     pub compact_task_size: HistogramVec,
     pub compact_task_file_count: HistogramVec,
     pub compact_task_batch_count: HistogramVec,
+    pub partition_l0_compaction_total: IntCounterVec,
+    pub partition_l0_compaction_bytes: HistogramVec,
+    pub partition_l0_compaction_count: HistogramVec,
+    pub partition_l0_compaction_score: HistogramVec,
     pub split_compaction_group_count: IntCounterVec,
     pub state_table_count: IntGaugeVec,
     pub branched_sst_count: IntGaugeVec,
@@ -871,6 +875,35 @@ impl MetaMetrics {
         let compact_task_batch_count =
             register_histogram_vec_with_registry!(opts, &["type"], registry).unwrap();
 
+        let partition_l0_compaction_total = register_int_counter_vec_with_registry!(
+            "storage_partition_l0_compaction_total",
+            "Number of partition-aware L0 picker observations.",
+            &["group", "picker", "outcome"],
+            registry
+        )
+        .unwrap();
+        let opts = histogram_opts!(
+            "storage_partition_l0_compaction_bytes",
+            "Range-local bytes observed by the partition-aware L0 picker.",
+            exponential_buckets(1048576.0, 2.0, 16).unwrap()
+        );
+        let partition_l0_compaction_bytes =
+            register_histogram_vec_with_registry!(opts, &["group", "kind"], registry).unwrap();
+        let opts = histogram_opts!(
+            "storage_partition_l0_compaction_count",
+            "Counts observed by the partition-aware L0 picker.",
+            exponential_buckets(1.0, 2.0, 12).unwrap()
+        );
+        let partition_l0_compaction_count =
+            register_histogram_vec_with_registry!(opts, &["group", "kind"], registry).unwrap();
+        let opts = histogram_opts!(
+            "storage_partition_l0_compaction_score",
+            "Scores multiplied by 100 as observed by the partition-aware L0 picker.",
+            exponential_buckets(25.0, 2.0, 16).unwrap()
+        );
+        let partition_l0_compaction_score =
+            register_histogram_vec_with_registry!(opts, &["group", "kind"], registry).unwrap();
+
         let table_write_throughput = register_int_counter_vec_with_registry!(
             "storage_commit_write_throughput",
             "The number of compactions from one level to another level that have been skipped.",
@@ -1076,6 +1109,10 @@ impl MetaMetrics {
             compact_task_size,
             compact_task_file_count,
             compact_task_batch_count,
+            partition_l0_compaction_total,
+            partition_l0_compaction_bytes,
+            partition_l0_compaction_count,
+            partition_l0_compaction_score,
             compact_task_trivial_move_sst_count,
             table_write_throughput,
             split_compaction_group_count,

--- a/src/risedevtool/config/src/main.rs
+++ b/src/risedevtool/config/src/main.rs
@@ -74,7 +74,7 @@ pub enum Components {
     NoBacktrace,
     Udf,
     NoDefaultFeatures,
-    NoHeavySinks,
+    NoHeavyConnectors,
     Moat,
     DataFusion,
     Adbc,
@@ -101,7 +101,7 @@ impl Components {
             Self::NoBacktrace => "[Runtime] Disable backtrace",
             Self::Udf => "[Build] Enable UDF",
             Self::NoDefaultFeatures => "[Build] Disable default features",
-            Self::NoHeavySinks => "[Build] Disable heavyweight sinks",
+            Self::NoHeavyConnectors => "[Build] Disable heavyweight connectors",
             Self::Moat => "[Component] Enable Moat",
             Self::DataFusion => "[Build] Enable DataFusion",
             Self::Adbc => "[Component] ADBC Snowflake Driver",
@@ -214,9 +214,9 @@ Add --no-default-features to build command.
 Currently, default features are: rw-static-link, all-connectors
 "
             }
-            Self::NoHeavySinks => {
+            Self::NoHeavyConnectors => {
                 "
-Exclude heavyweight sinks, such as LanceDB, to reduce build size.
+Exclude heavyweight connectors, such as LanceDB, to reduce build size.
 Other default connectors remain enabled unless default features are disabled."
             }
             Self::Moat => {
@@ -257,7 +257,7 @@ This will download the ADBC Snowflake driver shared library (.so/.dylib)."
             "DISABLE_BACKTRACE" => Some(Self::NoBacktrace),
             "ENABLE_UDF" => Some(Self::Udf),
             "DISABLE_DEFAULT_FEATURES" => Some(Self::NoDefaultFeatures),
-            "DISABLE_HEAVY_SINKS" => Some(Self::NoHeavySinks),
+            "DISABLE_HEAVY_CONNECTORS" => Some(Self::NoHeavyConnectors),
             "ENABLE_MOAT" => Some(Self::Moat),
             "ENABLE_DATAFUSION" => Some(Self::DataFusion),
             "ENABLE_ADBC" => Some(Self::Adbc),
@@ -285,7 +285,7 @@ This will download the ADBC Snowflake driver shared library (.so/.dylib)."
             Self::NoBacktrace => "DISABLE_BACKTRACE",
             Self::Udf => "ENABLE_UDF",
             Self::NoDefaultFeatures => "DISABLE_DEFAULT_FEATURES",
-            Self::NoHeavySinks => "DISABLE_HEAVY_SINKS",
+            Self::NoHeavyConnectors => "DISABLE_HEAVY_CONNECTORS",
             Self::Moat => "ENABLE_MOAT",
             Self::DataFusion => "ENABLE_DATAFUSION",
             Self::Adbc => "ENABLE_ADBC",
@@ -294,7 +294,7 @@ This will download the ADBC Snowflake driver shared library (.so/.dylib)."
     }
 
     pub fn default_enabled() -> &'static [Self] {
-        &[Self::RustComponents, Self::NoHeavySinks]
+        &[Self::RustComponents, Self::NoHeavyConnectors]
     }
 }
 

--- a/src/risedevtool/config/src/main.rs
+++ b/src/risedevtool/config/src/main.rs
@@ -74,7 +74,7 @@ pub enum Components {
     NoBacktrace,
     Udf,
     NoDefaultFeatures,
-    NoLanceDbSink,
+    NoHeavySinks,
     Moat,
     DataFusion,
     Adbc,
@@ -101,7 +101,7 @@ impl Components {
             Self::NoBacktrace => "[Runtime] Disable backtrace",
             Self::Udf => "[Build] Enable UDF",
             Self::NoDefaultFeatures => "[Build] Disable default features",
-            Self::NoLanceDbSink => "[Build] Disable LanceDB sink",
+            Self::NoHeavySinks => "[Build] Disable heavyweight sinks",
             Self::Moat => "[Component] Enable Moat",
             Self::DataFusion => "[Build] Enable DataFusion",
             Self::Adbc => "[Component] ADBC Snowflake Driver",
@@ -214,9 +214,9 @@ Add --no-default-features to build command.
 Currently, default features are: rw-static-link, all-connectors
 "
             }
-            Self::NoLanceDbSink => {
+            Self::NoHeavySinks => {
                 "
-Exclude the LanceDB sink from default connectors to reduce build size.
+Exclude heavyweight sinks, such as LanceDB, to reduce build size.
 Other default connectors remain enabled unless default features are disabled."
             }
             Self::Moat => {
@@ -257,7 +257,7 @@ This will download the ADBC Snowflake driver shared library (.so/.dylib)."
             "DISABLE_BACKTRACE" => Some(Self::NoBacktrace),
             "ENABLE_UDF" => Some(Self::Udf),
             "DISABLE_DEFAULT_FEATURES" => Some(Self::NoDefaultFeatures),
-            "DISABLE_LANCEDB_SINK" => Some(Self::NoLanceDbSink),
+            "DISABLE_HEAVY_SINKS" => Some(Self::NoHeavySinks),
             "ENABLE_MOAT" => Some(Self::Moat),
             "ENABLE_DATAFUSION" => Some(Self::DataFusion),
             "ENABLE_ADBC" => Some(Self::Adbc),
@@ -285,7 +285,7 @@ This will download the ADBC Snowflake driver shared library (.so/.dylib)."
             Self::NoBacktrace => "DISABLE_BACKTRACE",
             Self::Udf => "ENABLE_UDF",
             Self::NoDefaultFeatures => "DISABLE_DEFAULT_FEATURES",
-            Self::NoLanceDbSink => "DISABLE_LANCEDB_SINK",
+            Self::NoHeavySinks => "DISABLE_HEAVY_SINKS",
             Self::Moat => "ENABLE_MOAT",
             Self::DataFusion => "ENABLE_DATAFUSION",
             Self::Adbc => "ENABLE_ADBC",
@@ -294,7 +294,7 @@ This will download the ADBC Snowflake driver shared library (.so/.dylib)."
     }
 
     pub fn default_enabled() -> &'static [Self] {
-        &[Self::RustComponents]
+        &[Self::RustComponents, Self::NoHeavySinks]
     }
 }
 

--- a/src/risedevtool/config/src/main.rs
+++ b/src/risedevtool/config/src/main.rs
@@ -74,6 +74,7 @@ pub enum Components {
     NoBacktrace,
     Udf,
     NoDefaultFeatures,
+    NoLanceDbSink,
     Moat,
     DataFusion,
     Adbc,
@@ -100,6 +101,7 @@ impl Components {
             Self::NoBacktrace => "[Runtime] Disable backtrace",
             Self::Udf => "[Build] Enable UDF",
             Self::NoDefaultFeatures => "[Build] Disable default features",
+            Self::NoLanceDbSink => "[Build] Disable LanceDB sink",
             Self::Moat => "[Component] Enable Moat",
             Self::DataFusion => "[Build] Enable DataFusion",
             Self::Adbc => "[Component] ADBC Snowflake Driver",
@@ -212,6 +214,11 @@ Add --no-default-features to build command.
 Currently, default features are: rw-static-link, all-connectors
 "
             }
+            Self::NoLanceDbSink => {
+                "
+Exclude the LanceDB sink from default connectors to reduce build size.
+Other default connectors remain enabled unless default features are disabled."
+            }
             Self::Moat => {
                 "
 Enable Moat as distributed hybrid cache service."
@@ -250,6 +257,7 @@ This will download the ADBC Snowflake driver shared library (.so/.dylib)."
             "DISABLE_BACKTRACE" => Some(Self::NoBacktrace),
             "ENABLE_UDF" => Some(Self::Udf),
             "DISABLE_DEFAULT_FEATURES" => Some(Self::NoDefaultFeatures),
+            "DISABLE_LANCEDB_SINK" => Some(Self::NoLanceDbSink),
             "ENABLE_MOAT" => Some(Self::Moat),
             "ENABLE_DATAFUSION" => Some(Self::DataFusion),
             "ENABLE_ADBC" => Some(Self::Adbc),
@@ -277,6 +285,7 @@ This will download the ADBC Snowflake driver shared library (.so/.dylib)."
             Self::NoBacktrace => "DISABLE_BACKTRACE",
             Self::Udf => "ENABLE_UDF",
             Self::NoDefaultFeatures => "DISABLE_DEFAULT_FEATURES",
+            Self::NoLanceDbSink => "DISABLE_LANCEDB_SINK",
             Self::Moat => "ENABLE_MOAT",
             Self::DataFusion => "ENABLE_DATAFUSION",
             Self::Adbc => "ENABLE_ADBC",

--- a/src/storage/src/hummock/compactor/iterator.rs
+++ b/src/storage/src/hummock/compactor/iterator.rs
@@ -199,6 +199,14 @@ impl SstableStreamIterator {
         }
 
         self.prune_from_valid_block_iter().await?;
+        // A physical block may contain keys beyond this logical SST's range.
+        if self
+            .block_iter
+            .as_ref()
+            .is_some_and(|iter| self.exceed_key_range_right(iter.key()))
+        {
+            self.block_iter = None;
+        }
         Ok(())
     }
 
@@ -731,6 +739,7 @@ pub(crate) fn filter_block_metas(
 mod tests {
     use std::cmp::Ordering;
     use std::collections::HashSet;
+    use std::sync::Arc;
 
     use risingwave_common::catalog::TableId;
     use risingwave_common::util::epoch::test_epoch;
@@ -740,6 +749,8 @@ mod tests {
 
     use crate::hummock::BlockMeta;
     use crate::hummock::compactor::ConcatSstableIterator;
+    use crate::hummock::compactor::iterator::SstableStreamIterator;
+    use crate::hummock::compactor::task_progress::TaskProgress;
     use crate::hummock::iterator::test_utils::mock_sstable_store;
     use crate::hummock::iterator::{HummockIterator, MergeIterator};
     use crate::hummock::test_utils::{
@@ -747,6 +758,58 @@ mod tests {
         gen_test_sstable_with_table_ids, test_key_of, test_value_of,
     };
     use crate::hummock::value::HummockValue;
+    use crate::monitor::StoreLocalStatistic;
+
+    #[tokio::test]
+    async fn test_stream_iterator_seek_respects_logical_right() {
+        let sstable_store = mock_sstable_store().await;
+        let cases = [
+            (vec![10, 30], 20, true, 30, false),
+            (vec![10, 30], 15, true, 30, false),
+            (vec![10, 20, 30], 20, true, 20, false),
+            (vec![10, 20, 30], 20, false, 20, true),
+        ];
+        for (object_id, (keys, seek, right_exclusive, landing, logical_valid)) in
+            cases.into_iter().enumerate()
+        {
+            let physical = gen_test_sstable_info(
+                default_builder_opt_for_test(),
+                object_id as u64,
+                keys.into_iter()
+                    .map(|i| (test_key_of(i), HummockValue::put(test_value_of(i)))),
+                sstable_store.clone(),
+            )
+            .await;
+            let mut logical = physical.get_inner();
+            logical.sst_id = (100 + object_id as u64).into();
+            logical.key_range.right = test_key_of(20).encode().into();
+            logical.key_range.right_exclusive = right_exclusive;
+
+            // Verify the actual physical landing key first, including seek < right with
+            // no remaining logical key. Both iterators read the same single physical block.
+            for (info, expected_valid) in [(physical, true), (logical.into(), logical_valid)] {
+                let mut stats = StoreLocalStatistic::default();
+                let sstable = sstable_store.sstable(&info, &mut stats).await.unwrap();
+                assert_eq!(sstable.meta.block_metas.len(), 1);
+                let progress = Arc::new(TaskProgress::default());
+                progress.inc_num_pending_read_io();
+                let mut iter = SstableStreamIterator::new(
+                    sstable,
+                    0..1,
+                    info,
+                    &stats,
+                    progress,
+                    sstable_store.clone(),
+                    0,
+                );
+                iter.seek(Some(test_key_of(seek).to_ref())).await.unwrap();
+                assert_eq!(iter.is_valid(), expected_valid, "case {object_id}");
+                if expected_valid {
+                    assert_eq!(iter.key(), test_key_of(landing).to_ref());
+                }
+            }
+        }
+    }
 
     #[tokio::test]
     async fn test_concat_iterator() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What changed and what is the intention?

This is stack 3/3 and depends on #26997, which in turn depends on #26996. Its base branch is the head branch of #26997, so this PR contains only the partition-aware picker layer.

- Enable the new strategy only for a compaction group containing exactly one table with `split_weight_by_vnode > 1` and a known table vnode count.
- Rebuild a transient fixed-partition L0 view from the current version and pending-file state for every selection. Sparse or unwritten vnode ranges remain stable empty partitions.
- Admit partitions by runnable non-overlapping L0 depth divided by `level0_sub_level_compact_level_count`.
- Rank the new strategy with adjacent-level pressure: each source fill is divided by the effective output-level fill, including pending incoming and outgoing bytes. L0 must pass the adjusted score; positive levels remain admitted by their own fill so downstream draining cannot be disabled by a full output level.
- Try ToBase for eligible partitions in descending local pressure order. Only after all eligible ToBase candidates are blocked does selection fall back to partition-local Intra compaction.
- Grow a valid ToBase task with additional partition-local L0 closures only when the exact Base SST set is unchanged and existing byte, file-count, and level-count limits remain satisfied.
- Decouple partition ToBase candidate ordering from `sub_level_max_compaction_bytes`; that legacy knob continues to size Intra and Tier work but no longer silently changes the new ToBase seed.
- Remove the write-amplification validator and small-file trivial-move minimum from the new single-table path. The picker retains a defensive minimum-level check.
- Fall back to the existing global selector when an old or unaligned SST cannot be represented by the fixed vnode layout. Non-single-table compaction groups continue to use the existing scoring and picker path.

The score and target-aware growth are separate commits so their behavior remains reviewable independently.
\n- Fix compactor stream iteration after seek so a logical vnode-split SST cannot expose a key beyond its right boundary in the shared physical object.\n\n## Validation\n
- `cargo test -p risingwave_meta -- --test-threads=1` (480 unit tests and 5 doc tests passed)
- Focused selector and Base-picker suites passed.

A new 8 GiB import comparison has not been run for these two follow-up changes yet.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the release timeline and supported versions for cherry-picks.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Not applicable. This draft tracks an internal Hummock compaction-policy experiment.

</details>