### PR TITLE
fix(cdc): align heartbeat interval validation across Rust and Java

### DIFF
--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/SourceValidateHandler.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/SourceValidateHandler.java
@@ -123,27 +123,42 @@ public class SourceValidateHandler {
         }
     }
 
-    /** Validate debezium.heartbeat.interval.ms if specified. If present, it must not be 0. */
-    private static void validateHeartbeatInterval(
-            Map<String, String> props, boolean isCdcSourceJob) {
+    /**
+     * Validates user-supplied options, not the final Debezium configuration. If the interval is
+     * omitted, DbzConnectorConfig supplies the connector default (300000 ms for PostgreSQL/Citus).
+     * Keep this policy in sync with Rust's validate_cdc_heartbeat_interval (CREATE and ALTER).
+     */
+    static void validateHeartbeatInterval(
+            Map<String, String> props, ConnectorServiceProto.SourceType sourceType) {
         String intervalStr = props.get("debezium.heartbeat.interval.ms");
         if (intervalStr == null) {
             return; // Not specified, use default
         }
 
-        long interval;
+        int interval;
         try {
-            interval = Long.parseLong(intervalStr);
+            // Match Rust's ASCII integer syntax; Integer.parseInt also accepts Unicode digits.
+            if (!intervalStr.matches("[+-]?[0-9]+")) {
+                throw new NumberFormatException();
+            }
+            // Debezium's heartbeat field is INT with a nonnegative-integer validator, not LONG.
+            interval = Integer.parseInt(intervalStr);
+            if (interval < 0) {
+                throw new NumberFormatException();
+            }
         } catch (NumberFormatException e) {
             throw ValidatorUtils.invalidArgument(
                     String.format(
-                            "'debezium.heartbeat.interval.ms' must be a valid number, got: '%s'",
+                            "'debezium.heartbeat.interval.ms' must be an integer between 0 and 2147483647, got: '%s'",
                             intervalStr));
         }
 
-        // Validate interval is not 0
-        if (interval == 0) {
-            throw ValidatorUtils.invalidArgument("'debezium.heartbeat.interval.ms' must not be 0");
+        boolean heartbeatRequired =
+                sourceType == ConnectorServiceProto.SourceType.POSTGRES
+                        || sourceType == ConnectorServiceProto.SourceType.CITUS;
+        if (heartbeatRequired && interval == 0) {
+            throw ValidatorUtils.invalidArgument(
+                    "'debezium.heartbeat.interval.ms' must be greater than 0 for PostgreSQL and Citus CDC: heartbeats are required for replication-slot progress and WAL reclamation");
         }
     }
 
@@ -159,6 +174,7 @@ public class SourceValidateHandler {
                 isCdcSourceJob,
                 isBackfillTable);
 
+        validateHeartbeatInterval(props, request.getSourceType());
         TableSchema tableSchema = TableSchema.fromProto(request.getTableSchema());
         switch (request.getSourceType()) {
             case POSTGRES:
@@ -207,7 +223,6 @@ public class SourceValidateHandler {
                 ensureRequiredProps(props, isCdcSourceJob);
                 ensurePropNotBlank(props, DbzConnectorConfig.MYSQL_SERVER_ID);
                 validateQueueMemoryRatio(props);
-                validateHeartbeatInterval(props, isCdcSourceJob);
                 try (var validator =
                         new MySqlValidator(props, tableSchema, isCdcSourceJob, isBackfillTable)) {
                     validator.validateAll();
@@ -225,7 +240,6 @@ public class SourceValidateHandler {
                 ensureRequiredProps(props, isCdcSourceJob);
                 ensurePropNotBlank(props, DbzConnectorConfig.SQL_SERVER_SCHEMA_NAME);
                 validateQueueMemoryRatio(props);
-                validateHeartbeatInterval(props, isCdcSourceJob);
                 try (var sqlServerValidator =
                         new SqlServerValidator(props, tableSchema, isCdcSourceJob)) {
                     sqlServerValidator.validateAll();

--- a/java/connector-node/risingwave-connector-service/src/test/java/com/risingwave/connector/source/SourceValidateHandlerTest.java
+++ b/java/connector-node/risingwave-connector-service/src/test/java/com/risingwave/connector/source/SourceValidateHandlerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 RisingWave Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.risingwave.connector.source;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.risingwave.proto.ConnectorServiceProto.SourceType;
+import com.risingwave.proto.ConnectorServiceProto.ValidateSourceRequest;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class SourceValidateHandlerTest {
+    private static final String HEARTBEAT_INTERVAL = "debezium.heartbeat.interval.ms";
+    private final SourceType sourceType;
+
+    public SourceValidateHandlerTest(SourceType sourceType) {
+        this.sourceType = sourceType;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Object[] sourceTypes() {
+        return new Object[] {
+            SourceType.MYSQL,
+            SourceType.SQL_SERVER,
+            SourceType.MONGODB,
+            SourceType.POSTGRES,
+            SourceType.CITUS
+        };
+    }
+
+    @Test
+    public void acceptsMissingAndPositiveHeartbeatIntervals() {
+        SourceValidateHandler.validateHeartbeatInterval(Map.of(), sourceType);
+        for (String value : new String[] {"1", "300000", "2147483647", "+1"}) {
+            SourceValidateHandler.validateHeartbeatInterval(
+                    Map.of(HEARTBEAT_INTERVAL, value), sourceType);
+        }
+    }
+
+    @Test
+    public void rejectsInvalidHeartbeatIntervals() {
+        // Keep these cases aligned with the Rust heartbeat validation tests.
+        for (String value :
+                new String[] {
+                    "-1",
+                    "",
+                    "invalid",
+                    "0.5",
+                    "2147483648",
+                    "9223372036854775807",
+                    "9223372036854775808",
+                    " 1",
+                    "1 ",
+                    "１"
+                }) {
+            var props = Map.of(HEARTBEAT_INTERVAL, value);
+            var error =
+                    assertThrows(
+                            StatusRuntimeException.class,
+                            () ->
+                                    SourceValidateHandler.validateHeartbeatInterval(
+                                            props, sourceType));
+            assertEquals(Status.Code.INVALID_ARGUMENT, error.getStatus().getCode());
+            assertTrue(error.getMessage().contains("between 0 and 2147483647"));
+            assertRejectedBeforeDatabaseValidation(props, "between 0 and 2147483647");
+        }
+    }
+
+    @Test
+    public void zeroDisablesHeartbeatExceptForPostgresAndCitus() {
+        for (String value : new String[] {"0", "+0", "-0"}) {
+            var props = Map.of(HEARTBEAT_INTERVAL, value);
+            if (sourceType == SourceType.POSTGRES || sourceType == SourceType.CITUS) {
+                var error =
+                        assertThrows(
+                                StatusRuntimeException.class,
+                                () ->
+                                        SourceValidateHandler.validateHeartbeatInterval(
+                                                props, sourceType));
+                assertTrue(error.getMessage().contains("WAL reclamation"));
+                assertRejectedBeforeDatabaseValidation(props, "WAL reclamation");
+            } else {
+                SourceValidateHandler.validateHeartbeatInterval(props, sourceType);
+            }
+        }
+    }
+
+    private void assertRejectedBeforeDatabaseValidation(
+            Map<String, String> props, String expectedMessage) {
+        // Exercise the request entry point without a database, for source and table jobs.
+        for (boolean isSourceJob : new boolean[] {false, true}) {
+            var request =
+                    ValidateSourceRequest.newBuilder()
+                            .setSourceType(sourceType)
+                            .setIsSourceJob(isSourceJob)
+                            .putAllProperties(props)
+                            .build();
+            var error =
+                    assertThrows(
+                            StatusRuntimeException.class,
+                            () -> SourceValidateHandler.validateSource(request));
+            assertEquals(Status.Code.INVALID_ARGUMENT, error.getStatus().getCode());
+            assertTrue(error.getMessage(), error.getMessage().contains(expectedMessage));
+        }
+    }
+}

--- a/src/frontend/src/handler/alter_source_props.rs
+++ b/src/frontend/src/handler/alter_source_props.rs
@@ -16,6 +16,7 @@ use risingwave_common::id::{ConnectionId, SourceId};
 use risingwave_pb::catalog::connection::Info::ConnectionParams;
 
 use super::RwPgResponse;
+use super::create_source::validate_cdc_heartbeat_interval;
 use crate::catalog::catalog_service::CatalogReadGuard;
 use crate::catalog::root_catalog::SchemaPath;
 use crate::error::{ErrorCode, Result};
@@ -37,7 +38,7 @@ pub async fn handle_alter_table_connector_props(
     let user_name = &session.user_name();
     let schema_path = SchemaPath::new(schema_name.as_deref(), &search_path, user_name);
 
-    let source_id = {
+    let (source_id, connector) = {
         let reader = session.env().catalog_reader().read_guard();
         let (table, schema_name) =
             reader.get_any_table_by_name(db_name, schema_path, &real_table_name)?;
@@ -66,18 +67,19 @@ pub async fn handle_alter_table_connector_props(
             associate_source_id
         );
 
-        associate_source_id
+        (associate_source_id, source_catalog.connector_name())
     };
 
-    handle_alter_source_props_inner(&session, alter_props, source_id).await?;
+    handle_alter_source_props_inner(&session, alter_props, source_id, &connector).await?;
 
     Ok(RwPgResponse::empty_result(StatementType::ALTER_TABLE))
 }
 
-async fn handle_alter_source_props_inner(
+pub(super) async fn handle_alter_source_props_inner(
     session: &SessionImpl,
     alter_props: Vec<SqlOption>,
     source_id: SourceId,
+    connector: &str,
 ) -> Result<()> {
     let meta_client = session.env().meta_client();
     let (resolved_with_options, _, connector_conn_ref) = resolve_connection_ref_and_secret_ref(
@@ -115,16 +117,7 @@ async fn handle_alter_source_props_inner(
         .into());
     }
 
-    // Validate debezium.heartbeat.interval.ms if present: must be a valid integer and not 0
-    if let Some(interval_value) = changed_props.get("debezium.heartbeat.interval.ms")
-        && !interval_value.parse::<i64>().is_ok_and(|v| v != 0)
-    {
-        return Err(ErrorCode::InvalidConfigValue {
-            config_entry: "debezium.heartbeat.interval.ms".to_owned(),
-            config_value: interval_value.to_owned(),
-        }
-        .into());
-    }
+    validate_cdc_heartbeat_interval(connector, &changed_props)?;
 
     meta_client
         .alter_source_connector_props(
@@ -150,7 +143,7 @@ pub async fn handle_alter_source_connector_props(
     let user_name = &session.user_name();
     let schema_path = SchemaPath::new(schema_name.as_deref(), &search_path, user_name);
 
-    let source_id = {
+    let (source_id, connector) = {
         let reader = session.env().catalog_reader().read_guard();
         let (source, schema_name) =
             reader.get_source_by_name(db_name, schema_path, &real_source_name)?;
@@ -172,10 +165,10 @@ pub async fn handle_alter_source_connector_props(
             &alter_props,
         )?;
 
-        source.id
+        (source.id, source.connector_name())
     };
 
-    handle_alter_source_props_inner(&session, alter_props, source_id).await?;
+    handle_alter_source_props_inner(&session, alter_props, source_id, &connector).await?;
 
     Ok(RwPgResponse::empty_result(StatementType::ALTER_SOURCE))
 }

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -115,6 +115,7 @@ pub use external_schema::{
     bind_columns_from_source, get_schema_location, schema_has_schema_registry,
 };
 mod validate;
+pub(crate) use validate::validate_cdc_heartbeat_interval;
 pub use validate::validate_compatibility;
 use validate::{SOURCE_ALLOWED_CONNECTION_CONNECTOR, SOURCE_ALLOWED_CONNECTION_SCHEMA_REGISTRY};
 mod additional_column;

--- a/src/frontend/src/handler/create_source/validate.rs
+++ b/src/frontend/src/handler/create_source/validate.rs
@@ -123,6 +123,42 @@ fn validate_license(connector: &str) -> Result<()> {
     Ok(())
 }
 
+/// Keep this policy in sync with Java's `SourceValidateHandler.validateHeartbeatInterval`.
+/// Validates user-supplied options, not the final Debezium configuration. On CREATE, an omitted
+/// interval uses the connector default (300000 ms for PostgreSQL/Citus); on ALTER, omission leaves
+/// the existing interval unchanged. Unrelated connector heartbeat mechanisms are not checked here.
+pub(crate) fn validate_cdc_heartbeat_interval(
+    connector: &str,
+    props: &BTreeMap<String, String>,
+) -> Result<()> {
+    let heartbeat_required = match connector {
+        POSTGRES_CDC_CONNECTOR | CITUS_CDC_CONNECTOR => true,
+        MYSQL_CDC_CONNECTOR | SQL_SERVER_CDC_CONNECTOR | MONGODB_CDC_CONNECTOR => false,
+        _ => return Ok(()),
+    };
+    let Some(value) = props.get("debezium.heartbeat.interval.ms") else {
+        return Ok(());
+    };
+
+    // Debezium defines this field as INT with a nonnegative-integer validator, not LONG.
+    let interval = value
+        .parse::<i32>()
+        .ok()
+        .filter(|interval| *interval >= 0)
+        .ok_or_else(|| {
+            ErrorCode::InvalidParameterValue(format!(
+                "'debezium.heartbeat.interval.ms' must be an integer between 0 and 2147483647, got: '{value}'"
+            ))
+        })?;
+    if heartbeat_required && interval == 0 {
+        return Err(ErrorCode::InvalidParameterValue(
+            "'debezium.heartbeat.interval.ms' must be greater than 0 for PostgreSQL and Citus CDC: heartbeats are required for replication-slot progress and WAL reclamation".to_owned(),
+        )
+        .into());
+    }
+    Ok(())
+}
+
 pub fn validate_compatibility(
     format_encode: &FormatEncodeOptions,
     props: &mut BTreeMap<String, String>,
@@ -271,17 +307,166 @@ pub fn validate_compatibility(
         .into());
     }
 
-    // Validate debezium.heartbeat.interval.ms for Postgres CDC: must be a valid integer and not 0
-    if connector == POSTGRES_CDC_CONNECTOR
-        && let Some(interval_value) = props.get("debezium.heartbeat.interval.ms")
-        && !interval_value.parse::<i64>().is_ok_and(|v| v != 0)
-    {
-        return Err(ErrorCode::InvalidConfigValue {
-            config_entry: "debezium.heartbeat.interval.ms".to_owned(),
-            config_value: interval_value.to_owned(),
+    validate_cdc_heartbeat_interval(&connector, props)
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_sqlparser::ast::{Ident, SqlOption, SqlOptionValue, Value};
+
+    use super::*;
+    use crate::handler::alter_source_props::handle_alter_source_props_inner;
+    use crate::test_utils::LocalFrontend;
+
+    const HEARTBEAT_INTERVAL_CASES: [Option<&str>; 8] = [
+        None,
+        Some("0"),
+        Some("1"),
+        Some("300000"),
+        Some("2147483647"),
+        Some("-1"),
+        Some("invalid"),
+        Some("2147483648"),
+    ];
+
+    #[test]
+    fn test_cdc_heartbeat_interval() {
+        for connector in [
+            MYSQL_CDC_CONNECTOR,
+            SQL_SERVER_CDC_CONNECTOR,
+            MONGODB_CDC_CONNECTOR,
+            POSTGRES_CDC_CONNECTOR,
+            CITUS_CDC_CONNECTOR,
+        ] {
+            let mut props = BTreeMap::new();
+            assert!(validate_cdc_heartbeat_interval(connector, &props).is_ok());
+            for value in ["1", "300000", "2147483647", "+1"] {
+                props.insert(
+                    "debezium.heartbeat.interval.ms".to_owned(),
+                    value.to_owned(),
+                );
+                assert!(
+                    validate_cdc_heartbeat_interval(connector, &props).is_ok(),
+                    "{connector}: {value}"
+                );
+            }
+            for value in [
+                "-1",
+                "",
+                "invalid",
+                "0.5",
+                "2147483648",
+                "9223372036854775807",
+                "9223372036854775808",
+                " 1",
+                "1 ",
+                "１",
+            ] {
+                props.insert(
+                    "debezium.heartbeat.interval.ms".to_owned(),
+                    value.to_owned(),
+                );
+                let err = validate_cdc_heartbeat_interval(connector, &props).unwrap_err();
+                assert!(
+                    err.to_string().contains("between 0 and 2147483647"),
+                    "{err}"
+                );
+            }
+            for value in ["0", "+0", "-0"] {
+                props.insert(
+                    "debezium.heartbeat.interval.ms".to_owned(),
+                    value.to_owned(),
+                );
+                let result = validate_cdc_heartbeat_interval(connector, &props);
+                if matches!(connector, POSTGRES_CDC_CONNECTOR | CITUS_CDC_CONNECTOR) {
+                    let err = result.unwrap_err();
+                    assert!(err.to_string().contains("WAL reclamation"), "{err}");
+                } else {
+                    result.unwrap();
+                }
+            }
         }
-        .into());
     }
 
-    Ok(())
+    #[test]
+    fn test_create_cdc_heartbeat_interval() {
+        for (connector, format) in [
+            (MYSQL_CDC_CONNECTOR, FormatEncodeOptions::debezium_json()),
+            (POSTGRES_CDC_CONNECTOR, FormatEncodeOptions::debezium_json()),
+            (
+                MONGODB_CDC_CONNECTOR,
+                FormatEncodeOptions::debezium_mongo_json(),
+            ),
+        ] {
+            for value in HEARTBEAT_INTERVAL_CASES {
+                let mut props = BTreeMap::from([("connector".to_owned(), connector.to_owned())]);
+                if let Some(value) = value {
+                    props.insert(
+                        "debezium.heartbeat.interval.ms".to_owned(),
+                        value.to_owned(),
+                    );
+                }
+                let expected = validate_cdc_heartbeat_interval(connector, &props);
+                let result = validate_compatibility(&format, &mut props);
+                assert_eq!(
+                    result.map_err(|e| e.to_string()),
+                    expected.map_err(|e| e.to_string()),
+                    "{connector}: {value:?}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_alter_cdc_heartbeat_interval() {
+        let frontend = LocalFrontend::new(Default::default()).await;
+        for connector in [
+            MYSQL_CDC_CONNECTOR,
+            POSTGRES_CDC_CONNECTOR,
+            MONGODB_CDC_CONNECTOR,
+            SQL_SERVER_CDC_CONNECTOR,
+            CITUS_CDC_CONNECTOR,
+        ] {
+            for value in HEARTBEAT_INTERVAL_CASES {
+                let mut props = BTreeMap::new();
+                let mut options = Vec::new();
+                if let Some(value) = value {
+                    props.insert(
+                        "debezium.heartbeat.interval.ms".to_owned(),
+                        value.to_owned(),
+                    );
+                    options.push(SqlOption {
+                        name: ObjectName(vec![Ident::new_unchecked(
+                            "debezium.heartbeat.interval.ms",
+                        )]),
+                        value: SqlOptionValue::Value(Value::SingleQuotedString(value.to_owned())),
+                    });
+                }
+                let expected = validate_cdc_heartbeat_interval(connector, &props);
+                // Exercise the shared ALTER SOURCE/TABLE frontend path. The mock meta client
+                // accepts valid requests; connector-specific ALTER allowlists are not tested here.
+                let result = handle_alter_source_props_inner(
+                    &frontend.session_ref(),
+                    options,
+                    SourceId::new(1),
+                    connector,
+                )
+                .await;
+                assert_eq!(
+                    result.map_err(|e| e.to_string()),
+                    expected.map_err(|e| e.to_string()),
+                    "{connector}: {value:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_non_cdc_heartbeat_interval_ignored() {
+        let props = BTreeMap::from([(
+            "debezium.heartbeat.interval.ms".to_owned(),
+            "invalid".to_owned(),
+        )]);
+        assert!(validate_cdc_heartbeat_interval(KAFKA_CONNECTOR, &props).is_ok());
+    }
 }

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -1435,7 +1435,7 @@ impl FrontendMetaClient for MockFrontendMetaClient {
         _changed_secret_refs: BTreeMap<String, PbSecretRef>,
         _connector_conn_ref: Option<ConnectionId>,
     ) -> RpcResult<()> {
-        unimplemented!()
+        Ok(())
     }
 
     async fn alter_connection_connector_props(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## Expectations

Require every explicitly supplied `debezium.heartbeat.interval.ms` to be a positive signed 32-bit integer (`1..=2147483647` milliseconds), consistently across Rust CREATE, Rust ALTER SOURCE/TABLE, and Java validation. The policy applies to all CDC connectors, including MongoDB and Citus, without connector-specific exceptions.

Omitting the option preserves connector defaults on CREATE and leaves the existing interval unchanged on ALTER.

## Limitations

This only changes validation; heartbeat delivery, snapshot/backfill behavior, connector defaults, and connector-specific ALTER allowlists remain unchanged. Existing sources are not rewritten. Heartbeats keep recovery offsets current but do not guarantee recovery after upstream log retention has expired; this PR does not add automatic resnapshot recovery.

## What's changed and what's your intention?

Closes #27016.

Previously, Rust and Java validated different sets of connectors and allowed negative values or integers outside Debezium's signed 32-bit range through explicit checks. Apply one positive-only policy instead of connector-specific heartbeat exceptions.

MySQL/SQL Server shared-source initialization needs an initial offset even without captured-table activity (see #23304 and #24515). PostgreSQL also needs heartbeat-driven replication-slot progress for WAL reclamation. For MongoDB, heartbeats advance persisted resume tokens during quiet periods, reducing the risk that oplog retention makes recovery impossible. Although upstream Debezium allows zero, RisingWave requires heartbeats for all CDC connectors rather than exposing this recovery risk as an opt-out.

### Implementation

- Share `validate_heartbeat_interval` between Rust CREATE and ALTER. Validate the supplied Debezium option without a connector allowlist or connector argument.
- Run Java heartbeat validation before connector-specific database validation.
- Reject zero, negatives, malformed values, and signed 32-bit overflow with the same message: `'debezium.heartbeat.interval.ms' must be a positive integer, got: '...'`.
- Keep Java's ASCII integer syntax check so it matches Rust; `Integer.parseInt` otherwise also accepts Unicode digits.
- Document that validation inspects user-supplied options, not the resolved Debezium configuration.

Compatibility: definitions or alterations that previously accepted zero, negative, or overflowing intervals now fail validation. Omitted values and valid positive intervals retain their existing behavior.

## Unit tests

No new unit tests are included. The initially added Rust/Java heartbeat unit tests and their mock support were removed in favor of SQL-level regression coverage.

## E2E tests

Extend `e2e_test/source_legacy/cdc/cdc.validate.shared.slt` with MySQL `CREATE SOURCE` cases asserting rejection of `0`, `-1`, and `invalid`. The existing successful MySQL source definition still omits the interval, covering use of the default.

These cases exercise CREATE validation; they do not directly test Java validation in isolation, ALTER behavior, or runtime recovery after a quiet period.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

CDC heartbeat interval validation is now consistent across Rust CREATE/ALTER and Java. All CDC connectors require explicitly supplied `debezium.heartbeat.interval.ms` values to be positive signed 32-bit integers (`1..=2147483647`). Zero, negative, malformed, and overflowing values are rejected. Omitting the option preserves existing defaults or ALTER state. Existing connector defaults and ALTER support are unchanged.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized validation for the Debezium heartbeat interval when creating or altering sources.
  - Positive 32-bit integer values are accepted; zero, negative, malformed, and out-of-range values are rejected with clearer error messages.
  - Validation now applies consistently across supported source types.
  - Omitted heartbeat intervals continue to use the connector default.
  - Added coverage for invalid heartbeat interval values in CDC source creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->