### PR TITLE
fix(meta): try L0-to-base before intra-L0 compaction

### DIFF
--- a/src/meta/src/hummock/compaction/selector/level_selector.rs
+++ b/src/meta/src/hummock/compaction/selector/level_selector.rs
@@ -295,8 +295,10 @@ impl DynamicLevelSelectorCore {
             let non_overlapping_score =
                 std::cmp::max(non_overlapping_size_score, non_overlapping_level_score);
 
-            // Reduce the level num of l0 non-overlapping sub_level
-            if non_overlapping_size_score > SCORE_BASE {
+            // Always try L0-to-base before falling back to intra-L0 compaction. The base picker
+            // checks every candidate interval, so a depth-triggered L0 may still find a runnable
+            // range even when its total size is below the base-level size threshold.
+            if non_overlapping_score > SCORE_BASE {
                 ctx.score_levels.push(PickerInfo {
                     score: non_overlapping_score + 1,
                     select_level: 0,
@@ -769,6 +771,72 @@ pub mod tests {
             ),
         );
         assert!(compaction.is_none());
+    }
+
+    fn depth_triggered_l0_levels() -> (CompactionGroup, Levels) {
+        let config = CompactionConfigBuilder::new()
+            .max_bytes_for_level_base(1000)
+            .max_level(1)
+            .max_compaction_bytes(10000)
+            .sub_level_max_compaction_bytes(1000)
+            .level0_sub_level_compact_level_count(3)
+            .compaction_mode(CompactionMode::Range as i32)
+            .build();
+        let levels = Levels {
+            levels: vec![generate_level(1, vec![generate_table(100, 1, 0, 99, 1)])],
+            l0: generate_l0_nonoverlapping_sublevels(
+                (0..4)
+                    .map(|id| generate_table(id, 1, 0, 99, id + 2))
+                    .collect(),
+            ),
+            ..Default::default()
+        };
+        (CompactionGroup::new(1, config), levels)
+    }
+
+    #[test]
+    fn depth_trigger_tries_to_base_before_intra_l0() {
+        let (group, levels) = depth_triggered_l0_levels();
+        let mut selector = DynamicLevelSelector::default();
+        let mut handlers = (0..=1).map(LevelHandler::new).collect_vec();
+        let mut stats = LocalSelectorStatistic::default();
+
+        let compaction = pick_compaction_with_in_progress(
+            &mut selector,
+            1,
+            &group,
+            &levels,
+            &mut handlers,
+            &mut stats,
+            &InProgressCompactionView::default(),
+        )
+        .unwrap();
+
+        assert_eq!(compaction.input.target_level, 1);
+    }
+
+    #[test]
+    fn depth_trigger_falls_back_to_intra_l0_after_base_candidates_fail() {
+        let (group, levels) = depth_triggered_l0_levels();
+        let mut selector = DynamicLevelSelector::default();
+        let mut handlers = (0..=1).map(LevelHandler::new).collect_vec();
+        handlers[1].add_pending_task(100, 1, &levels.levels[0].table_infos);
+        let mut stats = LocalSelectorStatistic::default();
+
+        let compaction = pick_compaction_with_in_progress(
+            &mut selector,
+            1,
+            &group,
+            &levels,
+            &mut handlers,
+            &mut stats,
+            &InProgressCompactionView::default(),
+        )
+        .unwrap();
+
+        assert_eq!(compaction.input.target_level, 0);
+        assert_eq!(stats.skip_picker.len(), 1);
+        assert!(stats.skip_picker[0].2.skip_by_pending_files > 0);
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

When non-overlapping L0 is triggered by sub-level depth but not by total size, the dynamic selector currently schedules only intra-L0 compaction. This can rewrite L0 even when an L0-to-base interval is available.

This PR admits L0-to-base whenever either the size score or the depth score triggers, and gives it priority over intra-L0. The existing base picker still validates candidate intervals; if all base candidates are blocked or rejected, selection falls back to intra-L0.

Two regression tests cover:

- choosing L0-to-base before intra-L0 for a depth-triggered L0;
- falling back to intra-L0 when the base-level candidate is pending.

This is a draft while performance validation is in progress. In a matched local 8 GiB ingestion test, the change reduced small L0-to-L0 tasks, but total write amplification increased by 4.4%. A Docker image and Nexmark runs will be used to evaluate the end-to-end tradeoff before marking the PR ready.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [x] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

</details>
