### PR TITLE
chore(tests): add explicit reasons to ignored tests

### DIFF
--- a/src/common/rate_limit/src/lib.rs
+++ b/src/common/rate_limit/src/lib.rs
@@ -495,7 +495,7 @@ mod tests {
     /// ```bash
     /// cargo test --package risingwave_common_rate_limit --lib -- tests::test_leak_bucket --exact --show-output --ignored
     /// ```
-    #[ignore]
+    #[ignore = "long-running (10s) timing-sensitive throughput test; run manually with --ignored"]
     #[test]
     fn test_leak_bucket() {
         let v = Arc::new(AtomicU64::new(0));
@@ -545,7 +545,7 @@ mod tests {
     /// ```bash
     /// cargo test --package risingwave_common_rate_limit --lib -- tests::test_leak_bucket_overflow --exact --show-output --ignored
     /// ```
-    #[ignore]
+    #[ignore = "long-running (10s) timing-sensitive throughput test; run manually with --ignored"]
     #[test]
     fn test_leak_bucket_overflow() {
         let v = Arc::new(AtomicU64::new(0));

--- a/src/stream/src/executor/error.rs
+++ b/src/stream/src/executor/error.rs
@@ -180,14 +180,14 @@ mod tests {
 
     #[test]
     #[should_panic]
-    #[ignore]
+    #[ignore = "manual UI check: only prints the error/backtrace for human inspection"]
     fn executor_error_ui_test_1() {
         // For this test, ensure that we have only one backtrace from error when panic.
         func_return_error().unwrap();
     }
 
     #[test]
-    #[ignore]
+    #[ignore = "manual UI check: only prints the error/backtrace for human inspection"]
     fn executor_error_ui_test_2() {
         // For this test, ensure that we have only one backtrace from error when panic.
         func_return_error().map_err(|e| println!("{:?}", e)).ok();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/main/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Add an explicit reason to four tests that were skipped with a bare ignore attribute, using the format the repo already uses for other ignored tests.

A bare ignore attribute gives no information about why a test is not run. From the source alone it is impossible to tell whether the test is slow, timing-sensitive, needs external services, or is a manual check that a human has to eyeball. Adding the reason makes each skip self-explanatory, and makes it possible to audit later which ignored tests could be re-enabled.

Details:

- src/common/rate_limit/src/lib.rs - test_leak_bucket / test_leak_bucket_overflow: long-running (10s) timing-sensitive throughput tests. The rustdoc above each already shows how to run them manually with --ignored.
- src/stream/src/executor/error.rs - executor_error_ui_test_1 / executor_error_ui_test_2: manual UI checks that only print the error/backtrace for human inspection.

Limitations: no test is un-ignored here; re-enabling any of them is a separate decision. Attribute-only change, no behavioral impact.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests. (N/A: attribute-only change; no new behavior to cover.)
- [x] I have added test labels as necessary. (N/A: no new test added.)
- [x] I have added fuzzing tests or opened an issue to track them. (N/A: no fuzzable code path touched.)
- [x] All commits in this PR are signed-off-by the author.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added explanatory reasons to ignored timing-sensitive throughput tests.
  - Added explanatory reasons to ignored manual UI-check tests.
  - Test behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->