### PR TITLE
cherry-pick (opened for CI only): feat(stream): support broadcast temporal join to v3.0.3

### DIFF
--- a/e2e_test/streaming/delta_join/delta_join_upstream.slt
+++ b/e2e_test/streaming/delta_join/delta_join_upstream.slt
@@ -51,5 +51,46 @@ drop table a;
 statement ok
 drop table b;
 
+# Test non-trivial output indices conversion in delta join. The MV output reorders
+# right-side and left-side columns instead of using the trivial join output order.
+
+statement ok
+create table a (a1 int, a2 int);
+
+statement ok
+create index i_a1 on a(a1);
+
+statement ok
+create table b (b1 int, b2 int);
+
+statement ok
+create index i_b1 on b(b1);
+
+statement ok
+create materialized view v as select b.b2, a.a2, b.b1, a.a1 from a join b on a.a1 = b.b1;
+
+statement ok
+insert into a values (1,2), (1,3);
+
+statement ok
+insert into b values (1,4), (1,5);
+
+query IIII rowsort
+select * from v order by a2, b2;
+----
+4 2 1 1
+4 3 1 1
+5 2 1 1
+5 3 1 1
+
+statement ok
+drop materialized view v;
+
+statement ok
+drop table a;
+
+statement ok
+drop table b;
+
 statement ok
 set rw_streaming_enable_delta_join = false;

--- a/e2e_test/streaming/temporal_join/append_only/broadcast.slt
+++ b/e2e_test/streaming/temporal_join/append_only/broadcast.slt
@@ -1,0 +1,52 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+CREATE TABLE events(id INT, payload INT) APPEND ONLY;
+
+statement ok
+CREATE TABLE dimensions(id INT PRIMARY KEY, dim_value INT);
+
+statement ok
+CREATE MATERIALIZED VIEW joined AS
+SELECT events.id, payload, dim_value
+FROM events
+BROADCAST LEFT JOIN dimensions FOR SYSTEM_TIME AS OF PROCTIME()
+ON events.id = dimensions.id;
+
+statement ok
+INSERT INTO dimensions VALUES (1, 10), (2, 20);
+
+statement ok
+INSERT INTO events VALUES (1, 101), (1, 102), (3, 103);
+
+query III rowsort
+SELECT * FROM joined;
+----
+1 101 10
+1 102 10
+3 103 NULL
+
+statement ok
+UPDATE dimensions SET dim_value = 11 WHERE id = 1;
+
+statement ok
+INSERT INTO events VALUES (1, 104), (2, 105);
+
+query III rowsort
+SELECT * FROM joined;
+----
+1 101 10
+1 102 10
+1 104 11
+2 105 20
+3 103 NULL
+
+statement ok
+DROP MATERIALIZED VIEW joined;
+
+statement ok
+DROP TABLE events;
+
+statement ok
+DROP TABLE dimensions;

--- a/e2e_test/streaming/temporal_join/append_only/nested_loop.slt
+++ b/e2e_test/streaming/temporal_join/append_only/nested_loop.slt
@@ -94,3 +94,36 @@ drop table stream;
 
 statement ok
 drop table version;
+
+# Test non-trivial output indices conversion in nested-loop temporal join. The
+# right stream key `id2` appears after `b2` in the projected right-side output.
+
+statement ok
+create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
+
+statement ok
+create table version(id2 int, a2 int, b2 int, primary key (id2));
+
+statement ok
+create materialized view v as select id1, b2, id2 from stream join version FOR SYSTEM_TIME AS OF PROCTIME() on a1 > a2;
+
+statement ok
+insert into version values(1, 12, 122), (2, 10, 102);
+
+statement ok
+insert into stream values(1, 14, 111), (2, 9, 222);
+
+query III rowsort
+select * from v;
+----
+1 102 2
+1 122 1
+
+statement ok
+drop materialized view v;
+
+statement ok
+drop table stream;
+
+statement ok
+drop table version;

--- a/e2e_test/streaming/temporal_join/append_only/temporal_join.slt
+++ b/e2e_test/streaming/temporal_join/append_only/temporal_join.slt
@@ -62,3 +62,36 @@ drop table stream;
 
 statement ok
 drop table version;
+
+# Test non-trivial output indices conversion in hash temporal join. The right
+# stream key `id2` appears after `b2` in the projected right-side output.
+
+statement ok
+create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
+
+statement ok
+create table version(id2 int, a2 int, b2 int, primary key (id2));
+
+statement ok
+create materialized view v as select id1, b2, id2 from stream left join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
+
+statement ok
+insert into version values(3, 30, 300);
+
+statement ok
+insert into stream values(3, 33, 333), (4, 44, 444);
+
+query III rowsort
+select * from v;
+----
+3 300 3
+4 NULL NULL
+
+statement ok
+drop materialized view v;
+
+statement ok
+drop table stream;
+
+statement ok
+drop table version;

--- a/e2e_test/streaming/temporal_join/non_append_only/broadcast.slt
+++ b/e2e_test/streaming/temporal_join/non_append_only/broadcast.slt
@@ -1,0 +1,206 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+# Give the left index and lookup table different vnode counts. The temporal join fragment follows
+# the left side; every actor independently keeps a full replica of the lookup side.
+statement ok
+SET streaming_parallelism = 2;
+
+statement ok
+SET streaming_max_parallelism = 8;
+
+statement ok
+CREATE TABLE raw_events(
+    event_id INT PRIMARY KEY,
+    lookup_id INT,
+    shard_id INT,
+    payload INT
+);
+
+statement ok
+CREATE INDEX events_by_shard
+ON raw_events(shard_id, event_id, lookup_id, payload)
+DISTRIBUTED BY (shard_id);
+
+statement ok
+SET streaming_max_parallelism = 16;
+
+statement ok
+CREATE TABLE dimensions(id INT PRIMARY KEY, dim_value INT);
+
+statement ok
+SET streaming_max_parallelism = 8;
+
+statement ok
+CREATE MATERIALIZED VIEW joined AS
+SELECT event_id, lookup_id, shard_id, payload, dim_value
+FROM events_by_shard AS events
+BROADCAST LEFT JOIN dimensions FOR SYSTEM_TIME AS OF PROCTIME()
+ON events.lookup_id = dimensions.id;
+
+statement ok
+INSERT INTO raw_events VALUES (99, 1, 0, 999);
+
+query IIIII
+SELECT * FROM joined;
+----
+99 1 0 999 NULL
+
+# A later dimension insert must not rewrite the existing unmatched temporal result. Deleting the
+# left row must retract the memoized NULL result rather than the now-current matching dimension.
+statement ok
+INSERT INTO dimensions VALUES (1, 10);
+
+query IIIII
+SELECT * FROM joined;
+----
+99 1 0 999 NULL
+
+statement ok
+DELETE FROM raw_events WHERE event_id = 99;
+
+query IIIII
+SELECT * FROM joined;
+----
+
+
+statement ok
+INSERT INTO raw_events VALUES (100, 1, 0, 1000);
+
+query IIIII
+SELECT * FROM joined;
+----
+100 1 0 1000 10
+
+# Updating the lookup table does not rewrite an existing temporal-join result.
+statement ok
+UPDATE dimensions SET dim_value = 20 WHERE id = 1;
+
+query IIIII
+SELECT * FROM joined;
+----
+100 1 0 1000 10
+
+# Deleting the left row must retract the memoized v1 row, not the current v2 lookup row.
+statement ok
+DELETE FROM raw_events WHERE event_id = 100;
+
+query IIIII
+SELECT * FROM joined;
+----
+
+
+statement ok
+INSERT INTO raw_events VALUES (101, 1, 0, 1001);
+
+query IIIII
+SELECT * FROM joined;
+----
+101 1 0 1001 20
+
+# Updating the index distribution key sends U- and U+ to actors selected by the old and new
+# shard_id respectively. Each side must access the corresponding left-owned memo vnode.
+statement ok
+UPDATE raw_events SET shard_id = 1, payload = 1002 WHERE event_id = 101;
+
+query IIIII
+SELECT * FROM joined;
+----
+101 1 1 1002 20
+
+statement ok
+UPDATE dimensions SET dim_value = 30 WHERE id = 1;
+
+# Exercise memo migration in both directions while the lookup replica keeps its full vnode set.
+statement ok
+ALTER MATERIALIZED VIEW joined SET PARALLELISM = 1;
+
+query IIIII
+SELECT * FROM joined;
+----
+101 1 1 1002 20
+
+statement ok
+ALTER MATERIALIZED VIEW joined SET PARALLELISM = 2;
+
+query IIIII
+SELECT * FROM joined;
+----
+101 1 1 1002 20
+
+statement ok
+DELETE FROM raw_events WHERE event_id = 101;
+
+query IIIII
+SELECT * FROM joined;
+----
+
+
+statement ok
+DROP MATERIALIZED VIEW joined;
+
+statement ok
+DROP INDEX events_by_shard;
+
+statement ok
+DROP TABLE raw_events;
+
+statement ok
+DROP TABLE dimensions;
+
+# A singleton retractable left input has no actor vnode bitmap. Its memo table must use singleton
+# distribution while the lookup side remains fully replicated.
+statement ok
+CREATE TABLE singleton_events(id INT PRIMARY KEY, v INT);
+
+statement ok
+CREATE TABLE singleton_dimensions(id INT PRIMARY KEY, name VARCHAR);
+
+statement ok
+INSERT INTO singleton_dimensions VALUES (1, 'one'), (2, 'two');
+
+statement ok
+CREATE MATERIALIZED VIEW singleton_joined AS
+SELECT s.k, s.c, singleton_dimensions.name
+FROM (SELECT max(id) AS k, count(*) AS c FROM singleton_events) AS s
+BROADCAST LEFT JOIN singleton_dimensions FOR SYSTEM_TIME AS OF PROCTIME()
+ON s.k = singleton_dimensions.id;
+
+statement ok
+INSERT INTO singleton_events VALUES (1, 10);
+
+query IIT
+SELECT * FROM singleton_joined;
+----
+1 1 one
+
+statement ok
+INSERT INTO singleton_events VALUES (2, 20);
+
+query IIT
+SELECT * FROM singleton_joined;
+----
+2 2 two
+
+statement ok
+DELETE FROM singleton_events WHERE id = 2;
+
+query IIT
+SELECT * FROM singleton_joined;
+----
+1 1 one
+
+statement ok
+DROP MATERIALIZED VIEW singleton_joined;
+
+statement ok
+DROP TABLE singleton_events;
+
+statement ok
+DROP TABLE singleton_dimensions;
+
+statement ok
+SET streaming_parallelism = default;
+
+statement ok
+SET streaming_max_parallelism = default;

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -697,6 +697,8 @@ message TemporalJoinNode {
   optional catalog.Table memo_table = 9;
   // If it is a nested lool temporal join
   bool is_nested_loop = 10;
+  // Whether lookup-side changes are broadcast to every temporal join actor.
+  bool is_broadcast = 11;
 }
 
 message DynamicFilterNode {

--- a/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
@@ -6,6 +6,32 @@
   expected_outputs:
   - batch_error
   - stream_plan
+- name: Broadcast temporal join keeps the left distribution
+  sql: |
+    create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    select id1, a1, id2, a2 from stream broadcast left join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
+  expected_outputs:
+  - stream_plan
+  - stream_dist_plan
+- name: Broadcast temporal join memo table follows the non-append-only left distribution
+  sql: |
+    create table stream(id1 int primary key, a1 int, b1 int);
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    select id1, a1, id2, a2 from stream broadcast join version FOR SYSTEM_TIME AS OF PROCTIME() on a1 = id2;
+  expected_outputs:
+  - stream_plan
+  - stream_dist_plan
+- name: Broadcast temporal join supports a singleton retractable left input
+  sql: |
+    create table stream(id int primary key, v int);
+    create table version(id int primary key, name varchar);
+    select s.k, s.c, version.name
+    from (select max(id) as k, count(*) as c from stream) as s
+    broadcast left join version FOR SYSTEM_TIME AS OF PROCTIME() on s.k = version.id;
+  expected_outputs:
+  - stream_plan
+  - stream_dist_plan
 - name: Inner join type for temporal join
   sql: |
     create table stream(id1 int, a1 int, b1 int) APPEND ONLY;

--- a/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
@@ -6,9 +6,25 @@
   expected_outputs:
   - batch_error
   - stream_plan
-- name: Broadcast temporal join keeps the left distribution
+- name: Broadcast temporal join shuffles the left input by its stream key into an independent fragment
   sql: |
     create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    select id1, a1, id2, a2 from stream broadcast left join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
+  expected_outputs:
+  - stream_plan
+  - stream_dist_plan
+- name: Broadcast temporal join on a kafka source is not fused into the source fragment
+  with_config_map:
+    streaming_use_shared_source: true
+  sql: |
+    create source stream(id1 int, a1 int, b1 int)
+    with (
+        connector = 'kafka',
+        topic = 'mytopic',
+        properties.bootstrap.server = '6',
+        scan.startup.mode = 'earliest'
+    ) format plain encode json;
     create table version(id2 int, a2 int, b2 int, primary key (id2));
     select id1, a1, id2, a2 from stream broadcast left join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
   expected_outputs:

--- a/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
@@ -15,6 +15,159 @@
   batch_error: |-
     Not supported: do not support temporal join for batch queries
     HINT: please use temporal join in streaming queries
+- name: Broadcast temporal join keeps the left distribution
+  sql: |
+    create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    select id1, a1, id2, a2 from stream broadcast left join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
+  stream_plan: |-
+    StreamMaterialize { columns: [id1, a1, id2, a2, stream._row_id(hidden)], stream_key: [stream._row_id, id1], pk_columns: [stream._row_id, id1], pk_conflict: NoCheck }
+    └─StreamExchange { dist: HashShard(stream.id1, stream._row_id) }
+      └─StreamTemporalJoin { type: LeftOuter, append_only: true, predicate: stream.id1 = version.id2, nested_loop: false, broadcast: true, output: [stream.id1, stream.a1, version.id2, version.a2, stream._row_id] }
+        ├─StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream._row_id], stream_scan_type: ArrangementBackfill, stream_key: [stream._row_id], pk: [_row_id], dist: UpstreamHashShard(stream._row_id) }
+        └─StreamExchange { dist: Broadcast }
+          └─StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) }
+  stream_dist_plan: |+
+    Fragment 0
+    StreamMaterialize { columns: [id1, a1, id2, a2, stream._row_id(hidden)], stream_key: [stream._row_id, id1], pk_columns: [stream._row_id, id1], pk_conflict: NoCheck }
+    └── StreamExchange Hash([0, 4]) from 1
+
+    Fragment 1
+    StreamTemporalJoin { type: LeftOuter, append_only: true, predicate: stream.id1 = version.id2, nested_loop: false, broadcast: true, output: [stream.id1, stream.a1, version.id2, version.a2, stream._row_id] }
+    ├── StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream._row_id], stream_scan_type: ArrangementBackfill, stream_key: [stream._row_id], pk: [_row_id], dist: UpstreamHashShard(stream._row_id) }
+    │   ├── tables: [ StreamScan: 0 ]
+    │   ├── Upstream
+    │   └── BatchPlanNode
+    └── StreamExchange Broadcast from 2
+
+    Fragment 2
+    StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) } { tables: [ StreamScan: 1 ] }
+    ├── Upstream
+    └── BatchPlanNode
+
+    Table 0 { columns: [ vnode, _row_id, backfill_finished, row_count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3 ], distribution key: [ 0 ], read pk prefix len hint: 1, vnode column idx: 0 }
+
+    Table 1 { columns: [ vnode, id2, backfill_finished, row_count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3 ], distribution key: [ 0 ], read pk prefix len hint: 1, vnode column idx: 0 }
+
+    Table 4294967294 { columns: [ id1, a1, id2, a2, stream._row_id, _rw_timestamp ], primary key: [ $4 ASC, $0 ASC ], value indices: [ 0, 1, 2, 3, 4 ], distribution key: [ 0, 4 ], read pk prefix len hint: 2 }
+
+- name: Broadcast temporal join memo table follows the non-append-only left distribution
+  sql: |
+    create table stream(id1 int primary key, a1 int, b1 int);
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    select id1, a1, id2, a2 from stream broadcast join version FOR SYSTEM_TIME AS OF PROCTIME() on a1 = id2;
+  stream_plan: |-
+    StreamMaterialize { columns: [id1, a1, id2, a2], stream_key: [id1, a1], pk_columns: [id1, a1], pk_conflict: NoCheck }
+    └─StreamExchange { dist: HashShard(stream.id1, stream.a1) }
+      └─StreamTemporalJoin { type: Inner, append_only: false, predicate: stream.a1 = version.id2, nested_loop: false, broadcast: true, output: all }
+        ├─StreamTableScan { table: stream, columns: [stream.id1, stream.a1], stream_scan_type: ArrangementBackfill, stream_key: [stream.id1], pk: [id1], dist: UpstreamHashShard(stream.id1) }
+        └─StreamExchange { dist: Broadcast }
+          └─StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) }
+  stream_dist_plan: |+
+    Fragment 0
+    StreamMaterialize { columns: [id1, a1, id2, a2], stream_key: [id1, a1], pk_columns: [id1, a1], pk_conflict: NoCheck }
+    └── StreamExchange Hash([0, 1]) from 1
+
+    Fragment 1
+    StreamTemporalJoin { type: Inner, append_only: false, predicate: stream.a1 = version.id2, nested_loop: false, broadcast: true, output: all } { tables: [ TemporalJoinMemo: 0 ] }
+    ├── StreamTableScan { table: stream, columns: [stream.id1, stream.a1], stream_scan_type: ArrangementBackfill, stream_key: [stream.id1], pk: [id1], dist: UpstreamHashShard(stream.id1) }
+    │   ├── tables: [ StreamScan: 1 ]
+    │   ├── Upstream
+    │   └── BatchPlanNode
+    └── StreamExchange Broadcast from 2
+
+    Fragment 2
+    StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) }
+    ├── tables: [ StreamScan: 2 ]
+    ├── Upstream
+    └── BatchPlanNode
+
+    Table 0
+    ├── columns: [ version_id2, version_a2, stream_a1, stream_id1, _rw_timestamp ]
+    ├── primary key: [ $2 ASC, $3 ASC, $0 ASC ]
+    ├── value indices: [ 0, 1, 2, 3 ]
+    ├── distribution key: [ 3 ]
+    └── read pk prefix len hint: 2
+
+    Table 1
+    ├── columns: [ vnode, id1, backfill_finished, row_count, _rw_timestamp ]
+    ├── primary key: [ $0 ASC ]
+    ├── value indices: [ 1, 2, 3 ]
+    ├── distribution key: [ 0 ]
+    ├── read pk prefix len hint: 1
+    └── vnode column idx: 0
+
+    Table 2
+    ├── columns: [ vnode, id2, backfill_finished, row_count, _rw_timestamp ]
+    ├── primary key: [ $0 ASC ]
+    ├── value indices: [ 1, 2, 3 ]
+    ├── distribution key: [ 0 ]
+    ├── read pk prefix len hint: 1
+    └── vnode column idx: 0
+
+    Table 4294967294
+    ├── columns: [ id1, a1, id2, a2, _rw_timestamp ]
+    ├── primary key: [ $0 ASC, $1 ASC ]
+    ├── value indices: [ 0, 1, 2, 3 ]
+    ├── distribution key: [ 0, 1 ]
+    └── read pk prefix len hint: 2
+
+- name: Broadcast temporal join supports a singleton retractable left input
+  sql: |
+    create table stream(id int primary key, v int);
+    create table version(id int primary key, name varchar);
+    select s.k, s.c, version.name
+    from (select max(id) as k, count(*) as c from stream) as s
+    broadcast left join version FOR SYSTEM_TIME AS OF PROCTIME() on s.k = version.id;
+  stream_plan: |-
+    StreamMaterialize { columns: [k, c, name, version.id(hidden)], stream_key: [k], pk_columns: [k], pk_conflict: NoCheck }
+    └─StreamTemporalJoin { type: LeftOuter, append_only: false, predicate: max(max(stream.id)) = version.id, nested_loop: false, broadcast: true, output: [max(max(stream.id)), sum0(count), version.name, version.id] }
+      ├─StreamProject { exprs: [max(max(stream.id)), sum0(count)] }
+      │ └─StreamSimpleAgg { aggs: [max(max(stream.id)), sum0(count), count] }
+      │   └─StreamExchange { dist: Single }
+      │     └─StreamHashAgg { group_key: [_vnode], aggs: [max(stream.id), count] }
+      │       └─StreamProject { exprs: [stream.id, Vnode(stream.id) as _vnode] }
+      │         └─StreamTableScan { table: stream, columns: [stream.id], stream_scan_type: ArrangementBackfill, stream_key: [stream.id], pk: [id], dist: UpstreamHashShard(stream.id) }
+      └─StreamExchange { dist: Broadcast }
+        └─StreamTableScan { table: version, columns: [version.id, version.name], stream_scan_type: UpstreamOnly, stream_key: [version.id], pk: [id], dist: UpstreamHashShard(version.id) }
+  stream_dist_plan: |+
+    Fragment 0
+    StreamMaterialize { columns: [k, c, name, version.id(hidden)], stream_key: [k], pk_columns: [k], pk_conflict: NoCheck }
+    └── StreamTemporalJoin { type: LeftOuter, append_only: false, predicate: max(max(stream.id)) = version.id, nested_loop: false, broadcast: true, output: [max(max(stream.id)), sum0(count), version.name, version.id] }
+        ├── tables: [ TemporalJoinMemo: 0 ]
+        ├── StreamProject { exprs: [max(max(stream.id)), sum0(count)] }
+        │   └── StreamSimpleAgg { aggs: [max(max(stream.id)), sum0(count), count] } { tables: [ SimpleAggState: 2, SimpleAggCall0: 1 ] }
+        │       └── StreamExchange Single from 1
+        └── StreamExchange Broadcast from 2
+
+    Fragment 1
+    StreamHashAgg { group_key: [_vnode], aggs: [max(stream.id), count] } { tables: [ HashAggState: 4, HashAggCall0: 3 ] }
+    └── StreamProject { exprs: [stream.id, Vnode(stream.id) as _vnode] }
+        └── StreamTableScan { table: stream, columns: [stream.id], stream_scan_type: ArrangementBackfill, stream_key: [stream.id], pk: [id], dist: UpstreamHashShard(stream.id) } { tables: [ StreamScan: 5 ] }
+            ├── Upstream
+            └── BatchPlanNode
+
+    Fragment 2
+    StreamTableScan { table: version, columns: [version.id, version.name], stream_scan_type: UpstreamOnly, stream_key: [version.id], pk: [id], dist: UpstreamHashShard(version.id) } { tables: [ StreamScan: 6 ] }
+    ├── Upstream
+    └── BatchPlanNode
+
+    Table 0 { columns: [ version_id, version_name, max(max(stream_id)), _rw_timestamp ], primary key: [ $2 ASC, $0 ASC ], value indices: [ 0, 1, 2 ], distribution key: [], read pk prefix len hint: 1 }
+
+    Table 1 { columns: [ max(stream_id), _vnode, _rw_timestamp ], primary key: [ $0 DESC, $1 ASC ], value indices: [ 0, 1 ], distribution key: [], read pk prefix len hint: 0 }
+
+    Table 2 { columns: [ max(max(stream_id)), sum0(count), count, _rw_timestamp ], primary key: [], value indices: [ 0, 1, 2 ], distribution key: [], read pk prefix len hint: 0 }
+
+    Table 3 { columns: [ _vnode, stream_id, _rw_timestamp ], primary key: [ $0 ASC, $1 DESC ], value indices: [ 1 ], distribution key: [ 1 ], read pk prefix len hint: 1, vnode column idx: 0 }
+
+    Table 4 { columns: [ _vnode, max(stream_id), count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2 ], distribution key: [], read pk prefix len hint: 1, vnode column idx: 0 }
+
+    Table 5 { columns: [ vnode, id, backfill_finished, row_count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3 ], distribution key: [ 0 ], read pk prefix len hint: 1, vnode column idx: 0 }
+
+    Table 6 { columns: [ vnode, id, backfill_finished, row_count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3 ], distribution key: [ 0 ], read pk prefix len hint: 1, vnode column idx: 0 }
+
+    Table 4294967294 { columns: [ k, c, name, version.id, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 0, 1, 2, 3 ], distribution key: [], read pk prefix len hint: 1 }
+
 - name: Inner join type for temporal join
   sql: |
     create table stream(id1 int, a1 int, b1 int) APPEND ONLY;

--- a/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
@@ -15,7 +15,7 @@
   batch_error: |-
     Not supported: do not support temporal join for batch queries
     HINT: please use temporal join in streaming queries
-- name: Broadcast temporal join keeps the left distribution
+- name: Broadcast temporal join shuffles the left input by its stream key into an independent fragment
   sql: |
     create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
     create table version(id2 int, a2 int, b2 int, primary key (id2));
@@ -24,7 +24,8 @@
     StreamMaterialize { columns: [id1, a1, id2, a2, stream._row_id(hidden)], stream_key: [stream._row_id, id1], pk_columns: [stream._row_id, id1], pk_conflict: NoCheck }
     └─StreamExchange { dist: HashShard(stream.id1, stream._row_id) }
       └─StreamTemporalJoin { type: LeftOuter, append_only: true, predicate: stream.id1 = version.id2, nested_loop: false, broadcast: true, output: [stream.id1, stream.a1, version.id2, version.a2, stream._row_id] }
-        ├─StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream._row_id], stream_scan_type: ArrangementBackfill, stream_key: [stream._row_id], pk: [_row_id], dist: UpstreamHashShard(stream._row_id) }
+        ├─StreamExchange { dist: HashShard(stream._row_id) }
+        │ └─StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream._row_id], stream_scan_type: ArrangementBackfill, stream_key: [stream._row_id], pk: [_row_id], dist: UpstreamHashShard(stream._row_id) }
         └─StreamExchange { dist: Broadcast }
           └─StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) }
   stream_dist_plan: |+
@@ -34,23 +35,93 @@
 
     Fragment 1
     StreamTemporalJoin { type: LeftOuter, append_only: true, predicate: stream.id1 = version.id2, nested_loop: false, broadcast: true, output: [stream.id1, stream.a1, version.id2, version.a2, stream._row_id] }
-    ├── StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream._row_id], stream_scan_type: ArrangementBackfill, stream_key: [stream._row_id], pk: [_row_id], dist: UpstreamHashShard(stream._row_id) }
-    │   ├── tables: [ StreamScan: 0 ]
-    │   ├── Upstream
-    │   └── BatchPlanNode
-    └── StreamExchange Broadcast from 2
+    ├── StreamExchange Hash([2]) from 2
+    └── StreamExchange Broadcast from 3
 
     Fragment 2
-    StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) } { tables: [ StreamScan: 1 ] }
+    StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream._row_id], stream_scan_type: ArrangementBackfill, stream_key: [stream._row_id], pk: [_row_id], dist: UpstreamHashShard(stream._row_id) }
+    ├── tables: [ StreamScan: 0 ]
     ├── Upstream
     └── BatchPlanNode
 
-    Table 0 { columns: [ vnode, _row_id, backfill_finished, row_count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3 ], distribution key: [ 0 ], read pk prefix len hint: 1, vnode column idx: 0 }
+    Fragment 3
+    StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) }
+    ├── tables: [ StreamScan: 1 ]
+    ├── Upstream
+    └── BatchPlanNode
+
+    Table 0
+    ├── columns: [ vnode, _row_id, backfill_finished, row_count, _rw_timestamp ]
+    ├── primary key: [ $0 ASC ]
+    ├── value indices: [ 1, 2, 3 ]
+    ├── distribution key: [ 0 ]
+    ├── read pk prefix len hint: 1
+    └── vnode column idx: 0
 
     Table 1 { columns: [ vnode, id2, backfill_finished, row_count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3 ], distribution key: [ 0 ], read pk prefix len hint: 1, vnode column idx: 0 }
 
     Table 4294967294 { columns: [ id1, a1, id2, a2, stream._row_id, _rw_timestamp ], primary key: [ $4 ASC, $0 ASC ], value indices: [ 0, 1, 2, 3, 4 ], distribution key: [ 0, 4 ], read pk prefix len hint: 2 }
 
+- name: Broadcast temporal join on a kafka source is not fused into the source fragment
+  sql: |
+    create source stream(id1 int, a1 int, b1 int)
+    with (
+        connector = 'kafka',
+        topic = 'mytopic',
+        properties.bootstrap.server = '6',
+        scan.startup.mode = 'earliest'
+    ) format plain encode json;
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    select id1, a1, id2, a2 from stream broadcast left join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
+  stream_plan: |-
+    StreamMaterialize { columns: [id1, a1, id2, a2, _row_id(hidden)], stream_key: [_row_id, id1], pk_columns: [_row_id, id1], pk_conflict: NoCheck }
+    └─StreamExchange { dist: HashShard(id1, _row_id) }
+      └─StreamTemporalJoin { type: LeftOuter, append_only: true, predicate: id1 = version.id2, nested_loop: false, broadcast: true, output: [id1, a1, version.id2, version.a2, _row_id] }
+        ├─StreamExchange { dist: HashShard(_row_id) }
+        │ └─StreamRowIdGen { row_id_index: 6 }
+        │   └─StreamSourceScan { columns: [id1, a1, b1, _rw_kafka_timestamp, _rw_kafka_partition, _rw_kafka_offset, _row_id] }
+        └─StreamExchange { dist: Broadcast }
+          └─StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) }
+  stream_dist_plan: |+
+    Fragment 0
+    StreamMaterialize { columns: [id1, a1, id2, a2, _row_id(hidden)], stream_key: [_row_id, id1], pk_columns: [_row_id, id1], pk_conflict: NoCheck }
+    └── StreamExchange Hash([0, 4]) from 1
+
+    Fragment 1
+    StreamTemporalJoin { type: LeftOuter, append_only: true, predicate: id1 = version.id2, nested_loop: false, broadcast: true, output: [id1, a1, version.id2, version.a2, _row_id] }
+    ├── StreamExchange Hash([6]) from 2
+    └── StreamExchange Broadcast from 3
+
+    Fragment 2
+    StreamRowIdGen { row_id_index: 6 }
+    └── StreamSourceScan { columns: [id1, a1, b1, _rw_kafka_timestamp, _rw_kafka_partition, _rw_kafka_offset, _row_id] } { tables: [ SourceBackfill: 0 ] }
+        └── Upstream
+
+    Fragment 3
+    StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) }
+    ├── tables: [ StreamScan: 1 ]
+    ├── Upstream
+    └── BatchPlanNode
+
+    Table 0 { columns: [ partition_id, backfill_progress, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 0, 1 ], distribution key: [], read pk prefix len hint: 0 }
+
+    Table 1
+    ├── columns: [ vnode, id2, backfill_finished, row_count, _rw_timestamp ]
+    ├── primary key: [ $0 ASC ]
+    ├── value indices: [ 1, 2, 3 ]
+    ├── distribution key: [ 0 ]
+    ├── read pk prefix len hint: 1
+    └── vnode column idx: 0
+
+    Table 4294967294
+    ├── columns: [ id1, a1, id2, a2, _row_id, _rw_timestamp ]
+    ├── primary key: [ $4 ASC, $0 ASC ]
+    ├── value indices: [ 0, 1, 2, 3, 4 ]
+    ├── distribution key: [ 0, 4 ]
+    └── read pk prefix len hint: 2
+
+  with_config_map:
+    streaming_use_shared_source: 'true'
 - name: Broadcast temporal join memo table follows the non-append-only left distribution
   sql: |
     create table stream(id1 int primary key, a1 int, b1 int);
@@ -60,7 +131,8 @@
     StreamMaterialize { columns: [id1, a1, id2, a2], stream_key: [id1, a1], pk_columns: [id1, a1], pk_conflict: NoCheck }
     └─StreamExchange { dist: HashShard(stream.id1, stream.a1) }
       └─StreamTemporalJoin { type: Inner, append_only: false, predicate: stream.a1 = version.id2, nested_loop: false, broadcast: true, output: all }
-        ├─StreamTableScan { table: stream, columns: [stream.id1, stream.a1], stream_scan_type: ArrangementBackfill, stream_key: [stream.id1], pk: [id1], dist: UpstreamHashShard(stream.id1) }
+        ├─StreamExchange { dist: HashShard(stream.id1) }
+        │ └─StreamTableScan { table: stream, columns: [stream.id1, stream.a1], stream_scan_type: ArrangementBackfill, stream_key: [stream.id1], pk: [id1], dist: UpstreamHashShard(stream.id1) }
         └─StreamExchange { dist: Broadcast }
           └─StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) }
   stream_dist_plan: |+
@@ -69,14 +141,18 @@
     └── StreamExchange Hash([0, 1]) from 1
 
     Fragment 1
-    StreamTemporalJoin { type: Inner, append_only: false, predicate: stream.a1 = version.id2, nested_loop: false, broadcast: true, output: all } { tables: [ TemporalJoinMemo: 0 ] }
-    ├── StreamTableScan { table: stream, columns: [stream.id1, stream.a1], stream_scan_type: ArrangementBackfill, stream_key: [stream.id1], pk: [id1], dist: UpstreamHashShard(stream.id1) }
-    │   ├── tables: [ StreamScan: 1 ]
-    │   ├── Upstream
-    │   └── BatchPlanNode
-    └── StreamExchange Broadcast from 2
+    StreamTemporalJoin { type: Inner, append_only: false, predicate: stream.a1 = version.id2, nested_loop: false, broadcast: true, output: all }
+    ├── tables: [ TemporalJoinMemo: 0 ]
+    ├── StreamExchange Hash([0]) from 2
+    └── StreamExchange Broadcast from 3
 
     Fragment 2
+    StreamTableScan { table: stream, columns: [stream.id1, stream.a1], stream_scan_type: ArrangementBackfill, stream_key: [stream.id1], pk: [id1], dist: UpstreamHashShard(stream.id1) }
+    ├── tables: [ StreamScan: 1 ]
+    ├── Upstream
+    └── BatchPlanNode
+
+    Fragment 3
     StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) }
     ├── tables: [ StreamScan: 2 ]
     ├── Upstream

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -1086,8 +1086,11 @@ impl LogicalJoin {
 
     fn temporal_join_on(&self) -> Option<TemporalJoinScan<'_>> {
         if let Some(logical_scan) = self.core.right.as_logical_scan() {
-            matches!(logical_scan.as_of(), Some(AsOf::ProcessTime))
-                .then_some(TemporalJoinScan(logical_scan))
+            matches!(
+                logical_scan.as_of(),
+                Some(AsOf::ProcessTime | AsOf::ProcessTimeBroadcast)
+            )
+            .then_some(TemporalJoinScan(logical_scan))
         } else {
             None
         }
@@ -1248,6 +1251,8 @@ impl LogicalJoin {
 
         assert!(predicate.has_eq());
 
+        let is_broadcast = matches!(logical_scan.as_of(), Some(AsOf::ProcessTimeBroadcast));
+
         let table = logical_scan.table();
         let output_column_ids = logical_scan.output_column_ids();
 
@@ -1310,8 +1315,13 @@ impl LogicalJoin {
         };
 
         let left = self.left().to_stream(ctx)?;
-        // Enforce a shuffle for the temporal join LHS to let the scheduler be able to schedule the join fragment together with the RHS with a `no_shuffle` exchange.
-        let left = required_dist.stream_enforce(left);
+        let left = if is_broadcast {
+            left.enforce_concrete_distribution()
+        } else {
+            // Enforce a shuffle for the temporal join LHS to let the scheduler be able to schedule
+            // the join fragment together with the RHS with a `no_shuffle` exchange.
+            required_dist.stream_enforce(left)
+        };
 
         let (new_stream_table_scan, new_predicate, new_join_on, new_join_output_indices) =
             Self::temporal_join_scan_predicate_pull_up(
@@ -1321,7 +1331,12 @@ impl LogicalJoin {
                 self.left().schema().len(),
             )?;
 
-        let right = RequiredDist::no_shuffle(new_stream_table_scan.into());
+        let right = if is_broadcast {
+            RequiredDist::PhysicalDist(Distribution::Broadcast)
+                .streaming_enforce_if_not_satisfies(new_stream_table_scan.into())?
+        } else {
+            RequiredDist::no_shuffle(new_stream_table_scan.into())
+        };
         if !new_predicate.has_eq() {
             return Err(RwError::from(ErrorCode::NotSupported(
                 "Temporal join requires a non trivial join condition".into(),
@@ -1353,6 +1368,13 @@ impl LogicalJoin {
     ) -> Result<StreamPlanRef> {
         use super::stream::prelude::*;
         assert!(!predicate.has_eq());
+
+        if matches!(logical_scan.as_of(), Some(AsOf::ProcessTimeBroadcast)) {
+            return Err(RwError::from(ErrorCode::NotSupported(
+                "Broadcast temporal join requires an equality condition".into(),
+                "Please add an equality condition over a lookup-table key".into(),
+            )));
+        }
 
         let left = self.left().to_stream_with_dist_required(
             &RequiredDist::PhysicalDist(Distribution::Broadcast),

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -1316,7 +1316,18 @@ impl LogicalJoin {
 
         let left = self.left().to_stream(ctx)?;
         let left = if is_broadcast {
-            left.enforce_concrete_distribution()
+            // Always shuffle the LHS by its stream key. The point of a broadcast temporal join is
+            // to make the join fragment independent: without an exchange here, the join would be
+            // fused into the upstream fragment whenever the LHS already declares a concrete
+            // distribution (e.g. a source with `HashShard(_row_id)` or a table scan with
+            // `UpstreamHashShard`), which ties the join parallelism to the upstream and inherits
+            // its key skew. One extra hash exchange buys an independently scalable join fragment
+            // and evenly spread rows. A singleton LHS cannot be sharded, so keep it as is.
+            match left.distribution() {
+                Distribution::Single => left,
+                _ => RequiredDist::shard_by_key(left.schema().len(), left.expect_stream_key())
+                    .stream_enforce(left),
+            }
         } else {
             // Enforce a shuffle for the temporal join LHS to let the scheduler be able to schedule
             // the join fragment together with the RHS with a `no_shuffle` exchange.

--- a/src/frontend/src/optimizer/plan_node/logical_vector_search_lookup_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_vector_search_lookup_join.rs
@@ -300,6 +300,8 @@ impl ToStream for LogicalVectorSearchLookupJoin {
 
     fn to_stream(&self, ctx: &mut ToStreamContext) -> Result<StreamPlanRef> {
         if let Some(core) = self.to_vector_index_lookup_join(|plan| plan.to_stream(ctx))? {
+            // `ProcessTimeBroadcast` is intentionally excluded: the vector-index lookup executor
+            // does not consume a broadcast change stream or maintain replicated lookup state.
             if !matches!(&core.as_of, Some(AsOf::ProcessTime)) {
                 bail!("streaming vector index lookup join must be proctime temporal join");
             }

--- a/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
@@ -32,6 +32,7 @@ use crate::optimizer::plan_node::utils::{IndicesDisplay, TableCatalogBuilder};
 use crate::optimizer::plan_node::{
     EqJoinPredicate, EqJoinPredicateDisplay, StreamExchange, StreamTableScan, TryToStreamPb,
 };
+use crate::optimizer::property::Distribution;
 use crate::scheduler::SchedulerResult;
 use crate::stream_fragmenter::BuildFragmentGraphState;
 use crate::utils::ColIndexMappingRewriteExt;
@@ -42,6 +43,7 @@ pub struct StreamTemporalJoin {
     core: generic::Join<PlanRef>,
     append_only: bool,
     is_nested_loop: bool,
+    is_broadcast: bool,
 }
 
 impl StreamTemporalJoin {
@@ -58,13 +60,23 @@ impl StreamTemporalJoin {
         let right = core.right.clone();
         let exchange: &StreamExchange = right
             .as_stream_exchange()
-            .expect("should be a no shuffle stream exchange");
-        assert!(exchange.no_shuffle());
+            .expect("temporal join lookup side should have an exchange");
         let exchange_input = exchange.input();
         let scan: &StreamTableScan = exchange_input
             .as_stream_table_scan()
             .expect("should be a stream table scan");
-        assert!(matches!(scan.core().as_of, Some(AsOf::ProcessTime)));
+        let is_broadcast = matches!(scan.core().as_of, Some(AsOf::ProcessTimeBroadcast));
+        assert!(matches!(
+            scan.core().as_of,
+            Some(AsOf::ProcessTime | AsOf::ProcessTimeBroadcast)
+        ));
+        if is_broadcast {
+            assert!(!exchange.no_shuffle());
+            assert_eq!(exchange.distribution(), &Distribution::Broadcast);
+            assert!(!is_nested_loop);
+        } else {
+            assert!(exchange.no_shuffle());
+        }
 
         let dist = if is_nested_loop {
             // Use right side distribution directly if it's nested loop temporal join.
@@ -104,6 +116,7 @@ impl StreamTemporalJoin {
             core,
             append_only,
             is_nested_loop,
+            is_broadcast,
         })
     }
 
@@ -127,17 +140,32 @@ impl StreamTemporalJoin {
         self.is_nested_loop
     }
 
-    /// Return memo-table catalog and its `pk_indices`.
-    /// (`join_key` + `left_pk` + `right_pk`) -> (`right_scan_schema` + `join_key` + `left_pk`)
+    pub fn is_broadcast(&self) -> bool {
+        self.is_broadcast
+    }
+
+    /// Return the memo-table catalog.
+    ///
+    /// The memo prefix is `join_key + left_stream_key`. A regular temporal join is distributed by
+    /// the lookup key, while a broadcast temporal join preserves the left input distribution and
+    /// maps that distribution key to its copy in the `left_stream_key` part of the prefix.
     ///
     /// Write pattern:
-    ///   for each left input row (with insert op), construct the memo table pk and insert the row into the memo table.
+    ///   for each left input row (with insert op), persist the matched right row followed by the
+    ///   memo prefix.
     ///
     /// Read pattern:
-    ///   for each left input row (with delete op), construct pk prefix (`join_key` + `left_pk`) to fetch rows and delete them from the memo table.
+    ///   for each left input row (with delete op), use the memo prefix to fetch and delete all
+    ///   right rows that matched when the left row was inserted.
     pub fn infer_memo_table_catalog(&self, right_scan: &StreamTableScan) -> TableCatalog {
         let left_eq_indexes = self.eq_join_predicate().left_eq_indexes();
-        let read_prefix_len_hint = left_eq_indexes.len() + self.left().stream_key().unwrap().len();
+        let left_stream_key = self.core.left.expect_stream_key();
+        let memo_prefix_indices = left_eq_indexes
+            .iter()
+            .chain(left_stream_key)
+            .copied()
+            .collect_vec();
+        let read_prefix_len_hint = memo_prefix_indices.len();
 
         // Build internal table
         let mut internal_table_catalog_builder = TableCatalogBuilder::default();
@@ -146,10 +174,9 @@ impl StreamTemporalJoin {
         for field in right_scan_schema.fields() {
             internal_table_catalog_builder.add_column(field);
         }
-        // Add join_key + left_pk
-        for field in left_eq_indexes
+        // Add the columns that identify and route a left row.
+        for field in memo_prefix_indices
             .iter()
-            .chain(self.core.left.stream_key().unwrap())
             .map(|idx| &self.core.left.schema().fields()[*idx])
         {
             internal_table_catalog_builder.add_column(field);
@@ -164,14 +191,31 @@ impl StreamTemporalJoin {
             internal_table_catalog_builder.add_order_column(*idx, OrderType::ascending())
         });
 
-        let dist_key_len = right_scan
-            .core()
-            .distribution_key()
-            .map(|keys| keys.len())
-            .unwrap_or(0);
-
-        let internal_table_dist_keys =
-            (right_scan_schema.len()..(right_scan_schema.len() + dist_key_len)).collect();
+        let internal_table_dist_keys = if self.is_broadcast {
+            let left_dist_key = self
+                .core
+                .left
+                .distribution()
+                .dist_column_indices_opt()
+                .expect("broadcast temporal join left input must have a concrete distribution");
+            left_dist_key
+                .iter()
+                .map(|dist_idx| {
+                    let position = left_stream_key
+                        .iter()
+                        .position(|idx| idx == dist_idx)
+                        .expect("left distribution key must be part of the left stream key");
+                    right_scan_schema.len() + left_eq_indexes.len() + position
+                })
+                .collect()
+        } else {
+            let dist_key_len = right_scan
+                .core()
+                .distribution_key()
+                .map(|keys| keys.len())
+                .unwrap_or(0);
+            (right_scan_schema.len()..(right_scan_schema.len() + dist_key_len)).collect()
+        };
         internal_table_catalog_builder.build(internal_table_dist_keys, read_prefix_len_hint)
     }
 }
@@ -193,6 +237,9 @@ impl Distill for StreamTemporalJoin {
         ));
 
         vec.push(("nested_loop", Pretty::debug(&self.is_nested_loop)));
+        if self.is_broadcast {
+            vec.push(("broadcast", Pretty::debug(&self.is_broadcast)));
+        }
 
         if let Some(ow) = watermark_pretty(self.base.watermark_columns(), self.schema()) {
             vec.push(("output_watermarks", ow));
@@ -241,8 +288,13 @@ impl TryToStreamPb for StreamTemporalJoin {
         let right = self.right();
         let exchange: &StreamExchange = right
             .as_stream_exchange()
-            .expect("should be a no shuffle stream exchange");
-        assert!(exchange.no_shuffle());
+            .expect("temporal join lookup side should have an exchange");
+        if self.is_broadcast {
+            assert!(!exchange.no_shuffle());
+            assert_eq!(exchange.distribution(), &Distribution::Broadcast);
+        } else {
+            assert!(exchange.no_shuffle());
+        }
         let exchange_input = exchange.input();
         let scan: &StreamTableScan = exchange_input
             .as_stream_table_scan()
@@ -276,6 +328,7 @@ impl TryToStreamPb for StreamTemporalJoin {
                 Some(memo_table.to_internal_table_prost())
             },
             is_nested_loop: self.is_nested_loop,
+            is_broadcast: self.is_broadcast,
         })))
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
@@ -147,8 +147,9 @@ impl StreamTemporalJoin {
     /// Return the memo-table catalog.
     ///
     /// The memo prefix is `join_key + left_stream_key`. A regular temporal join is distributed by
-    /// the lookup key, while a broadcast temporal join preserves the left input distribution and
-    /// maps that distribution key to its copy in the `left_stream_key` part of the prefix.
+    /// the lookup key, while a broadcast temporal join shuffles the left input by its stream key
+    /// (or keeps it singleton) and maps that distribution key to its copy in the
+    /// `left_stream_key` part of the prefix.
     ///
     /// Write pattern:
     ///   for each left input row (with insert op), persist the matched right row followed by the

--- a/src/frontend/src/optimizer/plan_node/utils.rs
+++ b/src/frontend/src/optimizer/plan_node/utils.rs
@@ -510,7 +510,7 @@ pub fn to_batch_query_epoch(a: &Option<AsOf>) -> Result<Option<PbBatchQueryEpoch
     };
     Feature::TimeTravel.check_available()?;
     let timestamp = match a {
-        AsOf::ProcessTime => {
+        AsOf::ProcessTime | AsOf::ProcessTimeBroadcast => {
             return Err(ErrorCode::NotSupported(
                 "do not support as of proctime".to_owned(),
                 "please use as of timestamp".to_owned(),
@@ -612,7 +612,9 @@ pub fn to_iceberg_time_travel_as_of(
                 timestamp * 1000 + date_time.time.microsecond as i64 / 1000,
             ))
         }
-        Some(AsOf::ProcessTime) | Some(AsOf::ProcessTimeWithInterval(_)) => {
+        Some(AsOf::ProcessTime)
+        | Some(AsOf::ProcessTimeBroadcast)
+        | Some(AsOf::ProcessTimeWithInterval(_)) => {
             unreachable!()
         }
         None => None,

--- a/src/frontend/src/optimizer/plan_visitor/temporal_join_validator.rs
+++ b/src/frontend/src/optimizer/plan_visitor/temporal_join_validator.rs
@@ -55,7 +55,10 @@ impl LogicalPlanVisitor for TemporalJoinValidator {
     }
 
     fn visit_logical_scan(&mut self, logical_scan: &LogicalScan) -> bool {
-        matches!(logical_scan.as_of(), Some(AsOf::ProcessTime))
+        matches!(
+            logical_scan.as_of(),
+            Some(AsOf::ProcessTime | AsOf::ProcessTimeBroadcast)
+        )
     }
 }
 
@@ -69,7 +72,10 @@ impl BatchPlanVisitor for TemporalJoinValidator {
     }
 
     fn visit_batch_seq_scan(&mut self, batch_seq_scan: &BatchSeqScan) -> bool {
-        matches!(batch_seq_scan.core().as_of, Some(AsOf::ProcessTime))
+        matches!(
+            batch_seq_scan.core().as_of,
+            Some(AsOf::ProcessTime | AsOf::ProcessTimeBroadcast)
+        )
     }
 }
 
@@ -83,7 +89,10 @@ impl StreamPlanVisitor for TemporalJoinValidator {
     }
 
     fn visit_stream_table_scan(&mut self, stream_table_scan: &StreamTableScan) -> bool {
-        matches!(stream_table_scan.core().as_of, Some(AsOf::ProcessTime))
+        matches!(
+            stream_table_scan.core().as_of,
+            Some(AsOf::ProcessTime | AsOf::ProcessTimeBroadcast)
+        )
     }
 
     fn visit_stream_temporal_join(&mut self, stream_temporal_join: &StreamTemporalJoin) -> bool {

--- a/src/frontend/src/planner/relation.rs
+++ b/src/frontend/src/planner/relation.rs
@@ -88,6 +88,7 @@ impl Planner {
                 match as_of {
                     None
                     | Some(AsOf::ProcessTime)
+                    | Some(AsOf::ProcessTimeBroadcast)
                     | Some(AsOf::TimestampNum(_))
                     | Some(AsOf::TimestampString(_))
                     | Some(AsOf::ProcessTimeWithInterval(_)) => {}
@@ -145,7 +146,9 @@ impl Planner {
             | Some(AsOf::VersionNum(_))
             | Some(AsOf::TimestampString(_))
             | Some(AsOf::TimestampNum(_)) => {}
-            Some(AsOf::ProcessTime) | Some(AsOf::ProcessTimeWithInterval(_)) => {
+            Some(AsOf::ProcessTime)
+            | Some(AsOf::ProcessTimeBroadcast)
+            | Some(AsOf::ProcessTimeWithInterval(_)) => {
                 bail_not_implemented!("As Of ProcessTime() is not supported yet.")
             }
             Some(AsOf::VersionString(_)) => {
@@ -289,7 +292,9 @@ impl Planner {
                 | Some(AsOf::VersionNum(_))
                 | Some(AsOf::TimestampString(_))
                 | Some(AsOf::TimestampNum(_)) => {}
-                Some(AsOf::ProcessTime) | Some(AsOf::ProcessTimeWithInterval(_)) => {
+                Some(AsOf::ProcessTime)
+                | Some(AsOf::ProcessTimeBroadcast)
+                | Some(AsOf::ProcessTimeWithInterval(_)) => {
                     bail_not_implemented!("As Of ProcessTime() is not supported yet.")
                 }
                 Some(AsOf::VersionString(_)) => {

--- a/src/meta/src/stream/stream_graph/schedule.rs
+++ b/src/meta/src/stream/stream_graph/schedule.rs
@@ -207,7 +207,15 @@ impl Scheduler {
                             return;
                         }
                     }
-                    NodeBody::TemporalJoin(node) => node.get_table_desc().unwrap().vnode_count(),
+                    NodeBody::TemporalJoin(node) => {
+                        if node.is_broadcast {
+                            // Every actor owns a full replicated view of the lookup table, so the
+                            // join fragment follows the left input rather than the lookup table's
+                            // vnode count.
+                            return;
+                        }
+                        node.get_table_desc().unwrap().vnode_count()
+                    }
                     NodeBody::BatchPlan(node) => node.get_table_desc().unwrap().vnode_count(),
                     NodeBody::Lookup(node) => node
                         .get_arrangement_table_info()

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -3863,6 +3863,10 @@ impl fmt::Display for SetVariableValueSingle {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AsOf {
     ProcessTime,
+    /// Internal marker for a process-time temporal join whose lookup side is broadcast to all join
+    /// actors. It stays on the lookup relation so optimizer rewrites cannot detach the strategy
+    /// from that relation; [`crate::ast::Join`]'s `Display` renders the modifier in join position.
+    ProcessTimeBroadcast,
     // used by time travel
     ProcessTimeWithInterval((String, DateTimeField)),
     // the number of seconds that have elapsed since the Unix epoch, which is January 1, 1970 at 00:00:00 Coordinated Universal Time (UTC).
@@ -3876,7 +3880,9 @@ impl fmt::Display for AsOf {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use AsOf::*;
         match self {
-            ProcessTime => write!(f, " FOR SYSTEM_TIME AS OF PROCTIME()"),
+            ProcessTime | ProcessTimeBroadcast => {
+                write!(f, " FOR SYSTEM_TIME AS OF PROCTIME()")
+            }
             ProcessTimeWithInterval((value, leading_field)) => write!(
                 f,
                 " FOR SYSTEM_TIME AS OF NOW() - '{}' {}",

--- a/src/sqlparser/src/ast/query.rs
+++ b/src/sqlparser/src/ast/query.rs
@@ -576,18 +576,31 @@ impl fmt::Display for Join {
             }
             Suffix(constraint)
         }
+        let broadcast = if matches!(
+            self.relation,
+            TableFactor::Table {
+                as_of: Some(AsOf::ProcessTimeBroadcast),
+                ..
+            }
+        ) {
+            "BROADCAST "
+        } else {
+            ""
+        };
         match &self.join_operator {
             JoinOperator::Inner(constraint) => write!(
                 f,
-                " {}JOIN {}{}",
+                " {}{}JOIN {}{}",
                 prefix(constraint),
+                broadcast,
                 self.relation,
                 suffix(constraint)
             ),
             JoinOperator::LeftOuter(constraint) => write!(
                 f,
-                " {}LEFT JOIN {}{}",
+                " {}{}LEFT JOIN {}{}",
                 prefix(constraint),
+                broadcast,
                 self.relation,
                 suffix(constraint)
             ),

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -4389,6 +4389,9 @@ impl Parser<'_> {
         &mut self,
         reserved_kwds: &[Keyword],
     ) -> ModalResult<Option<TableAlias>> {
+        if self.peek_broadcast_join() {
+            return Ok(None);
+        }
         match self.parse_optional_alias(reserved_kwds)? {
             Some(name) => {
                 let columns = self.parse_parenthesized_column_list(Optional)?;
@@ -5417,6 +5420,7 @@ impl Parser<'_> {
         // a table alias.
         let mut joins = vec![];
         loop {
+            let join_checkpoint = *self;
             let join = if self.parse_keyword(Keyword::CROSS) {
                 let join_operator = if self.parse_keyword(Keyword::JOIN) {
                     JoinOperator::CrossJoin
@@ -5428,6 +5432,10 @@ impl Parser<'_> {
                     join_operator,
                 }
             } else {
+                let broadcast = self.peek_broadcast_join();
+                if broadcast {
+                    let _ = self.next_token();
+                }
                 let (natural, asof) =
                     match self.parse_one_of_keywords(&[Keyword::NATURAL, Keyword::ASOF]) {
                         Some(Keyword::NATURAL) => (true, false),
@@ -5483,11 +5491,38 @@ impl Parser<'_> {
                     _ if asof => {
                         return self.expected("a join type after ASOF");
                     }
+                    _ if broadcast => {
+                        return self.expected_at(join_checkpoint, "a join type after BROADCAST");
+                    }
                     _ => break,
                 };
-                let relation = self.parse_table_factor()?;
+                let mut relation = self.parse_table_factor()?;
                 let join_constraint = self.parse_join_constraint(natural)?;
                 let join_operator = join_operator_type(join_constraint);
+                if broadcast {
+                    if !matches!(
+                        join_operator,
+                        JoinOperator::Inner(_) | JoinOperator::LeftOuter(_)
+                    ) {
+                        return self.expected_at(
+                            join_checkpoint,
+                            "INNER or LEFT temporal join after BROADCAST",
+                        );
+                    }
+                    match &mut relation {
+                        TableFactor::Table {
+                            as_of: Some(as_of), ..
+                        } if matches!(as_of, AsOf::ProcessTime) => {
+                            *as_of = AsOf::ProcessTimeBroadcast;
+                        }
+                        _ => {
+                            return self.expected_at(
+                                join_checkpoint,
+                                "a table with FOR SYSTEM_TIME AS OF PROCTIME() after BROADCAST JOIN",
+                            );
+                        }
+                    }
+                }
                 let need_constraint = match join_operator {
                     JoinOperator::Inner(JoinConstraint::None) => Some("INNER JOIN"),
                     JoinOperator::AsOfInner(JoinConstraint::None) => Some("ASOF INNER JOIN"),
@@ -5506,6 +5541,22 @@ impl Parser<'_> {
             joins.push(join);
         }
         Ok(TableWithJoins { relation, joins })
+    }
+
+    /// Whether the next tokens start a supported broadcast join.
+    ///
+    /// `BROADCAST` remains a regular identifier outside this exact position so that existing
+    /// table aliases and identifier formatting remain compatible.
+    fn peek_broadcast_join(&self) -> bool {
+        matches!(
+            self.peek_nth_token(0).token,
+            Token::Word(word)
+                if word.quote_style.is_none() && word.value.eq_ignore_ascii_case("BROADCAST")
+        ) && matches!(
+            self.peek_nth_token(1).token,
+            Token::Word(word)
+                if matches!(word.keyword, Keyword::INNER | Keyword::JOIN | Keyword::LEFT)
+        )
     }
 
     /// A table name or a parenthesized subquery, followed by optional `[AS] alias`

--- a/src/storage/src/hummock/shared_buffer/mod.rs
+++ b/src/storage/src/hummock/shared_buffer/mod.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use risingwave_common::metrics::{
     LabelGuardedHistogram, LabelGuardedIntCounter, LabelGuardedIntGauge,
-    LazyLabelGuardedIntCounter, LazyLabelGuardedIntGauge,
+    LazyLabelGuardedIntCounter, LazyLabelGuardedIntGauge, UintGauge,
 };
 use risingwave_pb::id::{FragmentId, TableId};
 
@@ -30,6 +30,7 @@ pub mod shared_buffer_batch;
 pub(crate) struct TableMemoryMetrics {
     imm_total_size: LabelGuardedIntGauge,
     imm_count: LabelGuardedIntGauge,
+    replicated_imm_size: Option<UintGauge>,
     pub write_batch_tuple_counts: LabelGuardedIntCounter,
     pub write_batch_duration: LabelGuardedHistogram,
     pub write_batch_size: LabelGuardedHistogram,
@@ -60,6 +61,7 @@ impl TableMemoryMetrics {
             imm_count: metrics
                 .per_table_imm_count
                 .with_guarded_label_values(table_labels),
+            replicated_imm_size: is_replicated.then(|| metrics.replicated_imm_size.clone()),
             write_batch_tuple_counts: metrics
                 .write_batch_tuple_counts
                 .with_guarded_label_values(table_labels),
@@ -91,11 +93,17 @@ impl TableMemoryMetrics {
     pub(super) fn inc_imm(&self, imm_size: usize) {
         self.imm_total_size.add(imm_size as _);
         self.imm_count.inc();
+        if let Some(replicated_imm_size) = &self.replicated_imm_size {
+            replicated_imm_size.add(imm_size as _);
+        }
     }
 
     pub(super) fn dec_imm(&self, imm_size: usize) {
         self.imm_total_size.sub(imm_size as _);
         self.imm_count.dec();
+        if let Some(replicated_imm_size) = &self.replicated_imm_size {
+            replicated_imm_size.sub(imm_size as _);
+        }
     }
 }
 

--- a/src/storage/src/hummock/store/local_hummock_storage.rs
+++ b/src/storage/src/hummock/store/local_hummock_storage.rs
@@ -679,6 +679,11 @@ impl LocalHummockStorage {
             self.spill_offset += 1;
 
             if self.is_replicated {
+                // A replicated imm cannot be uploaded independently: it is discarded when the
+                // source table's committed epoch catches up. It therefore bypasses the regular
+                // write and memory limiters. Keep this memory visible through
+                // `state_store_replicated_imm_size`, especially for operators that maintain one
+                // full replica per actor.
                 self.read_version.write().add_replicated_imm(imm);
             } else {
                 self.write_limiter.wait_permission(self.table_id).await;

--- a/src/storage/src/monitor/hummock_state_store_metrics.rs
+++ b/src/storage/src/monitor/hummock_state_store_metrics.rs
@@ -83,6 +83,7 @@ pub struct HummockStateStoreMetrics {
     pub uploader_per_table_imm_count: RelabeledGuardedIntGaugeVec,
 
     // memory
+    pub replicated_imm_size: UintGauge,
     pub per_table_imm_size: RelabeledGuardedIntGaugeVec,
     pub per_table_imm_count: RelabeledGuardedIntGaugeVec,
     pub mem_table_spill_counts: RelabeledGuardedIntCounterVec,
@@ -474,6 +475,15 @@ impl HummockStateStoreMetrics {
             metric_level,
         );
 
+        let replicated_imm_size = UintGauge::new(
+            "state_store_replicated_imm_size",
+            "Total retained replicated immutable memtable size",
+        )
+        .unwrap();
+        registry
+            .register(Box::new(replicated_imm_size.clone()))
+            .unwrap();
+
         let per_table_imm_size = register_guarded_int_gauge_vec_with_registry!(
             "state_store_per_table_imm_size",
             "Total imm size per table",
@@ -649,6 +659,7 @@ impl HummockStateStoreMetrics {
             uploader_wait_poll_latency,
             uploader_per_table_imm_size,
             uploader_per_table_imm_count,
+            replicated_imm_size,
             per_table_imm_size,
             per_table_imm_count,
             mem_table_spill_counts,

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -670,11 +670,6 @@ impl<S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool, PreloadAllRow>
         self
     }
 
-    pub fn with_output_column_ids(mut self, output_column_ids: Vec<ColumnId>) -> Self {
-        self.output_column_ids = Some(output_column_ids);
-        self
-    }
-
     pub fn enable_vnode_key_stats(mut self, enable: bool, config: &StreamingConfig) -> Self {
         self.enable_vnode_key_stats = Some(enable);
         self.enable_state_table_vnode_stats_pruning =
@@ -684,6 +679,15 @@ impl<S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool, PreloadAllRow>
 
     pub fn with_metrics(mut self, metrics: StateTableMetrics) -> Self {
         self.metrics = Some(metrics);
+        self
+    }
+}
+
+impl<S: StateStore, SD: ValueRowSerde, PreloadAllRow>
+    StateTableBuilder<S, SD, true, PreloadAllRow>
+{
+    pub fn with_output_column_ids(mut self, output_column_ids: Vec<ColumnId>) -> Self {
+        self.output_column_ids = Some(output_column_ids);
         self
     }
 }
@@ -1065,7 +1069,7 @@ impl<S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool>
         table_desc: &StorageTableDesc,
         store: S,
         vnodes: Option<Arc<Bitmap>>,
-        fragment_id: u32,
+        fragment_id: FragmentId,
     ) -> Self {
         let table_id = table_desc.table_id;
         let table_columns: Vec<ColumnDesc> =
@@ -1107,7 +1111,7 @@ impl<S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool>
             prefix_hint_len: table_desc.read_prefix_len_hint as usize,
             retention_seconds: table_desc.retention_seconds,
             versioned: table_desc.versioned,
-            fragment_id: fragment_id.into(),
+            fragment_id,
             clean_watermark_index: None,
             store,
             vnodes,
@@ -1841,7 +1845,13 @@ where
         Ok(self
             .iter_kv_with_pk_range::<()>(pk_range, vnode, prefetch_options)
             .await?
-            .map_ok(|(_, row)| row))
+            .map_ok(|(_, row)| {
+                if IS_REPLICATED {
+                    row.project(&self.output_indices).into_owned_row()
+                } else {
+                    row
+                }
+            }))
     }
 
     pub async fn iter_keyed_row_with_vnode(
@@ -1854,19 +1864,6 @@ where
             .iter_kv_with_pk_range(pk_range, vnode, prefetch_options)
             .await?
             .map_ok(|(key, row)| KeyedRow::new(TableKey(key), row)))
-    }
-
-    pub async fn iter_with_vnode_and_output_indices(
-        &self,
-        vnode: VirtualNode,
-        pk_range: &(Bound<impl Row>, Bound<impl Row>),
-        prefetch_options: PrefetchOptions,
-    ) -> StreamExecutorResult<impl RowStream<'_>> {
-        assert!(IS_REPLICATED);
-        let stream = self
-            .iter_with_vnode(vnode, pk_range, prefetch_options)
-            .await?;
-        Ok(stream.map(|row| row.map(|row| row.project(&self.output_indices).into_owned_row())))
     }
 }
 
@@ -2069,7 +2066,13 @@ where
     ) -> StreamExecutorResult<impl RowStream<'_>> {
         let stream = self.iter_with_prefix_inner::</* REVERSE */ false, ()>(pk_prefix, sub_range, prefetch_options)
             .await?;
-        Ok(stream.map_ok(|(_, row)| row))
+        Ok(stream.map_ok(|(_, row)| {
+            if IS_REPLICATED {
+                row.project(&self.output_indices).into_owned_row()
+            } else {
+                row
+            }
+        }))
     }
 
     /// This function scans rows from the relational table with specific `prefix` and `sub_range` under the same

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -35,6 +35,7 @@ use risingwave_common::catalog::{
 };
 use risingwave_common::config::StreamingConfig;
 use risingwave_common::hash::{VirtualNode, VnodeBitmapExt, VnodeCountCompat};
+use risingwave_common::id::FragmentId;
 use risingwave_common::row::{self, OwnedRow, Row, RowExt};
 use risingwave_common::types::{DataType, ScalarImpl};
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
@@ -51,6 +52,7 @@ use risingwave_hummock_sdk::table_watermark::{
     VnodeWatermark, WatermarkDirection, WatermarkSerdeType,
 };
 use risingwave_pb::catalog::Table;
+use risingwave_pb::plan_common::StorageTableDesc;
 use risingwave_storage::StateStore;
 use risingwave_storage::error::{ErrorKind, StorageError, StorageResult};
 use risingwave_storage::hummock::CachePolicy;
@@ -569,8 +571,24 @@ pub enum StateTableOpConsistencyLevel {
     LogStoreEnabled,
 }
 
-pub struct StateTableBuilder<'a, S, SD, const IS_REPLICATED: bool, PreloadAllRow> {
-    table_catalog: &'a Table,
+pub struct StateTableBuilder<S, SD, const IS_REPLICATED: bool, PreloadAllRow> {
+    // Extracted intermediate fields (source-agnostic)
+    table_id: TableId,
+    table_name_for_debug: String,
+    table_columns: Vec<ColumnDesc>,
+    order_types: Vec<OrderType>,
+    pk_indices: Vec<usize>,
+    dist_key_in_pk_indices: Vec<usize>,
+    vnode_col_idx_in_pk: Option<usize>,
+    expected_vnode_count: usize,
+    value_indices: Vec<usize>,
+    prefix_hint_len: usize,
+    retention_seconds: Option<u32>,
+    versioned: bool,
+    fragment_id: FragmentId,
+    clean_watermark_index: Option<usize>,
+
+    // Builder configuration fields
     store: S,
     vnodes: Option<Arc<Bitmap>>,
     op_consistency_level: Option<StateTableOpConsistencyLevel>,
@@ -585,30 +603,28 @@ pub struct StateTableBuilder<'a, S, SD, const IS_REPLICATED: bool, PreloadAllRow
     _serde: PhantomData<SD>,
 }
 
-impl<'a, S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool>
-    StateTableBuilder<'a, S, SD, IS_REPLICATED, ()>
+impl<S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool>
+    StateTableBuilder<S, SD, IS_REPLICATED, ()>
 {
-    pub fn new(table_catalog: &'a Table, store: S, vnodes: Option<Arc<Bitmap>>) -> Self {
-        Self {
-            table_catalog,
-            store,
-            vnodes,
-            op_consistency_level: None,
-            output_column_ids: None,
-            preload_all_rows: (),
-            enable_vnode_key_stats: None,
-            enable_state_table_vnode_stats_pruning: false,
-            metrics: None,
-            _serde: Default::default(),
-        }
-    }
-
     fn with_preload_all_rows(
         self,
         preload_all_rows: bool,
-    ) -> StateTableBuilder<'a, S, SD, IS_REPLICATED, bool> {
+    ) -> StateTableBuilder<S, SD, IS_REPLICATED, bool> {
         StateTableBuilder {
-            table_catalog: self.table_catalog,
+            table_id: self.table_id,
+            table_name_for_debug: self.table_name_for_debug,
+            table_columns: self.table_columns,
+            order_types: self.order_types,
+            pk_indices: self.pk_indices,
+            dist_key_in_pk_indices: self.dist_key_in_pk_indices,
+            vnode_col_idx_in_pk: self.vnode_col_idx_in_pk,
+            expected_vnode_count: self.expected_vnode_count,
+            value_indices: self.value_indices,
+            prefix_hint_len: self.prefix_hint_len,
+            retention_seconds: self.retention_seconds,
+            versioned: self.versioned,
+            fragment_id: self.fragment_id,
+            clean_watermark_index: self.clean_watermark_index,
             store: self.store,
             vnodes: self.vnodes,
             op_consistency_level: self.op_consistency_level,
@@ -624,27 +640,27 @@ impl<'a, S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool>
     pub fn enable_preload_all_rows_by_config(
         self,
         config: &StreamingConfig,
-    ) -> StateTableBuilder<'a, S, SD, IS_REPLICATED, bool> {
+    ) -> StateTableBuilder<S, SD, IS_REPLICATED, bool> {
         let developer = &config.developer;
         let preload_all_rows = if developer.default_enable_mem_preload_state_table {
             !developer
                 .mem_preload_state_table_ids_blacklist
-                .contains(&self.table_catalog.id.as_raw_id())
+                .contains(&self.table_id.as_raw_id())
         } else {
             developer
                 .mem_preload_state_table_ids_whitelist
-                .contains(&self.table_catalog.id.as_raw_id())
+                .contains(&self.table_id.as_raw_id())
         };
         self.with_preload_all_rows(preload_all_rows)
     }
 
-    pub fn forbid_preload_all_rows(self) -> StateTableBuilder<'a, S, SD, IS_REPLICATED, bool> {
+    pub fn forbid_preload_all_rows(self) -> StateTableBuilder<S, SD, IS_REPLICATED, bool> {
         self.with_preload_all_rows(false)
     }
 }
 
-impl<'a, S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool, PreloadAllRow>
-    StateTableBuilder<'a, S, SD, IS_REPLICATED, PreloadAllRow>
+impl<S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool, PreloadAllRow>
+    StateTableBuilder<S, SD, IS_REPLICATED, PreloadAllRow>
 {
     pub fn with_op_consistency_level(
         mut self,
@@ -672,8 +688,8 @@ impl<'a, S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool, PreloadAll
     }
 }
 
-impl<'a, S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool>
-    StateTableBuilder<'a, S, SD, IS_REPLICATED, bool>
+impl<S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool>
+    StateTableBuilder<S, SD, IS_REPLICATED, bool>
 {
     pub async fn build(self) -> StateTableInner<S, SD, IS_REPLICATED> {
         let mut preload_all_rows = self.preload_all_rows;
@@ -681,7 +697,7 @@ impl<'a, S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool>
             && let Err(e) =
                 risingwave_common::license::Feature::StateTableMemoryPreload.check_available()
         {
-            warn!(table_id=%self.table_catalog.id, e=%e.as_report(), "table configured to preload rows to memory but disabled by license");
+            warn!(table_id=%self.table_id, e=%e.as_report(), "table configured to preload rows to memory but disabled by license");
             preload_all_rows = false;
         }
 
@@ -693,20 +709,8 @@ impl<'a, S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool>
         } else {
             self.enable_vnode_key_stats.unwrap_or(false)
         };
-
-        StateTableInner::from_table_catalog_inner(
-            self.table_catalog,
-            self.store,
-            self.vnodes,
-            self.op_consistency_level
-                .unwrap_or(StateTableOpConsistencyLevel::ConsistentOldValue),
-            self.output_column_ids.unwrap_or_default(),
-            preload_all_rows,
-            should_enable_vnode_key_stats,
-            self.enable_state_table_vnode_stats_pruning,
-            self.metrics,
-        )
-        .await
+        self.build_inner(preload_all_rows, should_enable_vnode_key_stats)
+            .await
     }
 }
 
@@ -746,36 +750,17 @@ where
             .build()
             .await
     }
+}
 
-    /// Create state table from table catalog and store.
-    #[allow(clippy::too_many_arguments)]
-    async fn from_table_catalog_inner(
-        table_catalog: &Table,
-        store: S,
-        vnodes: Option<Arc<Bitmap>>,
-        op_consistency_level: StateTableOpConsistencyLevel,
-        output_column_ids: Vec<ColumnId>,
-        preload_all_rows: bool,
-        enable_vnode_key_stats: bool,
-        enable_state_table_vnode_stats_pruning: bool,
-        metrics: Option<StateTableMetrics>,
-    ) -> Self {
+impl<S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool>
+    StateTableBuilder<S, SD, IS_REPLICATED, ()>
+{
+    pub fn new(table_catalog: &Table, store: S, vnodes: Option<Arc<Bitmap>>) -> Self {
         let table_id = table_catalog.id;
         let table_columns: Vec<ColumnDesc> = table_catalog
             .columns
             .iter()
             .map(|col| col.column_desc.as_ref().unwrap().into())
-            .collect();
-        let data_types: Vec<DataType> = table_catalog
-            .columns
-            .iter()
-            .map(|col| {
-                col.get_column_desc()
-                    .unwrap()
-                    .get_column_type()
-                    .unwrap()
-                    .into()
-            })
             .collect();
         let order_types: Vec<OrderType> = table_catalog
             .pk
@@ -809,14 +794,93 @@ where
             let vnode_col_idx = *idx as usize;
             pk_indices.iter().position(|&i| vnode_col_idx == i)
         });
+        let value_indices = table_catalog
+            .value_indices
+            .iter()
+            .map(|val| *val as usize)
+            .collect_vec();
+        let clean_watermark_indices = table_catalog.get_clean_watermark_column_indices();
+        if clean_watermark_indices.len() > 1 {
+            unimplemented!("multiple clean watermark columns are not supported yet")
+        }
+        let clean_watermark_index = clean_watermark_indices.first().map(|&i| i as usize);
+
+        Self {
+            table_id,
+            table_name_for_debug: table_catalog.name.clone(),
+            table_columns,
+            order_types,
+            pk_indices,
+            dist_key_in_pk_indices,
+            vnode_col_idx_in_pk,
+            expected_vnode_count: table_catalog.vnode_count(),
+            value_indices,
+            prefix_hint_len: table_catalog.read_prefix_len_hint as usize,
+            retention_seconds: table_catalog.retention_seconds,
+            versioned: table_catalog.version.is_some(),
+            fragment_id: table_catalog.fragment_id,
+            clean_watermark_index,
+            store,
+            vnodes,
+            op_consistency_level: None,
+            output_column_ids: None,
+            preload_all_rows: (),
+            enable_vnode_key_stats: None,
+            enable_state_table_vnode_stats_pruning: false,
+            metrics: None,
+            _serde: Default::default(),
+        }
+    }
+}
+
+impl<S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool>
+    StateTableBuilder<S, SD, IS_REPLICATED, bool>
+{
+    async fn build_inner(
+        self,
+        preload_all_rows: bool,
+        should_enable_vnode_key_stats: bool,
+    ) -> StateTableInner<S, SD, IS_REPLICATED> {
+        let table_id = self.table_id;
+        let table_columns = self.table_columns;
+        let order_types = self.order_types;
+        let pk_indices = self.pk_indices;
+        let dist_key_in_pk_indices = self.dist_key_in_pk_indices;
+        let vnode_col_idx_in_pk = self.vnode_col_idx_in_pk;
+        let prefix_hint_len = self.prefix_hint_len;
+        let metrics = self.metrics;
+
+        let op_consistency_level = self
+            .op_consistency_level
+            .unwrap_or(StateTableOpConsistencyLevel::ConsistentOldValue);
+
+        let output_column_ids = self.output_column_ids.unwrap_or_default();
+
+        let data_types: Vec<DataType> = table_columns
+            .iter()
+            .map(|col| col.data_type.clone())
+            .collect();
+
+        // For replicated state tables (used in hash temporal join), the join key (pk_prefix) is
+        // guaranteed by the optimizer to cover the distribution key, which is required by
+        // `compute_prefix_vnode`. Assert this invariant at build time.
+        if IS_REPLICATED && prefix_hint_len > 0 {
+            assert!(
+                dist_key_in_pk_indices.iter().all(|&d| d < prefix_hint_len),
+                "replicated state table: distribution key indices {:?} must all be covered by \
+                 prefix_hint_len {}",
+                dist_key_in_pk_indices,
+                prefix_hint_len,
+            );
+        }
 
         let distribution =
-            TableDistribution::new(vnodes, dist_key_in_pk_indices, vnode_col_idx_in_pk);
+            TableDistribution::new(self.vnodes, dist_key_in_pk_indices, vnode_col_idx_in_pk);
         assert_eq!(
             distribution.vnode_count(),
-            table_catalog.vnode_count(),
+            self.expected_vnode_count,
             "vnode count mismatch, scanning table {} under wrong distribution?",
-            table_catalog.name,
+            self.table_name_for_debug,
         );
 
         let pk_data_types = pk_indices
@@ -825,11 +889,7 @@ where
             .collect();
         let pk_serde = OrderedRowSerde::new(pk_data_types, order_types);
 
-        let input_value_indices = table_catalog
-            .value_indices
-            .iter()
-            .map(|val| *val as usize)
-            .collect_vec();
+        let input_value_indices = self.value_indices;
 
         let no_shuffle_value_indices = (0..table_columns.len()).collect_vec();
 
@@ -838,17 +898,16 @@ where
             && input_value_indices == no_shuffle_value_indices
         {
             true => None,
-            false => Some(input_value_indices),
+            false => Some(input_value_indices.clone()),
         };
-        let prefix_hint_len = table_catalog.read_prefix_len_hint as usize;
 
         let row_serde = Arc::new(SD::new(
-            Arc::from_iter(table_catalog.value_indices.iter().map(|val| *val as usize)),
+            Arc::from_iter(input_value_indices.iter().copied()),
             Arc::from(table_columns.clone().into_boxed_slice()),
         ));
 
         let state_table_op_consistency_level = op_consistency_level;
-        let op_consistency_level = match op_consistency_level {
+        let op_consistency_level = match state_table_op_consistency_level {
             StateTableOpConsistencyLevel::Inconsistent => OpConsistencyLevel::Inconsistent,
             StateTableOpConsistencyLevel::ConsistentOldValue => {
                 consistent_old_value_op(row_serde.clone(), false)
@@ -858,11 +917,11 @@ where
             }
         };
 
-        let table_option = TableOption::new(table_catalog.retention_seconds);
+        let table_option = TableOption::new(self.retention_seconds);
         let new_local_options = if IS_REPLICATED {
             NewLocalOptions::new_replicated(
                 table_id,
-                table_catalog.fragment_id,
+                self.fragment_id,
                 op_consistency_level,
                 table_option,
                 distribution.vnodes().clone(),
@@ -870,24 +929,21 @@ where
         } else {
             NewLocalOptions::new(
                 table_id,
-                table_catalog.fragment_id,
+                self.fragment_id,
                 op_consistency_level,
                 table_option,
                 distribution.vnodes().clone(),
                 true,
             )
         };
-        let local_state_store = store.new_local(new_local_options).await;
+        let local_state_store = self.store.new_local(new_local_options).await;
 
         // If state table has versioning, that means it supports
         // Schema change. In that case, the row encoding should be column aware as well.
         // Otherwise both will be false.
         // NOTE(kwannoel): Replicated table will follow upstream table's versioning. I'm not sure
         // If ALTER TABLE will propagate to this replicated table as well. Ideally it won't
-        assert_eq!(
-            table_catalog.version.is_some(),
-            row_serde.kind().is_column_aware()
-        );
+        assert_eq!(self.versioned, row_serde.kind().is_column_aware());
 
         // Get info for replicated state table.
         let output_column_ids_to_input_idx = output_column_ids
@@ -896,12 +952,7 @@ where
             .map(|(pos, id)| (*id, pos))
             .collect::<HashMap<_, _>>();
 
-        // Compute column descriptions
-        let columns: Vec<ColumnDesc> = table_catalog
-            .columns
-            .iter()
-            .map(|c| c.column_desc.as_ref().unwrap().into())
-            .collect_vec();
+        let columns = table_columns;
 
         // Compute i2o mapping
         // Note that this can be a partial mapping, since we use the i2o mapping to get
@@ -917,11 +968,19 @@ where
 
         // Compute output indices
         let (_, output_indices) = find_columns_by_ids(&columns[..], &output_column_ids);
-        let clean_watermark_indices = table_catalog.get_clean_watermark_column_indices();
-        if clean_watermark_indices.len() > 1 {
-            unimplemented!("multiple clean watermark columns are not supported yet")
+
+        // For replicated state tables, pk columns must be explicitly provided by the write caller
+        // rather than being filled with None internally via i2o_mapping.
+        if IS_REPLICATED {
+            assert!(
+                pk_indices
+                    .iter()
+                    .all(|&pk_idx| output_indices.contains(&pk_idx)),
+                "all pk columns must be included in output_column_ids for replicated state table"
+            );
         }
-        let clean_watermark_index = clean_watermark_indices.first().map(|&i| i as usize);
+
+        let clean_watermark_index = self.clean_watermark_index;
         let watermark_serde = clean_watermark_index.map(|idx| {
             let pk_idx = pk_indices.iter().position(|&i| i == idx);
             let (watermark_serde, watermark_serde_type) = match pk_idx {
@@ -966,7 +1025,7 @@ where
             None
         };
 
-        Self {
+        StateTableInner {
             table_id,
             row_store: StateTableRowStore {
                 all_rows: preload_all_rows.then(HashMap::new),
@@ -975,11 +1034,11 @@ where
                 pk_serde: pk_serde.clone(),
                 table_id,
                 // Need to maintain vnode min/max key stats when vnode key pruning is enabled
-                vnode_stats: enable_vnode_key_stats.then(HashMap::new),
-                enable_state_table_vnode_stats_pruning,
+                vnode_stats: should_enable_vnode_key_stats.then(HashMap::new),
+                enable_state_table_vnode_stats_pruning: self.enable_state_table_vnode_stats_pruning,
                 metrics,
             },
-            store,
+            store: self.store,
             epoch: None,
             pk_serde,
             pk_indices,
@@ -997,7 +1056,77 @@ where
             on_post_commit: false,
         }
     }
+}
 
+impl<S: StateStore, SD: ValueRowSerde, const IS_REPLICATED: bool>
+    StateTableBuilder<S, SD, IS_REPLICATED, ()>
+{
+    pub fn new_from_storage_table_desc(
+        table_desc: &StorageTableDesc,
+        store: S,
+        vnodes: Option<Arc<Bitmap>>,
+        fragment_id: u32,
+    ) -> Self {
+        let table_id = table_desc.table_id;
+        let table_columns: Vec<ColumnDesc> =
+            table_desc.columns.iter().map(ColumnDesc::from).collect();
+        let order_types: Vec<OrderType> = table_desc
+            .pk
+            .iter()
+            .map(|col_order| OrderType::from_protobuf(col_order.get_order_type().unwrap()))
+            .collect();
+        let pk_indices = table_desc
+            .pk
+            .iter()
+            .map(|col_order| col_order.column_index as usize)
+            .collect_vec();
+        let dist_key_in_pk_indices = table_desc
+            .dist_key_in_pk_indices
+            .iter()
+            .map(|&idx| idx as usize)
+            .collect();
+        // StorageTableDesc provides vnode_col_idx_in_pk directly (already pk-relative),
+        // unlike Table which has an absolute column index that needs conversion.
+        let vnode_col_idx_in_pk = table_desc.vnode_col_idx_in_pk.map(|k| k as usize);
+        let raw_value_indices = table_desc
+            .value_indices
+            .iter()
+            .map(|val| *val as usize)
+            .collect_vec();
+
+        Self {
+            table_id,
+            table_name_for_debug: table_id.to_string(),
+            table_columns,
+            order_types,
+            pk_indices,
+            dist_key_in_pk_indices,
+            vnode_col_idx_in_pk,
+            expected_vnode_count: table_desc.vnode_count(),
+            value_indices: raw_value_indices,
+            prefix_hint_len: table_desc.read_prefix_len_hint as usize,
+            retention_seconds: table_desc.retention_seconds,
+            versioned: table_desc.versioned,
+            fragment_id: fragment_id.into(),
+            clean_watermark_index: None,
+            store,
+            vnodes,
+            op_consistency_level: None,
+            output_column_ids: None,
+            preload_all_rows: (),
+            enable_vnode_key_stats: None,
+            enable_state_table_vnode_stats_pruning: false,
+            metrics: None,
+            _serde: Default::default(),
+        }
+    }
+}
+
+impl<S, SD, const IS_REPLICATED: bool> StateTableInner<S, SD, IS_REPLICATED>
+where
+    S: StateStore,
+    SD: ValueRowSerde,
+{
     pub fn get_data_types(&self) -> &[DataType] {
         &self.data_types
     }
@@ -2142,7 +2271,7 @@ where
 
         // Construct prefix hint for prefix bloom filter.
         let pk_prefix_indices = &self.pk_indices[..pk_prefix.len()];
-        if self.prefix_hint_len != 0 {
+        if self.prefix_hint_len != 0 && !IS_REPLICATED {
             debug_assert_eq!(self.prefix_hint_len, pk_prefix.len());
         }
         let prefix_hint = {

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -2438,15 +2438,15 @@ fn fill_non_output_indices(
     data_types: &[DataType],
     chunk: StreamChunk,
 ) -> StreamChunk {
-    let cardinality = chunk.cardinality();
     let (ops, columns, vis) = chunk.into_inner();
+    let capacity = vis.len();
     let mut full_columns = Vec::with_capacity(data_types.len());
     for (i, data_type) in data_types.iter().enumerate() {
         if let Some(j) = i2o_mapping.try_map(i) {
             full_columns.push(columns[j].clone());
         } else {
-            let mut column_builder = ArrayImplBuilder::with_type(cardinality, data_type.clone());
-            column_builder.append_n_null(cardinality);
+            let mut column_builder = ArrayImplBuilder::with_type(capacity, data_type.clone());
+            column_builder.append_n_null(capacity);
             let column: ArrayRef = column_builder.finish().into();
             full_columns.push(column)
         }
@@ -2488,6 +2488,32 @@ mod tests {
             +---+---+---+-----+
             | + | 2 |   | 222 |
             +---+---+---+-----+
+             }"#]],
+        );
+    }
+
+    #[test]
+    fn test_fill_non_output_indices_with_invisible_rows() {
+        let data_types = vec![DataType::Int32, DataType::Int32, DataType::Int32];
+        let replicated_chunk = [
+            OwnedRow::new(vec![Some(222_i32.into()), Some(2_i32.into())]),
+            OwnedRow::new(vec![Some(333_i32.into()), Some(3_i32.into())]),
+        ];
+        let (columns, _) =
+            DataChunk::from_rows(&replicated_chunk, &[DataType::Int32, DataType::Int32])
+                .into_parts();
+        let replicated_chunk = StreamChunk::with_visibility(
+            vec![Op::Insert, Op::Insert],
+            columns,
+            Bitmap::from_iter([false, false]),
+        );
+        let i2o_mapping = ColIndexMapping::new(vec![Some(1), None, Some(0)], 2);
+        let filled_chunk = fill_non_output_indices(&i2o_mapping, &data_types, replicated_chunk);
+        check(
+            filled_chunk,
+            expect![[r#"
+            StreamChunk { cardinality: 0, capacity: 2, data:
+            (empty)
              }"#]],
         );
     }

--- a/src/stream/src/common/table/test_state_table.rs
+++ b/src/stream/src/common/table/test_state_table.rs
@@ -1580,7 +1580,7 @@ async fn test_replicated_state_table_replication() {
             .await
             .unwrap();
         let replicated_iter = replicated_state_table
-            .iter_with_vnode_and_output_indices(SINGLETON_VNODE, &range_bounds, Default::default())
+            .iter_with_vnode(SINGLETON_VNODE, &range_bounds, Default::default())
             .await
             .unwrap();
         pin_mut!(iter);
@@ -1648,7 +1648,7 @@ async fn test_replicated_state_table_replication() {
             std::ops::Bound::Unbounded,
         );
         let replicated_iter = replicated_state_table
-            .iter_with_vnode_and_output_indices(SINGLETON_VNODE, &range_bounds, Default::default())
+            .iter_with_vnode(SINGLETON_VNODE, &range_bounds, Default::default())
             .await
             .unwrap();
         pin_mut!(iter);
@@ -1679,7 +1679,7 @@ async fn test_replicated_state_table_replication() {
         let range_bounds: (Bound<OwnedRow>, Bound<OwnedRow>) =
             (std::ops::Bound::Unbounded, std::ops::Bound::Unbounded);
         let replicated_iter = replicated_state_table
-            .iter_with_vnode_and_output_indices(SINGLETON_VNODE, &range_bounds, Default::default())
+            .iter_with_vnode(SINGLETON_VNODE, &range_bounds, Default::default())
             .await
             .unwrap();
         pin_mut!(replicated_iter);

--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -773,10 +773,10 @@ where
                 vnode = ?vnode,
                 current_pos = ?current_pos,
                 range_bounds = ?range_bounds,
-                "iter_with_vnode_and_output_indices"
+                "iter_with_vnode"
             );
             let vnode_row_iter = upstream_table
-                .iter_with_vnode_and_output_indices(
+                .iter_with_vnode(
                     vnode,
                     &range_bounds,
                     PrefetchOptions::prefetch_for_small_range_scan(),

--- a/src/stream/src/executor/lookup.rs
+++ b/src/stream/src/executor/lookup.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use async_trait::async_trait;
+use risingwave_storage::row_serde::value_serde::ValueRowSerde;
 
 mod cache;
 mod sides;
@@ -33,14 +34,14 @@ mod tests;
 ///
 /// The output schema is `| stream columns | arrangement columns |`.
 /// The input is required to be first stream and then arrangement.
-pub struct LookupExecutor<S: StateStore> {
+pub struct LookupExecutor<S: StateStore, SD: ValueRowSerde> {
     ctx: ActorContextRef,
 
     /// the data types of the produced data chunk inside lookup (before reordering)
     chunk_data_types: Vec<DataType>,
 
     /// The join side of the arrangement
-    arrangement: ArrangeJoinSide<S>,
+    arrangement: ArrangeJoinSide<S, SD>,
 
     /// The join side of the stream
     stream: StreamJoinSide,
@@ -50,9 +51,6 @@ pub struct LookupExecutor<S: StateStore> {
 
     /// The executor for stream.
     stream_executor: Option<Executor>,
-
-    /// The last received barrier.
-    last_barrier: Option<Barrier>,
 
     /// Information of column reordering
     column_mapping: Vec<usize>,
@@ -75,7 +73,7 @@ pub struct LookupExecutor<S: StateStore> {
 }
 
 #[async_trait]
-impl<S: StateStore> Execute for LookupExecutor<S> {
+impl<S: StateStore, SD: ValueRowSerde> Execute for LookupExecutor<S, SD> {
     fn execute(self: Box<Self>) -> BoxedMessageStream {
         self.execute_inner().boxed()
     }

--- a/src/stream/src/executor/lookup/cache.rs
+++ b/src/stream/src/executor/lookup/cache.rs
@@ -70,11 +70,6 @@ impl LookupCache {
         self.data.len()
     }
 
-    /// Clear the cache.
-    pub fn clear(&mut self) {
-        self.data.clear();
-    }
-
     pub fn new(watermark_sequence: AtomicU64Ref, metrics_info: MetricsInfo) -> Self {
         let cache = ManagedLruCache::unbounded(watermark_sequence, metrics_info);
         Self { data: cache }

--- a/src/stream/src/executor/lookup/impl_.rs
+++ b/src/stream/src/executor/lookup/impl_.rs
@@ -12,21 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ops::Bound;
+
+use futures::TryStreamExt;
 use itertools::Itertools;
 use risingwave_common::catalog::ColumnDesc;
 use risingwave_common::row::RowExt;
-use risingwave_common::util::epoch::EpochPair;
 use risingwave_common::util::iter_util::ZipEqDebug;
 use risingwave_common::util::sort_util::ColumnOrder;
 use risingwave_common_estimate_size::collections::EstimatedVec;
-use risingwave_hummock_sdk::HummockReadEpoch;
+use risingwave_storage::row_serde::value_serde::ValueRowSerde;
 use risingwave_storage::store::PrefetchOptions;
-use risingwave_storage::table::TableIter;
-use risingwave_storage::table::batch_table::BatchTable;
 
 use super::sides::{stream_lookup_arrange_prev_epoch, stream_lookup_arrange_this_epoch};
-use crate::cache::keyed_cache_may_stale;
 use crate::common::metrics::MetricsInfo;
+use crate::common::table::state_table::ReplicatedStateTable;
 use crate::executor::join::builder::JoinStreamChunkBuilder;
 use crate::executor::lookup::LookupExecutor;
 use crate::executor::lookup::cache::LookupCache;
@@ -35,7 +35,7 @@ use crate::executor::monitor::LookupExecutorMetrics;
 use crate::executor::prelude::*;
 
 /// Parameters for [`LookupExecutor`].
-pub struct LookupExecutorParams<S: StateStore> {
+pub struct LookupExecutorParams<S: StateStore, SD: ValueRowSerde> {
     pub ctx: ActorContextRef,
     pub info: ExecutorInfo,
 
@@ -89,15 +89,15 @@ pub struct LookupExecutorParams<S: StateStore> {
     /// The join keys on the arrangement side.
     pub arrange_join_key_indices: Vec<usize>,
 
-    pub batch_table: BatchTable<S>,
+    pub state_table: ReplicatedStateTable<S, SD>,
 
     pub watermark_epoch: AtomicU64Ref,
 
     pub chunk_size: usize,
 }
 
-impl<S: StateStore> LookupExecutor<S> {
-    pub fn new(params: LookupExecutorParams<S>) -> Self {
+impl<S: StateStore, SD: ValueRowSerde> LookupExecutor<S, SD> {
+    pub fn new(params: LookupExecutorParams<S, SD>) -> Self {
         let LookupExecutorParams {
             ctx,
             info,
@@ -109,7 +109,7 @@ impl<S: StateStore> LookupExecutor<S> {
             stream_join_key_indices,
             arrange_join_key_indices,
             column_mapping,
-            batch_table: storage_table,
+            state_table: storage_table,
             watermark_epoch,
             chunk_size,
         } = params;
@@ -194,7 +194,6 @@ impl<S: StateStore> LookupExecutor<S> {
         Self {
             ctx,
             chunk_data_types,
-            last_barrier: None,
             stream_executor: Some(stream),
             arrangement_executor: Some(arrangement),
             stream: StreamJoinSide {
@@ -209,7 +208,7 @@ impl<S: StateStore> LookupExecutor<S> {
                 order_rules: arrangement_order_rules,
                 key_indices: arrange_join_key_indices,
                 use_current_epoch,
-                batch_table: storage_table,
+                state_table: storage_table,
             },
             column_mapping,
             key_indices_mapping,
@@ -225,22 +224,26 @@ impl<S: StateStore> LookupExecutor<S> {
     /// If we can use `async_stream` to write this part, things could be easier.
     #[try_stream(ok = Message, error = StreamExecutorError)]
     pub async fn execute_inner(mut self: Box<Self>) {
+        let mut stream_input = self.stream_executor.take().unwrap().execute();
+        let mut arrangement_input = self.arrangement_executor.take().unwrap().execute();
+
+        let first_barrier = expect_first_barrier(&mut stream_input).await?;
+        let arrangement_first_barrier = expect_first_barrier(&mut arrangement_input).await?;
+        if first_barrier.epoch != arrangement_first_barrier.epoch {
+            return Err(StreamExecutorError::align_barrier(
+                first_barrier.clone(),
+                arrangement_first_barrier,
+            ));
+        }
+
         let input = if self.arrangement.use_current_epoch {
-            stream_lookup_arrange_this_epoch(
-                self.stream_executor.take().unwrap(),
-                self.arrangement_executor.take().unwrap(),
-            )
-            .boxed()
+            stream_lookup_arrange_this_epoch(stream_input, arrangement_input).boxed()
         } else {
-            stream_lookup_arrange_prev_epoch(
-                self.stream_executor.take().unwrap(),
-                self.arrangement_executor.take().unwrap(),
-            )
-            .boxed()
+            stream_lookup_arrange_prev_epoch(stream_input, arrangement_input).boxed()
         };
 
         let metrics = self.ctx.streaming_metrics.new_lookup_executor_metrics(
-            self.arrangement.batch_table.table_id(),
+            self.arrangement.state_table.table_id(),
             self.ctx.id,
             self.ctx.fragment_id,
         );
@@ -257,24 +260,40 @@ impl<S: StateStore> LookupExecutor<S> {
             .map(|x| self.chunk_data_types[*x].clone())
             .collect_vec();
 
+        // Yield the barrier before init_epoch: init_epoch calls wait_for_epoch(epoch.prev)
+        // which blocks until the previous epoch is committed, and that requires all actors
+        // to have already forwarded this barrier downstream.
+        yield Message::Barrier(first_barrier.clone());
+        self.arrangement
+            .state_table
+            .init_epoch(first_barrier.epoch)
+            .await?;
+
         #[for_await]
         for msg in input {
             let msg = msg?;
             self.lookup_cache.evict();
             match msg {
                 ArrangeMessage::Barrier(barrier) => {
-                    self.process_barrier(&barrier);
+                    barrier.assume_no_update_vnode_bitmap(self.ctx.id)?;
+                    self.arrangement
+                        .state_table
+                        .commit_assert_no_update_vnode_bitmap(barrier.epoch)
+                        .await?;
 
                     if self.arrangement.use_current_epoch {
                         // When lookup this epoch, stream side barrier always come after arrangement
                         // ready, so we can forward barrier now.
-                        yield Message::Barrier(barrier);
+                        yield Message::Barrier(barrier.clone());
                     }
                 }
                 ArrangeMessage::ArrangeReady(arrangement_chunks, barrier) => {
                     // The arrangement is ready, and we will receive a bunch of stream messages for
                     // the next poll.
                     // TODO: apply chunk as soon as we receive them, instead of batching.
+                    for chunk in &arrangement_chunks {
+                        self.arrangement.state_table.write_chunk(chunk.clone());
+                    }
 
                     for chunk in arrangement_chunks {
                         self.lookup_cache
@@ -299,14 +318,7 @@ impl<S: StateStore> LookupExecutor<S> {
                     );
 
                     for (op, row) in ops.iter().zip_eq_debug(chunk.rows()) {
-                        for matched_row in self
-                            .lookup_one_row(
-                                &row,
-                                self.last_barrier.as_ref().unwrap().epoch,
-                                &metrics,
-                            )
-                            .await?
-                        {
+                        for matched_row in self.lookup_one_row(&row, &metrics).await? {
                             tracing::debug!(target: "events::stream::lookup::put", "{:?} {:?}", row, matched_row);
 
                             if let Some(chunk) = builder.append_row(*op, row, &matched_row) {
@@ -324,29 +336,10 @@ impl<S: StateStore> LookupExecutor<S> {
         }
     }
 
-    /// Process the barrier and apply changes if necessary.
-    fn process_barrier(&mut self, barrier: &Barrier) {
-        if let Some(vnode_bitmap) = barrier.as_update_vnode_bitmap(self.ctx.id) {
-            let previous_vnode_bitmap = self
-                .arrangement
-                .batch_table
-                .update_vnode_bitmap(vnode_bitmap.clone());
-
-            // Manipulate the cache if necessary.
-            if keyed_cache_may_stale(&previous_vnode_bitmap, &vnode_bitmap) {
-                self.lookup_cache.clear();
-            }
-        }
-
-        // Use the new stream barrier epoch as new cache epoch
-        self.last_barrier = Some(barrier.clone());
-    }
-
-    /// Lookup all rows corresponding to a join key in shared buffer.
+    /// Lookup all rows corresponding to a join key in the replicated state table.
     async fn lookup_one_row(
         &mut self,
         stream_row: &RowRef<'_>,
-        epoch_pair: EpochPair,
         metrics: &LookupExecutorMetrics,
     ) -> StreamExecutorResult<Vec<OwnedRow>> {
         // stream_row is the row from stream side, we need to transform into the correct order of
@@ -366,38 +359,19 @@ impl<S: StateStore> LookupExecutor<S> {
         tracing::debug!(target: "events::stream::lookup::lookup_row", "{:?}", lookup_row);
 
         let mut all_rows = EstimatedVec::new();
-        // Drop the stream.
         {
-            let all_data_iter = match self.arrangement.use_current_epoch {
-                true => {
-                    self.arrangement
-                        .batch_table
-                        .batch_iter_with_pk_bounds(
-                            HummockReadEpoch::NoWait(epoch_pair.curr),
-                            &lookup_row,
-                            ..,
-                            false,
-                            PrefetchOptions::default(),
-                        )
-                        .await?
-                }
-                false => {
-                    self.arrangement
-                        .batch_table
-                        .batch_iter_with_pk_bounds(
-                            HummockReadEpoch::NoWait(epoch_pair.prev),
-                            &lookup_row,
-                            ..,
-                            false,
-                            PrefetchOptions::default(),
-                        )
-                        .await?
-                }
-            };
+            let all_data_iter = self
+                .arrangement
+                .state_table
+                .iter_with_prefix(
+                    &lookup_row,
+                    &(Bound::<OwnedRow>::Unbounded, Bound::<OwnedRow>::Unbounded),
+                    PrefetchOptions::default(),
+                )
+                .await?;
 
             pin_mut!(all_data_iter);
-            while let Some(row) = all_data_iter.next_row().await? {
-                // Only need value (include storage pk).
+            while let Some(row) = all_data_iter.try_next().await? {
                 all_rows.push(row);
             }
         }

--- a/src/stream/src/executor/lookup/sides.rs
+++ b/src/stream/src/executor/lookup/sides.rs
@@ -25,10 +25,11 @@ use risingwave_common::catalog::ColumnDesc;
 use risingwave_common::types::DataType;
 use risingwave_common::util::sort_util::ColumnOrder;
 use risingwave_storage::StateStore;
-use risingwave_storage::table::batch_table::BatchTable;
+use risingwave_storage::row_serde::value_serde::ValueRowSerde;
 
+use crate::common::table::state_table::ReplicatedStateTable;
 use crate::executor::error::StreamExecutorError;
-use crate::executor::{Barrier, BoxedMessageStream, Executor, Message, MessageStream};
+use crate::executor::{Barrier, BoxedMessageStream, Message, MessageStream};
 
 /// Join side of Lookup Executor's stream
 pub(crate) struct StreamJoinSide {
@@ -53,7 +54,7 @@ impl std::fmt::Debug for StreamJoinSide {
 }
 
 /// Join side of Arrange Executor's stream
-pub(crate) struct ArrangeJoinSide<S: StateStore> {
+pub(crate) struct ArrangeJoinSide<S: StateStore, SD: ValueRowSerde> {
     /// The primary key indices of this side, used for state store
     pub pk_indices: Vec<usize>,
 
@@ -76,7 +77,7 @@ pub(crate) struct ArrangeJoinSide<S: StateStore> {
     /// Whether to join with the arrangement of the current epoch
     pub use_current_epoch: bool,
 
-    pub batch_table: BatchTable<S>,
+    pub state_table: ReplicatedStateTable<S, SD>,
 }
 
 /// Message from the `arrange_join_stream`.
@@ -211,8 +212,11 @@ pub async fn align_barrier(mut left: BoxedMessageStream, mut right: BoxedMessage
 /// * Barrier (prev = `[2`], current = `[3`])
 /// * `[Msg`] Arrangement (batch)
 #[try_stream(ok = ArrangeMessage, error = StreamExecutorError)]
-pub async fn stream_lookup_arrange_prev_epoch(stream: Executor, arrangement: Executor) {
-    let mut input = pin!(align_barrier(stream.execute(), arrangement.execute()));
+pub async fn stream_lookup_arrange_prev_epoch(
+    stream: BoxedMessageStream,
+    arrangement: BoxedMessageStream,
+) {
+    let mut input = pin!(align_barrier(stream, arrangement));
     let mut arrange_buf = vec![];
     let mut stream_side_end = false;
 
@@ -292,8 +296,11 @@ pub async fn stream_lookup_arrange_prev_epoch(stream: Executor, arrangement: Exe
 /// * `[Do`] lookup `a` in arrangement of epoch `[2`] (current epoch)
 /// * Barrier (prev = `[2`], current = `[3`])
 #[try_stream(ok = ArrangeMessage, error = StreamExecutorError)]
-pub async fn stream_lookup_arrange_this_epoch(stream: Executor, arrangement: Executor) {
-    let mut input = pin!(align_barrier(stream.execute(), arrangement.execute()));
+pub async fn stream_lookup_arrange_this_epoch(
+    stream: BoxedMessageStream,
+    arrangement: BoxedMessageStream,
+) {
+    let mut input = pin!(align_barrier(stream, arrangement));
     let mut stream_buf = vec![];
     let mut arrange_buf = vec![];
 
@@ -390,7 +397,7 @@ pub async fn stream_lookup_arrange_this_epoch(stream: Executor, arrangement: Exe
     }
 }
 
-impl<S: StateStore> std::fmt::Debug for ArrangeJoinSide<S> {
+impl<S: StateStore, SD: ValueRowSerde> std::fmt::Debug for ArrangeJoinSide<S, SD> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ArrangeJoinSide")
             .field("pk_indices", &self.pk_indices)
@@ -436,7 +443,8 @@ mod tests {
             .stop_on_finish(false)
             .into_executor(schema, vec![1]);
 
-        let mut stream = stream_lookup_arrange_this_epoch(source_l, source_r).boxed();
+        let mut stream =
+            stream_lookup_arrange_this_epoch(source_l.execute(), source_r.execute()).boxed();
 
         // Simulate recovery test
         drop(tx_r);

--- a/src/stream/src/executor/lookup/tests.rs
+++ b/src/stream/src/executor/lookup/tests.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 
@@ -24,9 +25,12 @@ use risingwave_common::catalog::{ColumnDesc, ConflictBehavior, Field, Schema, Ta
 use risingwave_common::types::DataType;
 use risingwave_common::util::epoch::test_epoch;
 use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
-use risingwave_storage::memory::MemoryStateStore;
-use risingwave_storage::table::batch_table::BatchTable;
+use risingwave_common::util::value_encoding::BasicSerde;
+use risingwave_hummock_test::test_utils::prepare_hummock_test_env;
+use risingwave_storage::StateStore;
+use risingwave_storage::hummock::HummockStorage;
 
+use crate::common::table::state_table::{StateTableBuilder, StateTableOpConsistencyLevel};
 use crate::executor::lookup::LookupExecutor;
 use crate::executor::lookup::impl_::LookupExecutorParams;
 use crate::executor::test_utils::*;
@@ -69,7 +73,7 @@ fn arrangement_col_arrange_rules_join_key() -> Vec<ColumnOrder> {
 /// | +  | 2337  | 8    | 3       |
 /// | -  | 2333  | 6    | 3       |
 /// | b  |       |      | 3 -> 4  |
-async fn create_arrangement(table_id: TableId, memory_state_store: MemoryStateStore) -> Executor {
+async fn create_arrangement<S: StateStore>(table_id: TableId, store: S) -> Executor {
     // Two columns of int32 type, the second column is arrange key.
     let columns = arrangement_col_descs();
 
@@ -117,7 +121,7 @@ async fn create_arrangement(table_id: TableId, memory_state_store: MemoryStateSt
         ),
         MaterializeExecutor::for_test(
             source,
-            memory_state_store,
+            store,
             table_id,
             arrangement_col_arrange_rules(),
             column_ids,
@@ -182,12 +186,66 @@ fn check_chunk_eq(chunk1: &StreamChunk, chunk2: &StreamChunk) {
     assert_eq!(format!("{:?}", chunk1), format!("{:?}", chunk2));
 }
 
+fn create_storage_table_desc(table_id: TableId) -> risingwave_pb::plan_common::StorageTableDesc {
+    let col_descs = arrangement_col_descs();
+    let order_rules = arrangement_col_arrange_rules();
+    risingwave_pb::plan_common::StorageTableDesc {
+        table_id,
+        columns: col_descs.iter().map(|c| c.to_protobuf()).collect(),
+        pk: order_rules.iter().map(|o| o.to_protobuf()).collect(),
+        dist_key_in_pk_indices: vec![],
+        value_indices: vec![0, 1],
+        read_prefix_len_hint: 0,
+        versioned: false,
+        stream_key: vec![1, 0],
+        vnode_col_idx_in_pk: None,
+        retention_seconds: None,
+        maybe_vnode_count: None,
+    }
+}
+
+async fn create_replicated_state_table<S: StateStore>(
+    store: S,
+    table_id: TableId,
+) -> crate::common::table::state_table::ReplicatedStateTable<S, BasicSerde> {
+    let table_desc = create_storage_table_desc(table_id);
+    let column_ids = arrangement_col_descs()
+        .iter()
+        .map(|c| c.column_id)
+        .collect_vec();
+    StateTableBuilder::<_, BasicSerde, true, _>::new_from_storage_table_desc(
+        &table_desc,
+        store,
+        None,
+        0.into(),
+    )
+    .with_op_consistency_level(StateTableOpConsistencyLevel::Inconsistent)
+    .with_output_column_ids(column_ids)
+    .forbid_preload_all_rows()
+    .build()
+    .await
+}
+
+async fn prepare_hummock_store(table_id: TableId) -> HummockStorage {
+    let test_env = prepare_hummock_test_env().await;
+    test_env.register_table_id(table_id).await;
+    // Commit the initial epoch so that init_epoch's wait_for_epoch(prev) returns immediately.
+    test_env
+        .storage
+        .start_epoch(test_epoch(1), HashSet::from_iter([table_id]));
+    test_env.commit_epoch(test_epoch(1)).await;
+    for epoch in [test_epoch(2), test_epoch(3), test_epoch(4)] {
+        test_env
+            .storage
+            .start_epoch(epoch, HashSet::from_iter([table_id]));
+    }
+    test_env.storage
+}
+
 #[tokio::test]
 async fn test_lookup_this_epoch() {
-    // TODO: memory state store doesn't support read epoch yet, so it is possible that this test
-    // fails because read epoch doesn't take effect in memory state store.
-    let store = MemoryStateStore::new();
     let table_id = TableId::new(1);
+    let store = prepare_hummock_store(table_id).await;
     let arrangement = create_arrangement(table_id, store.clone()).await;
     let stream = create_source();
     let info = ExecutorInfo::for_test(
@@ -212,17 +270,7 @@ async fn test_lookup_this_epoch() {
         stream_join_key_indices: vec![0],
         arrange_join_key_indices: vec![1],
         column_mapping: vec![2, 3, 0, 1],
-        batch_table: BatchTable::for_test(
-            store.clone(),
-            table_id,
-            arrangement_col_descs(),
-            arrangement_col_arrange_rules()
-                .iter()
-                .map(|x| x.order_type)
-                .collect_vec(),
-            vec![1, 0],
-            vec![0, 1],
-        ),
+        state_table: create_replicated_state_table(store, table_id).await,
         watermark_epoch: Arc::new(AtomicU64::new(0)),
         chunk_size: 1024,
     }));
@@ -261,8 +309,8 @@ async fn test_lookup_this_epoch() {
 
 #[tokio::test]
 async fn test_lookup_last_epoch() {
-    let store = MemoryStateStore::new();
     let table_id = TableId::new(1);
+    let store = prepare_hummock_store(table_id).await;
     let arrangement = create_arrangement(table_id, store.clone()).await;
     let stream = create_source();
     let info = ExecutorInfo::for_test(
@@ -287,29 +335,22 @@ async fn test_lookup_last_epoch() {
         stream_join_key_indices: vec![0],
         arrange_join_key_indices: vec![1],
         column_mapping: vec![0, 1, 2, 3],
-        batch_table: BatchTable::for_test(
-            store.clone(),
-            table_id,
-            arrangement_col_descs(),
-            arrangement_col_arrange_rules()
-                .iter()
-                .map(|x| x.order_type)
-                .collect_vec(),
-            vec![1, 0],
-            vec![0, 1],
-        ),
+        state_table: create_replicated_state_table(store, table_id).await,
         watermark_epoch: Arc::new(AtomicU64::new(0)),
         chunk_size: 1024,
     }));
     let mut lookup_executor = lookup_executor.execute();
 
     let mut msgs = vec![];
-
     next_msg(&mut msgs, &mut lookup_executor).await;
     next_msg(&mut msgs, &mut lookup_executor).await;
     next_msg(&mut msgs, &mut lookup_executor).await;
     next_msg(&mut msgs, &mut lookup_executor).await;
 
+    // With HummockStateStore, the lookup table is isolated from the arrangement's store.
+    // Stream chunks in epoch 1 see no arrangement data (the lookup table is empty until
+    // the first ArrangeReady writes data). Stream chunks in epoch 2 see arrangement
+    // data replicated from epoch 1, matching the expected prev-epoch semantics.
     assert_eq!(msgs.len(), 4);
     assert_matches!(msgs[0], Message::Barrier(_));
     assert_matches!(msgs[1], Message::Barrier(_));

--- a/src/stream/src/executor/nested_loop_temporal_join.rs
+++ b/src/stream/src/executor/nested_loop_temporal_join.rs
@@ -84,7 +84,7 @@ async fn phase1_handle_chunk<S: StateStore, SD: ValueRowSerde, E: phase1::Phase1
             .then(|vnode| async move {
                 Ok::<_, StreamExecutorError>(Box::pin(
                     source
-                        .iter_with_vnode_and_output_indices(
+                        .iter_with_vnode(
                             vnode,
                             &(Bound::<OwnedRow>::Unbounded, Bound::<OwnedRow>::Unbounded),
                             PrefetchOptions::prefetch_for_large_range_scan(),

--- a/src/stream/src/executor/nested_loop_temporal_join.rs
+++ b/src/stream/src/executor/nested_loop_temporal_join.rs
@@ -13,36 +13,45 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::ops::Bound;
 use std::sync::Arc;
 
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt, pin_mut, stream};
 use futures_async_stream::try_stream;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::array::stream_chunk_builder::StreamChunkBuilder;
 use risingwave_common::bitmap::BitmapBuilder;
+use risingwave_common::hash::VnodeBitmapExt;
+use risingwave_common::row::OwnedRow;
 use risingwave_common::types::DataType;
 use risingwave_common::util::iter_util::ZipEqDebug;
 use risingwave_expr::expr::NonStrictExpression;
-use risingwave_hummock_sdk::{HummockEpoch, HummockReadEpoch};
 use risingwave_storage::StateStore;
+use risingwave_storage::row_serde::value_serde::ValueRowSerde;
 use risingwave_storage::store::PrefetchOptions;
-use risingwave_storage::table::batch_table::BatchTable;
 
 use super::join::{JoinType, JoinTypePrimitive};
-use super::temporal_join::{InternalMessage, align_input, apply_indices_map, phase1};
+use super::temporal_join::{
+    InternalMessage, align_input, apply_indices_map, expect_first_barrier, phase1,
+};
 use super::{Execute, ExecutorInfo, Message, StreamExecutorError};
 use crate::common::metrics::MetricsInfo;
+use crate::common::table::state_table::ReplicatedStateTable;
 use crate::executor::join::builder::JoinStreamChunkBuilder;
 use crate::executor::monitor::StreamingMetrics;
 use crate::executor::{ActorContextRef, Executor};
 
-pub struct NestedLoopTemporalJoinExecutor<S: StateStore, const T: JoinTypePrimitive> {
+pub struct NestedLoopTemporalJoinExecutor<
+    S: StateStore,
+    SD: ValueRowSerde,
+    const T: JoinTypePrimitive,
+> {
     ctx: ActorContextRef,
     #[expect(dead_code)]
     info: ExecutorInfo,
     left: Executor,
     right: Executor,
-    right_table: TemporalSide<S>,
+    right_table: TemporalSide<S, SD>,
     condition: Option<NonStrictExpression>,
     output_indices: Vec<usize>,
     chunk_size: usize,
@@ -51,36 +60,42 @@ pub struct NestedLoopTemporalJoinExecutor<S: StateStore, const T: JoinTypePrimit
     metrics: Arc<StreamingMetrics>,
 }
 
-struct TemporalSide<S: StateStore> {
-    source: BatchTable<S>,
+struct TemporalSide<S: StateStore, SD: ValueRowSerde> {
+    source: ReplicatedStateTable<S, SD>,
 }
 
-impl<S: StateStore> TemporalSide<S> {}
+impl<S: StateStore, SD: ValueRowSerde> TemporalSide<S, SD> {}
 
 #[try_stream(ok = StreamChunk, error = StreamExecutorError)]
-
-async fn phase1_handle_chunk<S: StateStore, E: phase1::Phase1Evaluation>(
+async fn phase1_handle_chunk<S: StateStore, SD: ValueRowSerde, E: phase1::Phase1Evaluation>(
     chunk_size: usize,
     right_size: usize,
     full_schema: Vec<DataType>,
-    epoch: HummockEpoch,
-    right_table: &mut TemporalSide<S>,
+    right_table: &mut TemporalSide<S, SD>,
     chunk: StreamChunk,
 ) {
     let mut builder = StreamChunkBuilder::new(chunk_size, full_schema);
 
     for (op, left_row) in chunk.rows() {
         let mut matched = false;
+        // Create a per-vnode stream for each vnode and flatten them concurrently.
+        let source = &right_table.source;
+        let right_rows = stream::iter(source.vnodes().iter_vnodes())
+            .then(|vnode| async move {
+                Ok::<_, StreamExecutorError>(Box::pin(
+                    source
+                        .iter_with_vnode_and_output_indices(
+                            vnode,
+                            &(Bound::<OwnedRow>::Unbounded, Bound::<OwnedRow>::Unbounded),
+                            PrefetchOptions::prefetch_for_large_range_scan(),
+                        )
+                        .await?,
+                ))
+            })
+            .try_flatten_unordered(None);
+        pin_mut!(right_rows);
         #[for_await]
-        for right_row in right_table
-            .source
-            .batch_iter(
-                HummockReadEpoch::NoWait(epoch),
-                false,
-                PrefetchOptions::prefetch_for_large_range_scan(),
-            )
-            .await?
-        {
+        for right_row in right_rows {
             let right_row = right_row?;
             matched = true;
             if let Some(chunk) = E::append_matched_row(op, &mut builder, left_row, right_row) {
@@ -96,14 +111,16 @@ async fn phase1_handle_chunk<S: StateStore, E: phase1::Phase1Evaluation>(
     }
 }
 
-impl<S: StateStore, const T: JoinTypePrimitive> NestedLoopTemporalJoinExecutor<S, T> {
+impl<S: StateStore, SD: ValueRowSerde, const T: JoinTypePrimitive>
+    NestedLoopTemporalJoinExecutor<S, SD, T>
+{
     #[expect(clippy::too_many_arguments)]
     pub fn new(
         ctx: ActorContextRef,
         info: ExecutorInfo,
         left: Executor,
         right: Executor,
-        table: BatchTable<S>,
+        table: ReplicatedStateTable<S, SD>,
         condition: Option<NonStrictExpression>,
         output_indices: Vec<usize>,
         metrics: Arc<StreamingMetrics>,
@@ -141,8 +158,6 @@ impl<S: StateStore, const T: JoinTypePrimitive> NestedLoopTemporalJoinExecutor<S
 
         let left_to_output: HashMap<usize, usize> = HashMap::from_iter(left_map.iter().cloned());
 
-        let mut prev_epoch = None;
-
         let full_schema: Vec<_> = self
             .left
             .schema()
@@ -151,24 +166,29 @@ impl<S: StateStore, const T: JoinTypePrimitive> NestedLoopTemporalJoinExecutor<S
             .chain(self.right.schema().data_types().into_iter())
             .collect();
 
+        let input = align_input::<true>(self.left, self.right);
+        pin_mut!(input);
+
+        let barrier = expect_first_barrier(&mut input).await?;
+        let barrier_epoch = barrier.epoch;
+        yield Message::Barrier(barrier);
+        self.right_table.source.init_epoch(barrier_epoch).await?;
+
         #[for_await]
-        for msg in align_input::<false>(self.left, self.right) {
+        for msg in input {
             match msg? {
                 InternalMessage::WaterMark(watermark) => {
                     let output_watermark_col_idx = *left_to_output.get(&watermark.col_idx).unwrap();
                     yield Message::Watermark(watermark.with_idx(output_watermark_col_idx));
                 }
                 InternalMessage::Chunk(chunk) => {
-                    let epoch = prev_epoch.expect("Chunk data should come after some barrier.");
-
                     let full_schema = full_schema.clone();
 
                     if T == JoinType::Inner {
-                        let st1 = phase1_handle_chunk::<S, phase1::Inner>(
+                        let st1 = phase1_handle_chunk::<S, SD, phase1::Inner>(
                             self.chunk_size,
                             right_size,
                             full_schema,
-                            epoch,
                             &mut self.right_table,
                             chunk,
                         );
@@ -191,11 +211,10 @@ impl<S: StateStore, const T: JoinTypePrimitive> NestedLoopTemporalJoinExecutor<S
                         }
                     } else if let Some(ref cond) = self.condition {
                         // Joined result without evaluating non-lookup conditions.
-                        let st1 = phase1_handle_chunk::<S, phase1::LeftOuterWithCond>(
+                        let st1 = phase1_handle_chunk::<S, SD, phase1::LeftOuterWithCond>(
                             self.chunk_size,
                             right_size,
                             full_schema,
-                            epoch,
                             &mut self.right_table,
                             chunk,
                         );
@@ -238,11 +257,10 @@ impl<S: StateStore, const T: JoinTypePrimitive> NestedLoopTemporalJoinExecutor<S
                         // The last row should always be marker row,
                         assert_eq!(matched_count, 0);
                     } else {
-                        let st1 = phase1_handle_chunk::<S, phase1::LeftOuter>(
+                        let st1 = phase1_handle_chunk::<S, SD, phase1::LeftOuter>(
                             self.chunk_size,
                             right_size,
                             full_schema,
-                            epoch,
                             &mut self.right_table,
                             chunk,
                         );
@@ -254,20 +272,30 @@ impl<S: StateStore, const T: JoinTypePrimitive> NestedLoopTemporalJoinExecutor<S
                         }
                     }
                 }
-                InternalMessage::Barrier(chunk, barrier) => {
-                    assert!(chunk.is_empty());
-                    if let Some(vnodes) = barrier.as_update_vnode_bitmap(self.ctx.id) {
-                        let _vnodes = self.right_table.source.update_vnode_bitmap(vnodes);
+                InternalMessage::Barrier(updates, barrier) => {
+                    let update_vnode_bitmap = barrier.as_update_vnode_bitmap(self.ctx.id);
+
+                    // Write right-side chunks to the replicated state table
+                    for chunk in updates {
+                        self.right_table.source.write_chunk(chunk);
                     }
-                    prev_epoch = Some(barrier.epoch.curr);
-                    yield Message::Barrier(barrier)
+
+                    let right_post_commit = self.right_table.source.commit(barrier.epoch).await?;
+
+                    yield Message::Barrier(barrier);
+
+                    right_post_commit
+                        .post_yield_barrier(update_vnode_bitmap)
+                        .await?;
                 }
             }
         }
     }
 }
 
-impl<S: StateStore, const T: JoinTypePrimitive> Execute for NestedLoopTemporalJoinExecutor<S, T> {
+impl<S: StateStore, SD: ValueRowSerde, const T: JoinTypePrimitive> Execute
+    for NestedLoopTemporalJoinExecutor<S, SD, T>
+{
     fn execute(self: Box<Self>) -> super::BoxedMessageStream {
         self.into_stream().boxed()
     }

--- a/src/stream/src/executor/temporal_join.rs
+++ b/src/stream/src/executor/temporal_join.rs
@@ -107,7 +107,6 @@ impl JoinEntry {
 struct TemporalSide<K: HashKey, S: StateStore, SD: ValueRowSerde> {
     source: ReplicatedStateTable<S, SD>,
     table_stream_key_indices: Vec<usize>,
-    table_output_indices: Vec<usize>,
     cache: ManagedLruCache<K, JoinEntry>,
     join_key_data_types: Vec<DataType>,
 }
@@ -148,7 +147,7 @@ impl<K: HashKey, S: StateStore, SD: ValueRowSerde> TemporalSide<K, S, SD> {
                             row.as_ref()
                                 .project(&self.table_stream_key_indices)
                                 .into_owned_row(),
-                            row.project(&self.table_output_indices).into_owned_row(),
+                            row,
                         );
                     }
                     let key = key.clone();
@@ -623,7 +622,6 @@ impl<
         null_safe: Vec<bool>,
         condition: Option<NonStrictExpression>,
         output_indices: Vec<usize>,
-        table_output_indices: Vec<usize>,
         table_stream_key_indices: Vec<usize>,
         watermark_sequence: AtomicU64Ref,
         metrics: Arc<StreamingMetrics>,
@@ -646,7 +644,6 @@ impl<
             right_table: TemporalSide {
                 source: table,
                 table_stream_key_indices,
-                table_output_indices,
                 cache,
                 join_key_data_types,
             },
@@ -1016,9 +1013,6 @@ mod tests {
         let (mut right_tx, right_source) = MockSource::channel();
         let right_executor = right_source.into_executor(right_schema.clone(), vec![0, 1]);
 
-        // table_output_indices: indices in right table output rows that form the output.
-        // All 3 columns are selected.
-        let table_output_indices = vec![0usize, 1, 2];
         // table_stream_key_indices: pk of right table within the output row = [0, 1] (key, seq).
         let table_stream_key_indices = vec![0usize, 1];
 
@@ -1056,7 +1050,6 @@ mod tests {
             null_safe,
             None, // no extra non-equi condition
             output_indices,
-            table_output_indices,
             table_stream_key_indices,
             Arc::new(AtomicU64::new(0)),
             Arc::new(StreamingMetrics::unused()),

--- a/src/stream/src/executor/temporal_join.rs
+++ b/src/stream/src/executor/temporal_join.rs
@@ -14,7 +14,9 @@
 
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
+use std::ops::Bound;
 
+use anyhow::Context;
 use either::Either;
 use futures::TryStreamExt;
 use futures::stream::{self, PollNext};
@@ -26,21 +28,21 @@ use risingwave_common::row::RowExt;
 use risingwave_common::util::iter_util::ZipEqDebug;
 use risingwave_common_estimate_size::{EstimateSize, KvSize};
 use risingwave_expr::expr::NonStrictExpression;
-use risingwave_hummock_sdk::{HummockEpoch, HummockReadEpoch};
+use risingwave_storage::row_serde::value_serde::ValueRowSerde;
 use risingwave_storage::store::PrefetchOptions;
-use risingwave_storage::table::TableIter;
-use risingwave_storage::table::batch_table::BatchTable;
 
 use super::join::{JoinType, JoinTypePrimitive};
 use super::monitor::TemporalJoinMetrics;
-use crate::cache::{ManagedLruCache, keyed_cache_may_stale};
+use crate::cache::ManagedLruCache;
 use crate::common::metrics::MetricsInfo;
+use crate::common::table::state_table::ReplicatedStateTable;
 use crate::executor::join::builder::JoinStreamChunkBuilder;
 use crate::executor::prelude::*;
 
 pub struct TemporalJoinExecutor<
     K: HashKey,
     S: StateStore,
+    SD: ValueRowSerde,
     const T: JoinTypePrimitive,
     const APPEND_ONLY: bool,
 > {
@@ -49,7 +51,7 @@ pub struct TemporalJoinExecutor<
     info: ExecutorInfo,
     left: Executor,
     right: Executor,
-    right_table: TemporalSide<K, S>,
+    right_table: TemporalSide<K, S, SD>,
     left_join_keys: Vec<usize>,
     right_join_keys: Vec<usize>,
     null_safe: Vec<bool>,
@@ -102,21 +104,20 @@ impl JoinEntry {
     }
 }
 
-struct TemporalSide<K: HashKey, S: StateStore> {
-    source: BatchTable<S>,
+struct TemporalSide<K: HashKey, S: StateStore, SD: ValueRowSerde> {
+    source: ReplicatedStateTable<S, SD>,
     table_stream_key_indices: Vec<usize>,
     table_output_indices: Vec<usize>,
     cache: ManagedLruCache<K, JoinEntry>,
     join_key_data_types: Vec<DataType>,
 }
 
-impl<K: HashKey, S: StateStore> TemporalSide<K, S> {
+impl<K: HashKey, S: StateStore, SD: ValueRowSerde> TemporalSide<K, S, SD> {
     /// Fetch records from temporal side table and ensure the entry in the cache.
     /// If already exists, the entry will be promoted.
     async fn fetch_or_promote_keys(
         &mut self,
         keys: impl Iterator<Item = &K>,
-        epoch: HummockEpoch,
         metrics: &TemporalJoinMetrics,
     ) -> StreamExecutorResult<()> {
         let mut futs = Vec::with_capacity(keys.size_hint().1.unwrap_or(0));
@@ -131,11 +132,9 @@ impl<K: HashKey, S: StateStore> TemporalSide<K, S> {
 
                     let iter = self
                         .source
-                        .batch_iter_with_pk_bounds(
-                            HummockReadEpoch::NoWait(epoch),
+                        .iter_with_prefix(
                             &pk_prefix,
-                            ..,
-                            false,
+                            &(Bound::<OwnedRow>::Unbounded, Bound::<OwnedRow>::Unbounded),
                             PrefetchOptions::default(),
                         )
                         .await?;
@@ -143,7 +142,8 @@ impl<K: HashKey, S: StateStore> TemporalSide<K, S> {
                     let mut entry = JoinEntry::default();
 
                     pin_mut!(iter);
-                    while let Some(row) = iter.next_row().await? {
+                    while let Some(row) = iter.next().await {
+                        let row: OwnedRow = row?;
                         entry.insert(
                             row.as_ref()
                                 .project(&self.table_stream_key_indices)
@@ -194,6 +194,7 @@ impl<K: HashKey, S: StateStore> TemporalSide<K, S> {
                     };
                 }
             }
+            self.source.write_chunk(chunk);
         }
         Ok(())
     }
@@ -237,6 +238,21 @@ async fn internal_messages_until_barrier(stream: impl MessageStream, expected_ba
             Message::Barrier(_) => return Ok(()),
         }
     }
+}
+
+pub(super) async fn expect_first_barrier(
+    stream: &mut (impl Stream<Item = StreamExecutorResult<InternalMessage>> + Unpin),
+) -> StreamExecutorResult<Barrier> {
+    let InternalMessage::Barrier(updates, barrier) = stream
+        .try_next()
+        .instrument_await("expect_first_barrier")
+        .await?
+        .context("failed to extract the first message: stream closed unexpectedly")?
+    else {
+        unreachable!("unexpected internal message");
+    };
+    assert!(updates.is_empty());
+    Ok(barrier)
 }
 
 // Align the left and right inputs according to their barriers,
@@ -319,8 +335,8 @@ pub(super) mod phase1 {
     use risingwave_common::row::{self, OwnedRow, Row, RowExt};
     use risingwave_common::types::{DataType, DatumRef};
     use risingwave_common::util::iter_util::ZipEqDebug;
-    use risingwave_hummock_sdk::HummockEpoch;
     use risingwave_storage::StateStore;
+    use risingwave_storage::row_serde::value_serde::ValueRowSerde;
 
     use super::{StreamExecutorError, TemporalSide};
     use crate::common::table::state_table::StateTable;
@@ -433,15 +449,15 @@ pub(super) mod phase1 {
         'a,
         K: HashKey,
         S: StateStore,
+        SD: ValueRowSerde,
         E: Phase1Evaluation,
         const APPEND_ONLY: bool,
     >(
         chunk_size: usize,
         right_size: usize,
         full_schema: Vec<DataType>,
-        epoch: HummockEpoch,
         left_join_keys: &'a [usize],
-        right_table: &'a mut TemporalSide<K, S>,
+        right_table: &'a mut TemporalSide<K, S, SD>,
         memo_table_lookup_prefix: &'a [usize],
         memo_table: &'a mut Option<StateTable<S>>,
         null_matched: &'a K::Bitmap,
@@ -471,7 +487,7 @@ pub(super) mod phase1 {
                 }
             });
         right_table
-            .fetch_or_promote_keys(to_fetch_keys, epoch, metrics)
+            .fetch_or_promote_keys(to_fetch_keys, metrics)
             .await?;
 
         for (r, key) in chunk.rows_with_holes().zip_eq_debug(keys.into_iter()) {
@@ -587,8 +603,13 @@ pub(super) mod phase1 {
     }
 }
 
-impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, const APPEND_ONLY: bool>
-    TemporalJoinExecutor<K, S, T, APPEND_ONLY>
+impl<
+    K: HashKey,
+    S: StateStore,
+    SD: ValueRowSerde,
+    const T: JoinTypePrimitive,
+    const APPEND_ONLY: bool,
+> TemporalJoinExecutor<K, S, SD, T, APPEND_ONLY>
 {
     #[expect(clippy::too_many_arguments)]
     pub fn new(
@@ -596,7 +617,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, const APPEND_ONLY: b
         info: ExecutorInfo,
         left: Executor,
         right: Executor,
-        table: BatchTable<S>,
+        table: ReplicatedStateTable<S, SD>,
         left_join_keys: Vec<usize>,
         right_join_keys: Vec<usize>,
         null_safe: Vec<bool>,
@@ -663,8 +684,6 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, const APPEND_ONLY: b
 
         let null_matched = K::Bitmap::from_bool_vec(self.null_safe);
 
-        let mut prev_epoch = None;
-
         let full_schema: Vec<_> = self
             .left
             .schema()
@@ -673,10 +692,22 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, const APPEND_ONLY: b
             .chain(self.right.schema().data_types().into_iter())
             .collect();
 
-        let mut wait_first_barrier = true;
+        let input = align_input::<true>(self.left, self.right);
+        pin_mut!(input);
+        let barrier = expect_first_barrier(&mut input).await?;
+        let barrier_epoch = barrier.epoch;
+        yield Message::Barrier(barrier);
+        self.right_table.source.init_epoch(barrier_epoch).await?;
+        if !APPEND_ONLY {
+            self.memo_table
+                .as_mut()
+                .unwrap()
+                .init_epoch(barrier_epoch)
+                .await?;
+        }
 
         #[for_await]
-        for msg in align_input::<true>(self.left, self.right) {
+        for msg in input {
             self.right_table.cache.evict();
             self.metrics
                 .temporal_join_cached_entry_count
@@ -687,16 +718,13 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, const APPEND_ONLY: b
                     yield Message::Watermark(watermark.with_idx(output_watermark_col_idx));
                 }
                 InternalMessage::Chunk(chunk) => {
-                    let epoch = prev_epoch.expect("Chunk data should come after some barrier.");
-
                     let full_schema = full_schema.clone();
 
                     if T == JoinType::Inner {
-                        let st1 = phase1::handle_chunk::<K, S, phase1::Inner, APPEND_ONLY>(
+                        let st1 = phase1::handle_chunk::<K, S, SD, phase1::Inner, APPEND_ONLY>(
                             self.chunk_size,
                             right_size,
                             full_schema,
-                            epoch,
                             &self.left_join_keys,
                             &mut self.right_table,
                             &memo_table_lookup_prefix,
@@ -724,20 +752,24 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, const APPEND_ONLY: b
                         }
                     } else if let Some(ref cond) = self.condition {
                         // Joined result without evaluating non-lookup conditions.
-                        let st1 =
-                            phase1::handle_chunk::<K, S, phase1::LeftOuterWithCond, APPEND_ONLY>(
-                                self.chunk_size,
-                                right_size,
-                                full_schema,
-                                epoch,
-                                &self.left_join_keys,
-                                &mut self.right_table,
-                                &memo_table_lookup_prefix,
-                                &mut self.memo_table,
-                                &null_matched,
-                                chunk,
-                                &self.metrics,
-                            );
+                        let st1 = phase1::handle_chunk::<
+                            K,
+                            S,
+                            SD,
+                            phase1::LeftOuterWithCond,
+                            APPEND_ONLY,
+                        >(
+                            self.chunk_size,
+                            right_size,
+                            full_schema,
+                            &self.left_join_keys,
+                            &mut self.right_table,
+                            &memo_table_lookup_prefix,
+                            &mut self.memo_table,
+                            &null_matched,
+                            chunk,
+                            &self.metrics,
+                        );
                         let mut matched_count = 0usize;
                         #[for_await]
                         for chunk in st1 {
@@ -777,11 +809,10 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, const APPEND_ONLY: b
                         // The last row should always be marker row,
                         assert_eq!(matched_count, 0);
                     } else {
-                        let st1 = phase1::handle_chunk::<K, S, phase1::LeftOuter, APPEND_ONLY>(
+                        let st1 = phase1::handle_chunk::<K, S, SD, phase1::LeftOuter, APPEND_ONLY>(
                             self.chunk_size,
                             right_size,
                             full_schema,
-                            epoch,
                             &self.left_join_keys,
                             &mut self.right_table,
                             &memo_table_lookup_prefix,
@@ -800,54 +831,306 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, const APPEND_ONLY: b
                 }
                 InternalMessage::Barrier(updates, barrier) => {
                     let update_vnode_bitmap = barrier.as_update_vnode_bitmap(self.ctx.id);
-                    let barrier_epoch = barrier.epoch;
-                    if !APPEND_ONLY {
-                        if wait_first_barrier {
-                            wait_first_barrier = false;
-                            yield Message::Barrier(barrier);
-                            self.memo_table
-                                .as_mut()
-                                .unwrap()
-                                .init_epoch(barrier_epoch)
-                                .await?;
-                        } else {
-                            let post_commit = self
-                                .memo_table
-                                .as_mut()
-                                .unwrap()
-                                .commit(barrier.epoch)
-                                .await?;
-                            yield Message::Barrier(barrier);
-                            post_commit
-                                .post_yield_barrier(update_vnode_bitmap.clone())
-                                .await?;
-                        }
-                    } else {
-                        yield Message::Barrier(barrier);
-                    }
-                    if let Some(vnodes) = update_vnode_bitmap {
-                        let prev_vnodes =
-                            self.right_table.source.update_vnode_bitmap(vnodes.clone());
-                        if keyed_cache_may_stale(&prev_vnodes, &vnodes) {
-                            self.right_table.cache.clear();
-                        }
-                    }
+
+                    // Write right-side chunks to the replicated state table and update LRU cache.
+                    // Must happen before commit.
                     self.right_table.update(
                         updates,
                         &self.right_join_keys,
                         &right_stream_key_indices,
                     )?;
-                    prev_epoch = Some(barrier_epoch.prev);
+                    let right_post_commit = self.right_table.source.commit(barrier.epoch).await?;
+                    let memo_post_commit = if !APPEND_ONLY {
+                        Some(
+                            self.memo_table
+                                .as_mut()
+                                .unwrap()
+                                .commit(barrier.epoch)
+                                .await?,
+                        )
+                    } else {
+                        None
+                    };
+
+                    yield Message::Barrier(barrier);
+
+                    if let Some((_, true)) = right_post_commit
+                        .post_yield_barrier(update_vnode_bitmap.clone())
+                        .await?
+                    {
+                        self.right_table.cache.clear();
+                    }
+                    if let Some(memo_post_commit) = memo_post_commit {
+                        memo_post_commit
+                            .post_yield_barrier(update_vnode_bitmap.clone())
+                            .await?;
+                    }
                 }
             }
         }
     }
 }
 
-impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive, const APPEND_ONLY: bool> Execute
-    for TemporalJoinExecutor<K, S, T, APPEND_ONLY>
+impl<
+    K: HashKey,
+    S: StateStore,
+    SD: ValueRowSerde,
+    const T: JoinTypePrimitive,
+    const APPEND_ONLY: bool,
+> Execute for TemporalJoinExecutor<K, S, SD, T, APPEND_ONLY>
 {
     fn execute(self: Box<Self>) -> super::BoxedMessageStream {
         self.into_stream().boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicU64;
+
+    use risingwave_common::array::*;
+    use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema, TableId};
+    use risingwave_common::hash::Key32;
+    use risingwave_common::types::{DataType, ScalarRefImpl};
+    use risingwave_common::util::epoch::{EpochPair, test_epoch};
+    use risingwave_common::util::sort_util::OrderType;
+    use risingwave_common::util::value_encoding::BasicSerde;
+    use risingwave_hummock_test::test_utils::prepare_hummock_test_env;
+    use risingwave_storage::hummock::HummockStorage;
+
+    use super::*;
+    use crate::common::table::state_table::{
+        StateTable, StateTableBuilder, StateTableOpConsistencyLevel,
+    };
+    use crate::common::table::test_utils::gen_pbtable;
+    use crate::executor::monitor::StreamingMetrics;
+    use crate::executor::test_utils::{MockSource, StreamExecutorTestExt};
+    use crate::executor::{ActorContext, ExecutorInfo, JoinType};
+
+    /// Tests that a temporal join on a pk-prefix (join key is a strict prefix of the right table's
+    /// pk) correctly merges rows committed in epoch1 with rows staged/committed during epoch2, and
+    /// produces the right results when the left side arrives in epoch3.
+    ///
+    /// Right table: (key INT, seq INT, val INT), pk = (key, seq), SINGLETON distribution.
+    /// Join condition: `left.left_key` = right.key  (pk prefix: join uses only the first pk column).
+    ///
+    /// Pre-commit at epoch1: (1,1,100), (1,2,200), (2,1,300)
+    /// Epoch2:  right side sends insert (3,1,400) — written to replicated state table, committed
+    ///          at the epoch2 barrier.
+    /// Epoch3:  left side sends (`left_key=1`, `left_val=111`) and (`left_key=3`, `left_val=333`).
+    ///
+    /// Expected join output in epoch3:
+    ///   (1, 111, 1, 1, 100)  — key=1 row matched from epoch1 data (cache miss → state store read)
+    ///   (1, 111, 1, 2, 200)  — key=1 row matched from epoch1 data (same cache entry)
+    ///   (3, 333, 3, 1, 400)  — key=3 row matched from epoch2 data (cache miss → state store read)
+    #[tokio::test]
+    async fn test_temporal_join_pk_prefix_staging_merge() {
+        let test_env = prepare_hummock_test_env().await;
+        let table_id = TableId::new(1);
+
+        // Right table schema: (key INT col_id=1, seq INT col_id=2, val INT col_id=3)
+        // pk = (key idx=0, seq idx=1), SINGLETON distribution (empty distribution_key),
+        // read_prefix_len_hint = 2 (= full pk length).
+        let right_col_descs = vec![
+            ColumnDesc::unnamed(ColumnId::new(1), DataType::Int32),
+            ColumnDesc::unnamed(ColumnId::new(2), DataType::Int32),
+            ColumnDesc::unnamed(ColumnId::new(3), DataType::Int32),
+        ];
+        let order_types = vec![OrderType::ascending(), OrderType::ascending()];
+        let pk_indices = vec![0usize, 1];
+        let pbtable = gen_pbtable(table_id, right_col_descs, order_types, pk_indices, 2);
+
+        test_env.register_table(pbtable.clone()).await;
+
+        // Pre-commit epoch1 data via a plain StateTable (bypasses the executor).
+        {
+            let mut setup_table = StateTable::<HummockStorage>::from_table_catalog_inconsistent_op(
+                &pbtable,
+                test_env.storage.clone(),
+                None,
+            )
+            .await;
+            test_env
+                .storage
+                .start_epoch(test_epoch(1), HashSet::from_iter([table_id]));
+            setup_table
+                .init_epoch(EpochPair::new_test_epoch(test_epoch(1)))
+                .await
+                .unwrap();
+            setup_table.insert(OwnedRow::new(vec![
+                Some(1i32.into()),
+                Some(1i32.into()),
+                Some(100i32.into()),
+            ]));
+            setup_table.insert(OwnedRow::new(vec![
+                Some(1i32.into()),
+                Some(2i32.into()),
+                Some(200i32.into()),
+            ]));
+            setup_table.insert(OwnedRow::new(vec![
+                Some(2i32.into()),
+                Some(1i32.into()),
+                Some(300i32.into()),
+            ]));
+            test_env
+                .storage
+                .start_epoch(test_epoch(2), HashSet::from_iter([table_id]));
+            setup_table
+                .commit_for_test(EpochPair::new_test_epoch(test_epoch(2)))
+                .await
+                .unwrap();
+            // Seal and commit epoch1 data in Hummock so it is visible to all readers.
+            test_env.commit_epoch(test_epoch(1)).await;
+        }
+
+        // Build the replicated state table for the executor (all 3 columns are output).
+        let output_column_ids = vec![ColumnId::new(1), ColumnId::new(2), ColumnId::new(3)];
+        let right_table = StateTableBuilder::<_, BasicSerde, true, _>::new(
+            &pbtable,
+            test_env.storage.clone(),
+            None,
+        )
+        .with_op_consistency_level(StateTableOpConsistencyLevel::Inconsistent)
+        .with_output_column_ids(output_column_ids)
+        .forbid_preload_all_rows()
+        .build()
+        .await;
+
+        // Left source: (left_key INT, left_val INT), stream_key = [0].
+        let left_schema = Schema::new(vec![
+            Field::unnamed(DataType::Int32),
+            Field::unnamed(DataType::Int32),
+        ]);
+        let (mut left_tx, left_source) = MockSource::channel();
+        let left_executor = left_source.into_executor(left_schema.clone(), vec![0]);
+
+        // Right source: mirrors the right table columns (key INT, seq INT, val INT),
+        // stream_key = [0, 1] (the pk).
+        let right_schema = Schema::new(vec![
+            Field::unnamed(DataType::Int32),
+            Field::unnamed(DataType::Int32),
+            Field::unnamed(DataType::Int32),
+        ]);
+        let (mut right_tx, right_source) = MockSource::channel();
+        let right_executor = right_source.into_executor(right_schema.clone(), vec![0, 1]);
+
+        // table_output_indices: indices in right table output rows that form the output.
+        // All 3 columns are selected.
+        let table_output_indices = vec![0usize, 1, 2];
+        // table_stream_key_indices: pk of right table within the output row = [0, 1] (key, seq).
+        let table_stream_key_indices = vec![0usize, 1];
+
+        // Join on left.left_key (col 0) = right.key (col 0 in right source).
+        let left_join_keys = vec![0usize];
+        let right_join_keys = vec![0usize];
+        let null_safe = vec![false];
+        let join_key_data_types = vec![DataType::Int32];
+
+        // Output: all 5 columns — [left_key, left_val, key, seq, val].
+        let output_indices = vec![0usize, 1, 2, 3, 4];
+        let output_schema = Schema::new(vec![
+            Field::unnamed(DataType::Int32),
+            Field::unnamed(DataType::Int32),
+            Field::unnamed(DataType::Int32),
+            Field::unnamed(DataType::Int32),
+            Field::unnamed(DataType::Int32),
+        ]);
+        let info = ExecutorInfo::for_test(output_schema, vec![], "TemporalJoinTest".to_owned(), 0);
+
+        let executor = TemporalJoinExecutor::<
+            Key32,
+            HummockStorage,
+            BasicSerde,
+            { JoinType::Inner },
+            true,
+        >::new(
+            ActorContext::for_test(0),
+            info.clone(),
+            left_executor,
+            right_executor,
+            right_table,
+            left_join_keys,
+            right_join_keys,
+            null_safe,
+            None, // no extra non-equi condition
+            output_indices,
+            table_output_indices,
+            table_stream_key_indices,
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(StreamingMetrics::unused()),
+            1024,
+            join_key_data_types,
+            None, // no memo table (append-only inner join)
+        );
+
+        let mut stream = Box::new(executor).execute();
+
+        // Push the first barrier (init epoch2, prev = epoch1) on both sides.
+        left_tx.push_barrier_with_prev_epoch_for_test(test_epoch(2), test_epoch(1), false);
+        right_tx.push_barrier_with_prev_epoch_for_test(test_epoch(2), test_epoch(1), false);
+        stream.expect_barrier().await;
+
+        // Epoch2: right side inserts (3, 1, 400); left side is quiet.
+        // The epoch2→epoch3 barrier will trigger write_chunk + commit for the right table,
+        // making (3,1,400) visible as committed epoch2 data.
+        right_tx.push_chunk(StreamChunk::from_pretty(
+            " i i   i
+            + 3 1 400",
+        ));
+        // Start epoch3 before the barrier that commits epoch2 data.
+        test_env
+            .storage
+            .start_epoch(test_epoch(3), HashSet::from_iter([table_id]));
+        left_tx.push_barrier_with_prev_epoch_for_test(test_epoch(3), test_epoch(2), false);
+        right_tx.push_barrier_with_prev_epoch_for_test(test_epoch(3), test_epoch(2), false);
+        stream.expect_barrier().await;
+
+        // Start epoch4 before the stop barrier that commits epoch3 data.
+        test_env
+            .storage
+            .start_epoch(test_epoch(4), HashSet::from_iter([table_id]));
+
+        // Epoch3: left side sends two rows.
+        //   key=1 → cache miss → state store read → finds (1,1,100) and (1,2,200) from epoch1.
+        //   key=3 → cache miss → state store read → finds (3,1,400) from epoch2.
+        left_tx.push_chunk(StreamChunk::from_pretty(
+            " i   i
+            + 1 111
+            + 3 333",
+        ));
+        left_tx.push_barrier_with_prev_epoch_for_test(test_epoch(4), test_epoch(3), true);
+        right_tx.push_barrier_with_prev_epoch_for_test(test_epoch(4), test_epoch(3), true);
+
+        // Collect all output rows before the stop barrier.
+        let mut output_rows: Vec<[i32; 5]> = vec![];
+        loop {
+            match stream.next().await.unwrap().unwrap() {
+                Message::Chunk(chunk) => {
+                    for (op, row) in chunk.rows() {
+                        assert_eq!(op, Op::Insert);
+                        let row: [i32; 5] =
+                            std::array::from_fn(|i| match row.datum_at(i).unwrap() {
+                                ScalarRefImpl::Int32(v) => v,
+                                _ => panic!("expected Int32"),
+                            });
+                        output_rows.push(row);
+                    }
+                }
+                Message::Barrier(_) => break,
+                _ => {}
+            }
+        }
+
+        output_rows.sort();
+        assert_eq!(
+            output_rows,
+            vec![
+                [1, 111, 1, 1, 100], // key=1 matched epoch1 row (1,1,100)
+                [1, 111, 1, 2, 200], // key=1 matched epoch1 row (1,2,200)
+                [3, 333, 3, 1, 400], // key=3 matched epoch2 row (3,1,400)
+            ]
+        );
     }
 }

--- a/src/stream/src/executor/temporal_join.rs
+++ b/src/stream/src/executor/temporal_join.rs
@@ -60,6 +60,7 @@ pub struct TemporalJoinExecutor<
     chunk_size: usize,
     memo_table: Option<StateTable<S>>,
     metrics: TemporalJoinMetrics,
+    is_broadcast: bool,
 }
 
 #[derive(Default)]
@@ -166,7 +167,7 @@ impl<K: HashKey, S: StateStore, SD: ValueRowSerde> TemporalSide<K, S, SD> {
     }
 
     fn force_peek(&self, key: &K) -> &JoinEntry {
-        self.cache.peek(key).expect("key should exists")
+        self.cache.peek(key).expect("key should exist")
     }
 
     fn update(
@@ -513,13 +514,15 @@ pub(super) mod phase1 {
                 }
             } else {
                 // Non-append-only temporal join
-                // The memo-table pk and columns:
-                // (`join_key` + `left_pk` + `right_pk`) -> (`right_scan_schema` + `join_key` + `left_pk`)
+                // The memo table persists each matched right row followed by
+                // `join_key + left_stream_key`. For broadcast temporal joins, its distribution key
+                // refers to the `left_stream_key` portion, so the memo state follows the left side.
                 //
                 // Write pattern:
-                //   for each left input row (with insert op), construct the memo table pk and insert the row into the memo table.
+                //   for each left input row (with insert op), persist every matched right row.
                 // Read pattern:
-                //   for each left input row (with delete op), construct pk prefix (`join_key` + `left_pk`) to fetch rows and delete them from the memo table.
+                //   for each left input row (with delete op), fetch the historical right rows by
+                //   memo prefix and delete them from the memo table.
                 //
                 // Temporal join supports inner join and left outer join, additionally, it could contain other conditions.
                 // Surprisingly, we could handle them in a unified way with memo table.
@@ -628,10 +631,10 @@ impl<
         chunk_size: usize,
         join_key_data_types: Vec<DataType>,
         memo_table: Option<StateTable<S>>,
+        is_broadcast: bool,
     ) -> Self {
         let metrics_info =
             MetricsInfo::new(metrics.clone(), table.table_id(), ctx.id, "temporal join");
-
         let cache = ManagedLruCache::unbounded(watermark_sequence, metrics_info);
 
         let metrics = metrics.new_temporal_join_metrics(table.table_id(), ctx.id, ctx.fragment_id);
@@ -655,6 +658,7 @@ impl<
             chunk_size,
             memo_table,
             metrics,
+            is_broadcast,
         }
     }
 
@@ -828,6 +832,11 @@ impl<
                 }
                 InternalMessage::Barrier(updates, barrier) => {
                     let update_vnode_bitmap = barrier.as_update_vnode_bitmap(self.ctx.id);
+                    let right_update_vnode_bitmap = if self.is_broadcast {
+                        None
+                    } else {
+                        update_vnode_bitmap.clone()
+                    };
 
                     // Write right-side chunks to the replicated state table and update LRU cache.
                     // Must happen before commit.
@@ -852,7 +861,7 @@ impl<
                     yield Message::Barrier(barrier);
 
                     if let Some((_, true)) = right_post_commit
-                        .post_yield_barrier(update_vnode_bitmap.clone())
+                        .post_yield_barrier(right_update_vnode_bitmap)
                         .await?
                     {
                         self.right_table.cache.clear();
@@ -1056,6 +1065,7 @@ mod tests {
             1024,
             join_key_data_types,
             None, // no memo table (append-only inner join)
+            false,
         );
 
         let mut stream = Box::new(executor).execute();

--- a/src/stream/src/from_proto/lookup.rs
+++ b/src/stream/src/from_proto/lookup.rs
@@ -12,13 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use risingwave_common::catalog::{ColumnDesc, ColumnId};
 use risingwave_common::util::sort_util::ColumnOrder;
+use risingwave_common::util::value_encoding::BasicSerde;
+use risingwave_common::util::value_encoding::column_aware_row_encoding::ColumnAwareSerde;
 use risingwave_pb::plan_common::StorageTableDesc;
 use risingwave_pb::stream_plan::LookupNode;
-use risingwave_storage::table::batch_table::BatchTable;
 
 use super::*;
+use crate::common::table::state_table::{StateTableBuilder, StateTableOpConsistencyLevel};
 use crate::executor::{LookupExecutor, LookupExecutorParams};
 
 pub struct LookupExecutorBuilder;
@@ -62,28 +66,55 @@ impl ExecutorBuilder for LookupExecutorBuilder {
             .map(|&idx| ColumnId::new(table_desc.columns[idx as usize].column_id))
             .collect_vec();
 
-        let storage_table = BatchTable::new_partial(
-            store,
-            column_ids,
-            params.vnode_bitmap.map(Into::into),
-            table_desc,
-        );
+        let versioned = table_desc.versioned;
+        let vnodes = params.vnode_bitmap.clone().map(Arc::new);
 
-        let exec = LookupExecutor::new(LookupExecutorParams {
-            ctx: params.actor_context,
-            info: params.info.clone(),
-            arrangement,
-            stream,
-            arrangement_col_descs,
-            arrangement_order_rules,
-            use_current_epoch: lookup.use_current_epoch,
-            stream_join_key_indices: lookup.stream_key.iter().map(|x| *x as usize).collect(),
-            arrange_join_key_indices: lookup.arrange_key.iter().map(|x| *x as usize).collect(),
-            column_mapping: lookup.column_mapping.iter().map(|x| *x as usize).collect(),
-            batch_table: storage_table,
-            watermark_epoch: params.watermark_epoch,
-            chunk_size: params.config.developer.chunk_size,
-        });
-        Ok((params.info, exec).into())
+        macro_rules! build_lookup {
+            ($SD:ident) => {{
+                let state_table =
+                    StateTableBuilder::<_, $SD, true, _>::new_from_storage_table_desc(
+                        table_desc,
+                        store.clone(),
+                        vnodes.clone(),
+                        params.fragment_id,
+                    )
+                    .with_op_consistency_level(StateTableOpConsistencyLevel::Inconsistent)
+                    .with_output_column_ids(column_ids.clone())
+                    .forbid_preload_all_rows()
+                    .build()
+                    .await;
+
+                let exec = LookupExecutor::new(LookupExecutorParams {
+                    ctx: params.actor_context,
+                    info: params.info.clone(),
+                    arrangement,
+                    stream,
+                    arrangement_col_descs,
+                    arrangement_order_rules,
+                    use_current_epoch: lookup.use_current_epoch,
+                    stream_join_key_indices: lookup
+                        .stream_key
+                        .iter()
+                        .map(|x| *x as usize)
+                        .collect(),
+                    arrange_join_key_indices: lookup
+                        .arrange_key
+                        .iter()
+                        .map(|x| *x as usize)
+                        .collect(),
+                    column_mapping: lookup.column_mapping.iter().map(|x| *x as usize).collect(),
+                    state_table,
+                    watermark_epoch: params.watermark_epoch,
+                    chunk_size: params.config.developer.chunk_size,
+                });
+                Ok((params.info, exec).into())
+            }};
+        }
+
+        if versioned {
+            build_lookup!(ColumnAwareSerde)
+        } else {
+            build_lookup!(BasicSerde)
+        }
     }
 }

--- a/src/stream/src/from_proto/temporal_join.rs
+++ b/src/stream/src/from_proto/temporal_join.rs
@@ -17,12 +17,16 @@ use std::sync::Arc;
 use risingwave_common::catalog::ColumnId;
 use risingwave_common::hash::{HashKey, HashKeyDispatcher};
 use risingwave_common::types::DataType;
+use risingwave_common::util::value_encoding::BasicSerde;
+use risingwave_common::util::value_encoding::column_aware_row_encoding::ColumnAwareSerde;
 use risingwave_expr::expr::{NonStrictExpression, build_non_strict_from_prost};
 use risingwave_pb::plan_common::{JoinType as JoinTypeProto, StorageTableDesc};
-use risingwave_storage::table::batch_table::BatchTable;
+use risingwave_storage::row_serde::value_serde::ValueRowSerde;
 
 use super::*;
-use crate::common::table::state_table::{StateTable, StateTableBuilder};
+use crate::common::table::state_table::{
+    ReplicatedStateTable, StateTable, StateTableBuilder, StateTableOpConsistencyLevel,
+};
 use crate::executor::monitor::StreamingMetrics;
 use crate::executor::{
     ActorContextRef, JoinType, NestedLoopTemporalJoinExecutor, TemporalJoinExecutor,
@@ -61,46 +65,54 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
             .collect_vec();
         let [source_l, source_r]: [_; 2] = params.input.try_into().unwrap();
 
+        let versioned = table_desc.versioned;
+        // Use table_output_indices to select only the column IDs that the right-side
+        // upstream actually delivers. The planner may prune unused columns from the
+        // right table scan, so the upstream chunks may have fewer columns than the
+        // full table.
+        let output_column_ids = table_output_indices
+            .iter()
+            .map(|&x| ColumnId::new(table_desc.columns[x].column_id))
+            .collect_vec();
+        let vnodes = params.vnode_bitmap.clone().map(Arc::new);
+
         if node.get_is_nested_loop() {
-            let right_table = BatchTable::new_partial(
-                store.clone(),
-                table_output_indices
-                    .iter()
-                    .map(|&x| ColumnId::new(table_desc.columns[x].column_id))
-                    .collect_vec(),
-                params.vnode_bitmap.clone().map(Into::into),
-                table_desc,
-            );
+            macro_rules! build_nested_loop {
+                ($SD:ident) => {{
+                    let right_table =
+                        StateTableBuilder::<_, $SD, true, _>::new_from_storage_table_desc(
+                            table_desc,
+                            store.clone(),
+                            vnodes.clone(),
+                            params.fragment_id.as_raw_id(),
+                        )
+                        .with_op_consistency_level(StateTableOpConsistencyLevel::Inconsistent)
+                        .with_output_column_ids(output_column_ids.clone())
+                        .forbid_preload_all_rows()
+                        .build()
+                        .await;
 
-            let dispatcher_args = NestedLoopTemporalJoinExecutorDispatcherArgs {
-                ctx: params.actor_context,
-                info: params.info.clone(),
-                left: source_l,
-                right: source_r,
-                right_table,
-                condition,
-                output_indices,
-                chunk_size: params.config.developer.chunk_size,
-                metrics: params.executor_stats,
-                join_type_proto: node.get_join_type()?,
-            };
-            Ok((params.info, dispatcher_args.dispatch()?).into())
+                    let dispatcher_args = NestedLoopTemporalJoinExecutorDispatcherArgs {
+                        ctx: params.actor_context,
+                        info: params.info.clone(),
+                        left: source_l,
+                        right: source_r,
+                        right_table,
+                        condition,
+                        output_indices,
+                        chunk_size: params.config.developer.chunk_size,
+                        metrics: params.executor_stats,
+                        join_type_proto: node.get_join_type()?,
+                    };
+                    Ok((params.info, dispatcher_args.dispatch()?).into())
+                }};
+            }
+            if versioned {
+                build_nested_loop!(ColumnAwareSerde)
+            } else {
+                build_nested_loop!(BasicSerde)
+            }
         } else {
-            let table = {
-                let column_ids = table_desc
-                    .columns
-                    .iter()
-                    .map(|x| ColumnId::new(x.column_id))
-                    .collect_vec();
-
-                BatchTable::new_partial(
-                    store.clone(),
-                    column_ids,
-                    params.vnode_bitmap.clone().map(Into::into),
-                    table_desc,
-                )
-            };
-
             let table_stream_key_indices = table_desc
                 .stream_key
                 .iter()
@@ -145,39 +157,61 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
             };
             let append_only = memo_table.is_none();
 
-            let dispatcher_args = TemporalJoinExecutorDispatcherArgs {
-                ctx: params.actor_context,
-                info: params.info.clone(),
-                left: source_l,
-                right: source_r,
-                right_table: table,
-                left_join_keys,
-                right_join_keys,
-                null_safe,
-                condition,
-                output_indices,
-                table_output_indices,
-                table_stream_key_indices,
-                watermark_epoch: params.watermark_epoch,
-                chunk_size: params.config.developer.chunk_size,
-                metrics: params.executor_stats,
-                join_type_proto: node.get_join_type()?,
-                join_key_data_types,
-                memo_table,
-                append_only,
-            };
+            macro_rules! build_hash {
+                ($SD:ident) => {{
+                    let right_table =
+                        StateTableBuilder::<_, $SD, true, _>::new_from_storage_table_desc(
+                            table_desc,
+                            store.clone(),
+                            vnodes.clone(),
+                            params.fragment_id.as_raw_id(),
+                        )
+                        .with_op_consistency_level(StateTableOpConsistencyLevel::Inconsistent)
+                        .with_output_column_ids(output_column_ids.clone())
+                        .forbid_preload_all_rows()
+                        .build()
+                        .await;
 
-            Ok((params.info, dispatcher_args.dispatch()?).into())
+                    let dispatcher_args = TemporalJoinExecutorDispatcherArgs::<_, $SD> {
+                        ctx: params.actor_context,
+                        info: params.info.clone(),
+                        left: source_l,
+                        right: source_r,
+                        right_table,
+                        left_join_keys,
+                        right_join_keys,
+                        null_safe,
+                        condition,
+                        output_indices,
+                        table_output_indices,
+                        table_stream_key_indices,
+                        watermark_epoch: params.watermark_epoch,
+                        chunk_size: params.config.developer.chunk_size,
+                        metrics: params.executor_stats,
+                        join_type_proto: node.get_join_type()?,
+                        join_key_data_types,
+                        memo_table,
+                        append_only,
+                    };
+
+                    Ok((params.info, dispatcher_args.dispatch()?).into())
+                }};
+            }
+            if versioned {
+                build_hash!(ColumnAwareSerde)
+            } else {
+                build_hash!(BasicSerde)
+            }
         }
     }
 }
 
-struct TemporalJoinExecutorDispatcherArgs<S: StateStore> {
+struct TemporalJoinExecutorDispatcherArgs<S: StateStore, SD: ValueRowSerde> {
     ctx: ActorContextRef,
     info: ExecutorInfo,
     left: Executor,
     right: Executor,
-    right_table: BatchTable<S>,
+    right_table: ReplicatedStateTable<S, SD>,
     left_join_keys: Vec<usize>,
     right_join_keys: Vec<usize>,
     null_safe: Vec<bool>,
@@ -194,7 +228,9 @@ struct TemporalJoinExecutorDispatcherArgs<S: StateStore> {
     append_only: bool,
 }
 
-impl<S: StateStore> HashKeyDispatcher for TemporalJoinExecutorDispatcherArgs<S> {
+impl<S: StateStore, SD: ValueRowSerde> HashKeyDispatcher
+    for TemporalJoinExecutorDispatcherArgs<S, SD>
+{
     type Output = StreamResult<Box<dyn Execute>>;
 
     fn dispatch_impl<K: HashKey>(self) -> Self::Output {
@@ -204,6 +240,7 @@ impl<S: StateStore> HashKeyDispatcher for TemporalJoinExecutorDispatcherArgs<S> 
                 Ok(Box::new(TemporalJoinExecutor::<
                     K,
                     S,
+                    SD,
                     { JoinType::$join_type },
                     { $append_only },
                 >::new(
@@ -251,12 +288,12 @@ impl<S: StateStore> HashKeyDispatcher for TemporalJoinExecutorDispatcherArgs<S> 
     }
 }
 
-struct NestedLoopTemporalJoinExecutorDispatcherArgs<S: StateStore> {
+struct NestedLoopTemporalJoinExecutorDispatcherArgs<S: StateStore, SD: ValueRowSerde> {
     ctx: ActorContextRef,
     info: ExecutorInfo,
     left: Executor,
     right: Executor,
-    right_table: BatchTable<S>,
+    right_table: ReplicatedStateTable<S, SD>,
     condition: Option<NonStrictExpression>,
     output_indices: Vec<usize>,
     chunk_size: usize,
@@ -264,13 +301,14 @@ struct NestedLoopTemporalJoinExecutorDispatcherArgs<S: StateStore> {
     join_type_proto: JoinTypeProto,
 }
 
-impl<S: StateStore> NestedLoopTemporalJoinExecutorDispatcherArgs<S> {
+impl<S: StateStore, SD: ValueRowSerde> NestedLoopTemporalJoinExecutorDispatcherArgs<S, SD> {
     fn dispatch(self) -> StreamResult<Box<dyn Execute>> {
         /// This macro helps to fill the const generic type parameter.
         macro_rules! build {
             ($join_type:ident) => {
                 Ok(Box::new(NestedLoopTemporalJoinExecutor::<
                     S,
+                    SD,
                     { JoinType::$join_type },
                 >::new(
                     self.ctx,

--- a/src/stream/src/from_proto/temporal_join.rs
+++ b/src/stream/src/from_proto/temporal_join.rs
@@ -84,7 +84,7 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
                             table_desc,
                             store.clone(),
                             vnodes.clone(),
-                            params.fragment_id.as_raw_id(),
+                            params.fragment_id,
                         )
                         .with_op_consistency_level(StateTableOpConsistencyLevel::Inconsistent)
                         .with_output_column_ids(output_column_ids.clone())
@@ -113,10 +113,18 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
                 build_nested_loop!(BasicSerde)
             }
         } else {
+            // `ReplicatedStateTable::iter_with_prefix` returns rows in `table_output_indices`
+            // order. The hash temporal join cache therefore needs stream-key positions within
+            // that projected row, not within the full table schema.
             let table_stream_key_indices = table_desc
                 .stream_key
                 .iter()
-                .map(|&k| k as usize)
+                .map(|&k| {
+                    table_output_indices
+                        .iter()
+                        .position(|&idx| idx == k as usize)
+                        .expect("stream key should be included in table output")
+                })
                 .collect_vec();
 
             let left_join_keys = node
@@ -164,7 +172,7 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
                             table_desc,
                             store.clone(),
                             vnodes.clone(),
-                            params.fragment_id.as_raw_id(),
+                            params.fragment_id,
                         )
                         .with_op_consistency_level(StateTableOpConsistencyLevel::Inconsistent)
                         .with_output_column_ids(output_column_ids.clone())
@@ -183,7 +191,6 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
                         null_safe,
                         condition,
                         output_indices,
-                        table_output_indices,
                         table_stream_key_indices,
                         watermark_epoch: params.watermark_epoch,
                         chunk_size: params.config.developer.chunk_size,
@@ -217,7 +224,6 @@ struct TemporalJoinExecutorDispatcherArgs<S: StateStore, SD: ValueRowSerde> {
     null_safe: Vec<bool>,
     condition: Option<NonStrictExpression>,
     output_indices: Vec<usize>,
-    table_output_indices: Vec<usize>,
     table_stream_key_indices: Vec<usize>,
     watermark_epoch: AtomicU64Ref,
     chunk_size: usize,
@@ -254,7 +260,6 @@ impl<S: StateStore, SD: ValueRowSerde> HashKeyDispatcher
                     self.null_safe,
                     self.condition,
                     self.output_indices,
-                    self.table_output_indices,
                     self.table_stream_key_indices,
                     self.watermark_epoch,
                     self.metrics,

--- a/src/stream/src/from_proto/temporal_join.rs
+++ b/src/stream/src/from_proto/temporal_join.rs
@@ -14,8 +14,9 @@
 
 use std::sync::Arc;
 
+use risingwave_common::bitmap::Bitmap;
 use risingwave_common::catalog::ColumnId;
-use risingwave_common::hash::{HashKey, HashKeyDispatcher};
+use risingwave_common::hash::{HashKey, HashKeyDispatcher, VnodeCountCompat};
 use risingwave_common::types::DataType;
 use risingwave_common::util::value_encoding::BasicSerde;
 use risingwave_common::util::value_encoding::column_aware_row_encoding::ColumnAwareSerde;
@@ -74,9 +75,18 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
             .iter()
             .map(|&x| ColumnId::new(table_desc.columns[x].column_id))
             .collect_vec();
-        let vnodes = params.vnode_bitmap.clone().map(Arc::new);
+        let is_broadcast = node.is_broadcast;
+        let vnodes = if is_broadcast {
+            Some(Arc::new(Bitmap::ones(table_desc.vnode_count())))
+        } else {
+            params.vnode_bitmap.clone().map(Arc::new)
+        };
 
         if node.get_is_nested_loop() {
+            assert!(
+                !is_broadcast,
+                "nested-loop temporal join cannot be broadcast"
+            );
             macro_rules! build_nested_loop {
                 ($SD:ident) => {{
                     let right_table =
@@ -149,13 +159,9 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
             let memo_table = node.get_memo_table();
             let memo_table = match memo_table {
                 Ok(memo_table) => {
-                    let vnodes = Arc::new(
-                        params
-                            .vnode_bitmap
-                            .expect("vnodes not set for temporal join"),
-                    );
+                    let vnodes = params.vnode_bitmap.clone().map(Arc::new);
                     Some(
-                        StateTableBuilder::new(memo_table, store.clone(), Some(vnodes.clone()))
+                        StateTableBuilder::new(memo_table, store.clone(), vnodes)
                             .enable_preload_all_rows_by_config(&params.config)
                             .build()
                             .await,
@@ -199,6 +205,7 @@ impl ExecutorBuilder for TemporalJoinExecutorBuilder {
                         join_key_data_types,
                         memo_table,
                         append_only,
+                        is_broadcast,
                     };
 
                     Ok((params.info, dispatcher_args.dispatch()?).into())
@@ -232,6 +239,7 @@ struct TemporalJoinExecutorDispatcherArgs<S: StateStore, SD: ValueRowSerde> {
     join_key_data_types: Vec<DataType>,
     memo_table: Option<StateTable<S>>,
     append_only: bool,
+    is_broadcast: bool,
 }
 
 impl<S: StateStore, SD: ValueRowSerde> HashKeyDispatcher
@@ -266,6 +274,7 @@ impl<S: StateStore, SD: ValueRowSerde> HashKeyDispatcher
                     self.chunk_size,
                     self.join_key_data_types,
                     self.memo_table,
+                    self.is_broadcast,
                 )))
             };
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Backport of broadcast temporal join (upstream `b69e37cedf`, #26932) onto **v3.0.3** for a customer patch. **Opened for CI only.** The branch is cut from the `v3.0.3` tag; base is `release-3.0` so the diff shows just the backported commits.

### Commits

| here | upstream | role |
| --- | --- | --- |
| `b73ad2f869` | `895b9237f9` (#25319) | lookup side `BatchTable` → `ReplicatedStateTable`: each join actor writes the lookup stream it receives into a local replica, so `prev_epoch` lookups are served locally. Broadcast depends on this. |
| `9a2802796a` | `7b944720ab` (#25331) | same refactor for the delta-join lookup executor; also fixes `table_stream_key_indices` for projected lookup rows in temporal join |
| `8200ffdeef` | `eead4530c3` (#26345) | invisible-rows fix on the replicated read path |
| `1e6054e1c6` | `b69e37cedf` (#26932) | the feature. Only adaptation: the `binder/relation/table_or_source.rs` hunk is dropped — the Iceberg-metadata `as_of` guard it extends does not exist on this base |
| `5be03359b6` | `266028c5f4` | always shuffle the broadcast join's left input by its stream key, so the join gets its own fragment instead of being fused into the source/scan fragment. **Picked from an unmerged upstream branch** (`dylan/broadcast-temporal-join-shuffle-left`) — needs re-syncing if it changes before merge |

All four picks apply without conflicts. Changed lines are identical to upstream in every file except the dropped hunk; only context lines differ where this base lacks unrelated later commits.

### Why the follow-up commit matters here

The customer's left input is a source. Without `5be03359b6` the join node lands in the source-backfill fragment, which sits in the upstream source job's no-shuffle ensemble; meta derives an ensemble's parallelism from the job owning its entry fragment, so the join fragment follows the **source job's** parallelism and neither `ALTER MATERIALIZED VIEW ... SET PARALLELISM` on the MV nor `ALTER FRAGMENT ... SET PARALLELISM` on the fused fragment can move it. With the shuffle in place the join fragment has no no-shuffle edge, forms its own ensemble, and becomes independently scalable.

### Why the prerequisites are required

Without #25319 the v3.0.3 executor serves cache misses from a read-only `BatchTable` at `NoWait(prev_epoch)` and applies lookup-side deltas only to keys already cached. That is consistent only while the join actor is co-located with the table's materialize — the `no_shuffle` requirement broadcast removes. For vnodes not hosted on the actor's node, `HummockStorage` silently falls back to the committed version, so a cache entry gets populated from a stale snapshot after its deltas were already discarded, and stays wrong until evicted. Single-node deployments hide this; so does `RW_IMPLICIT_FLUSH` in the SLTs, which is why a green CI on the earlier `BatchTable`-based revision of this PR (`a57abb3fa4`) was not evidence.

### Impact on the customer build

- All temporal joins and delta-join lookups switch to `ReplicatedStateTable`, as on `main` since May.
- A broadcast temporal join keeps the full lookup delta in every actor until checkpoint; `state_store_replicated_imm_size` (added by #26932) is the metric to watch.
- Breaking change inherited from upstream: `BROADCAST` becomes a contextual keyword. A bare table alias `broadcast` directly before `JOIN` / `INNER JOIN` / `LEFT JOIN` must be written `AS broadcast` or `"broadcast"`.

## Checklist

- [x] I have written necessary rustdoc comments.
- [ ] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [x] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [x] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Verification

- Local, through `1e6054e1c6`: `./risedev check` green (clippy 0 errors / 0 warnings, no fmt or `Cargo.lock` changes); `./risedev check-clippy --all-targets` also clean, so the test targets rewritten by #25331 compile on this base.
- `5be03359b6` has **not** been built locally; its planner-test expectations were generated on `main` and rely on CI here.
- CI: Buildkite build #100368 passed with every selected step green, including `unit-test` (covers the planner tests, whose expected output came from `main` unchanged), the e2e steps that run the two new SLTs, deterministic simulation, and the 4-version backwards-compatibility matrix (one matrix job was killed by `agent_stop` and passed on retry).

## Documentation

- [x] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Adds an opt-in `BROADCAST` modifier for process-time temporal joins, which preserves the left input distribution instead of reshuffling it by the lookup table's distribution key, avoiding hot-actor bottlenecks on low-cardinality or skewed lookup keys:

```sql
SELECT ...
FROM events
BROADCAST LEFT JOIN dimensions FOR SYSTEM_TIME AS OF PROCTIME()
ON events.key = dimensions.key;
```

`BROADCAST` is a contextual keyword: a bare table alias named `broadcast` directly before `JOIN` / `INNER JOIN` / `LEFT JOIN` is now read as the modifier, and must be written `AS broadcast` or `"broadcast"` to keep its old meaning.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `BROADCAST INNER JOIN` and `BROADCAST LEFT JOIN` with process-time temporal tables.
  * Broadcast temporal joins now replicate lookup data across join workers for consistent results.
  * Added support for append-only, updateable, deleteable, and singleton left-side inputs.
  * Improved handling of distribution changes, parallelism changes, unmatched rows, and reordered join outputs.

* **Bug Fixes**
  * Improved temporal join planning and execution across differing data distributions and source configurations.
  * Preserved stable temporal results after subsequent lookup-table updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->