### PR TITLE
fix(frontend): reject unsupported temporal join types instead of panicking

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
@@ -55,6 +55,20 @@
     select id1, a1, id2, a2 from stream right join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2 where a2 < 10;
   expected_outputs:
   - stream_error
+- name: Temporal join with an unsupported join type
+  sql: |
+    create table stream(id1 int, a1 int, b1 int);
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    select id1, a1, id2, a2 from stream full join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
+  expected_outputs:
+  - stream_error
+- name: Temporal join with a semi join type
+  sql: |
+    create table stream(id1 int, a1 int, b1 int);
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    select id1, a1 from stream where id1 in (select id2 from version FOR SYSTEM_TIME AS OF PROCTIME());
+  expected_outputs:
+  - stream_error
 - name: multi-way temporal join with the same key
   sql: |
     create table stream(k int, a1 int, b1 int);

--- a/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
@@ -100,6 +100,22 @@
   stream_error: |-
     Not supported: exist dangling temporal scan
     HINT: please check your temporal join syntax e.g. consider removing the right outer join if it is being used.
+- name: Temporal join with an unsupported join type
+  sql: |
+    create table stream(id1 int, a1 int, b1 int);
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    select id1, a1, id2, a2 from stream full join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
+  stream_error: |-
+    Not supported: temporal join with FullOuter join type
+    HINT: Temporal join only supports inner join and left outer join
+- name: Temporal join with a semi join type
+  sql: |
+    create table stream(id1 int, a1 int, b1 int);
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    select id1, a1 from stream where id1 in (select id2 from version FOR SYSTEM_TIME AS OF PROCTIME());
+  stream_error: |-
+    Not supported: temporal join with LeftSemi join type
+    HINT: Temporal join only supports inner join and left outer join
 - name: multi-way temporal join with the same key
   sql: |
     create table stream(k int, a1 int, b1 int);

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -1112,6 +1112,12 @@ impl LogicalJoin {
         ctx: &ToStreamContext,
     ) -> Result<Option<TemporalJoinScan<'a>>> {
         Ok(if let Some(scan) = self.temporal_join_on() {
+            if !matches!(self.join_type(), JoinType::Inner | JoinType::LeftOuter) {
+                return Err(RwError::from(ErrorCode::NotSupported(
+                    format!("temporal join with {:?} join type", self.join_type()),
+                    "Temporal join only supports inner join and left outer join".into(),
+                )));
+            }
             if ctx.backfill_type().is_snapshot_backfill() {
                 return Err(RwError::from(ErrorCode::NotSupported(
                     "Temporal join with snapshot backfill not supported".into(),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

A temporal join whose join type is neither inner nor left outer panics the frontend during planning:

```sql
create table stream(id1 int, a1 int, b1 int);
create table version(id2 int, a2 int, b2 int, primary key (id2));
create materialized view mv as
select id1, a1, id2, a2 from stream full join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
```

```
panicked at src/frontend/src/optimizer/plan_node/stream_temporal_join.rs:52:9:
assertion failed: core.join_type == JoinType::Inner || core.join_type == JoinType::LeftOuter
```

Why it is reachable:

- `should_be_stream_temporal_join` decides whether to plan a temporal join by looking only at the lookup side, so a join of any type enters that path.
- Inner and left outer are the only types either temporal join executor implements, but the restriction existed solely as a raw assertion inside `StreamTemporalJoin::new`, at the end of the path.
- Right outer escapes by accident. `JoinCommuteRule` rewrites it to left outer with the inputs swapped, which moves the temporal scan to the left input and ends at the existing `exist dangling temporal scan` error. Full outer commutes to itself, so it keeps the temporal scan on the right and reaches the assertion. Semi and anti joins derived from `IN` / `EXISTS` subqueries reach it as well.

This PR rejects the unsupported types at the same gate that already rejects snapshot backfill and cross-database lookups:

```
Not supported: temporal join with FullOuter join type
HINT: Temporal join only supports inner join and left outer join
```

The assertion in `StreamTemporalJoin::new` is left in place. With the gate above it, it is an internal invariant again rather than a user-reachable panic.

Planner test cases are added for both the full outer and the semi variant. Both panicked before this change.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Temporal joins now correctly reject unsupported join types, including full outer and semi joins.
  - Clear error messages explain that only inner and left outer temporal joins are supported.
  - Added coverage to verify the expected errors for unsupported temporal join queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->