### PR TITLE
fix(stream): honor cluster pause in snapshot backfill and locality provider

### DIFF
--- a/src/stream/src/executor/backfill/snapshot_backfill/consume_upstream/executor.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/consume_upstream/executor.rs
@@ -117,6 +117,7 @@ impl<T: UpstreamTable, S: StateStore> UpstreamTableExecutor<T, S> {
             .check_initial_vnode_bitmap(self.progress_state_table.vnodes())?;
         let first_barrier = receive_next_barrier(&mut self.barrier_rx).await?;
         let first_barrier_epoch = first_barrier.epoch;
+        let mut paused = first_barrier.is_pause_on_startup();
         yield Message::Barrier(first_barrier);
         let mut progress_state = BackfillState::new(
             self.progress_state_table,
@@ -145,7 +146,7 @@ impl<T: UpstreamTable, S: StateStore> UpstreamTableExecutor<T, S> {
             loop {
                 let barrier = {
                     loop {
-                        if self.rate_limiter.rate_limit().is_paused() {
+                        if paused || self.rate_limiter.rate_limit().is_paused() {
                             break receive_next_barrier(&mut self.barrier_rx).await?;
                         }
                         let future1 = receive_next_barrier(&mut self.barrier_rx);
@@ -160,7 +161,7 @@ impl<T: UpstreamTable, S: StateStore> UpstreamTableExecutor<T, S> {
                                 break barrier;
                             }
                             Either::Right(Ok(chunk)) => {
-                                assert!(!self.rate_limiter.rate_limit().is_paused());
+                                assert!(!paused && !self.rate_limiter.rate_limit().is_paused());
                                 self.rate_limiter.wait(chunk.cardinality() as _).await;
                                 yield Message::Chunk(chunk);
                             }
@@ -170,6 +171,7 @@ impl<T: UpstreamTable, S: StateStore> UpstreamTableExecutor<T, S> {
                         }
                     }
                 };
+                barrier.apply_pause_resume(&mut paused);
 
                 if let Some(chunk) = stream.consume_builder() {
                     self.rate_limiter.wait(chunk.cardinality() as _).await;

--- a/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
+++ b/src/stream/src/executor/backfill/snapshot_backfill/executor.rs
@@ -205,6 +205,7 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
         let first_recv_barrier_epoch = first_recv_barrier.epoch;
         let initial_backfill_paused =
             first_recv_barrier.is_backfill_pause_on_startup(self.actor_ctx.fragment_id);
+        let initial_paused = first_recv_barrier.is_pause_on_startup();
         yield Message::Barrier(first_recv_barrier);
         let mut backfill_state = BackfillState::new(
             self.progress_state_table,
@@ -267,6 +268,7 @@ impl<S: StateStore> SnapshotBackfillExecutor<S> {
                             &mut backfill_state,
                             first_recv_barrier_epoch,
                             initial_backfill_paused,
+                            initial_paused,
                             &self.actor_ctx,
                             &self.pk_scan_range,
                         );
@@ -1022,6 +1024,7 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
     backfill_state: &'a mut BackfillState<S>,
     first_recv_barrier_epoch: EpochPair,
     initial_backfill_paused: bool,
+    initial_paused: bool,
     actor_ctx: &'a ActorContextRef,
     pk_scan_range: &'a PkScanRange,
 ) {
@@ -1042,8 +1045,7 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
     async fn select_barrier_and_snapshot_stream(
         barrier_rx: &mut UnboundedReceiver<Barrier>,
         snapshot_stream: &mut (impl Stream<Item = StreamExecutorResult<StreamChunk>> + Unpin),
-        throttle_snapshot_stream: bool,
-        backfill_paused: bool,
+        snapshot_paused: bool,
     ) -> StreamExecutorResult<Either<Barrier, Option<StreamChunk>>> {
         select! {
             biased;
@@ -1051,22 +1053,19 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
             result = receive_next_barrier(barrier_rx) => {
                 Ok(Either::Left(result?))
             },
-            result = snapshot_stream.try_next(), if !throttle_snapshot_stream && !backfill_paused => {
+            result = snapshot_stream.try_next(), if !snapshot_paused => {
                 Ok(Either::Right(result?))
             }
         }
     }
 
     let mut backfill_paused = initial_backfill_paused;
+    let mut paused = initial_paused;
     loop {
-        let throttle_snapshot_stream = matches!(rate_limiter.rate_limit(), RateLimit::Pause);
-        match select_barrier_and_snapshot_stream(
-            barrier_rx,
-            &mut snapshot_stream,
-            throttle_snapshot_stream,
-            backfill_paused,
-        )
-        .await?
+        let snapshot_paused =
+            paused || backfill_paused || matches!(rate_limiter.rate_limit(), RateLimit::Pause);
+        match select_barrier_and_snapshot_stream(barrier_rx, &mut snapshot_stream, snapshot_paused)
+            .await?
         {
             Either::Left(barrier) => {
                 assert_eq!(barrier.epoch.prev, barrier_epoch.curr);
@@ -1075,6 +1074,7 @@ async fn make_consume_snapshot_stream<'a, S: StateStore>(
                 if barrier_epoch.curr >= snapshot_epoch {
                     return Err(anyhow!("should not receive barrier with epoch {barrier_epoch:?} later than snapshot epoch {snapshot_epoch}").into());
                 }
+                barrier.apply_pause_resume(&mut paused);
                 if barrier.should_start_fragment_backfill(actor_ctx.fragment_id) {
                     backfill_paused = false;
                 }

--- a/src/stream/src/executor/dispatch/dispatch_sync_log_store.rs
+++ b/src/stream/src/executor/dispatch/dispatch_sync_log_store.rs
@@ -432,10 +432,7 @@ impl<S: StateStore> StreamConsumer for SyncLogStoreDispatchExecutor<S> {
                                         clean_state = false;
                                         log_store_config.metrics.unclean_state.inc();
                                     } else {
-                                        SyncedKvLogStoreExecutor::<S>::apply_pause_resume_mutation(
-                                            &barrier,
-                                            &mut pause_stream,
-                                        );
+                                        barrier.apply_pause_resume(&mut pause_stream);
                                         let write_state_post_write_barrier =
                                             SyncedKvLogStoreExecutor::<S>::write_barrier(
                                                 actor_id,

--- a/src/stream/src/executor/locality_provider.rs
+++ b/src/stream/src/executor/locality_provider.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use futures::future::{Either as FutureEither, select};
+use futures::future::{Either as FutureEither, pending, select};
 use futures::{StreamExt, TryStreamExt, pin_mut};
 use futures_async_stream::try_stream;
 use itertools::Itertools;
@@ -439,6 +439,7 @@ impl<S: StateStore> LocalityProviderExecutor<S> {
         // Wait for first barrier to initialize
         let first_barrier = expect_first_barrier(&mut upstream).await?;
         let first_epoch = first_barrier.epoch;
+        let mut paused = first_barrier.is_pause_on_startup();
 
         // Propagate the first barrier
         yield Message::Barrier(first_barrier);
@@ -482,6 +483,7 @@ impl<S: StateStore> LocalityProviderExecutor<S> {
                     }
                     Message::Barrier(barrier) => {
                         let epoch = barrier.epoch;
+                        barrier.apply_pause_resume(&mut paused);
 
                         // Check for StartFragmentBackfill mutation
                         if let Some(mutation) = barrier.mutation.as_deref() {
@@ -579,13 +581,22 @@ impl<S: StateStore> LocalityProviderExecutor<S> {
                 let barrier = loop {
                     let upstream_next = upstream.next();
                     let mut snapshot_stream_ref = snapshot_stream.as_mut();
-                    let snapshot_next = snapshot_stream_ref.next();
+                    // Only the upstream is polled while paused, so no snapshot row is produced.
+                    let snapshot_paused = paused;
+                    let snapshot_next = async move {
+                        if snapshot_paused {
+                            pending().await
+                        } else {
+                            snapshot_stream_ref.next().await
+                        }
+                    };
                     pin_mut!(upstream_next);
                     pin_mut!(snapshot_next);
 
                     match select(upstream_next, snapshot_next).await {
                         FutureEither::Left((msg, _)) => match msg.transpose()? {
                             Some(Message::Barrier(barrier)) => {
+                                barrier.apply_pause_resume(&mut paused);
                                 // Process the barrier after draining the snapshot builders.
                                 break barrier;
                             }

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -596,6 +596,15 @@ impl Barrier {
         }
     }
 
+    /// Updates `paused` on a `Pause` or `Resume` mutation and leaves it untouched otherwise.
+    pub fn apply_pause_resume(&self, paused: &mut bool) {
+        match self.mutation.as_deref() {
+            Some(Mutation::Pause) => *paused = true,
+            Some(Mutation::Resume) => *paused = false,
+            _ => {}
+        }
+    }
+
     pub fn is_backfill_pause_on_startup(&self, backfill_fragment_id: FragmentId) -> bool {
         match self.mutation.as_deref() {
             Some(Mutation::Add(AddMutation {

--- a/src/stream/src/executor/sync_kv_log_store.rs
+++ b/src/stream/src/executor/sync_kv_log_store.rs
@@ -644,20 +644,6 @@ impl<S: StateStore> SyncedKvLogStoreExecutor<S> {
         }
     }
 
-    pub(crate) fn apply_pause_resume_mutation(barrier: &Barrier, pause_stream: &mut bool) {
-        if let Some(mutation) = barrier.mutation.as_deref() {
-            match mutation {
-                Mutation::Pause => {
-                    *pause_stream = true;
-                }
-                Mutation::Resume => {
-                    *pause_stream = false;
-                }
-                _ => {}
-            }
-        }
-    }
-
     pub(crate) fn process_upstream_chunk(
         seq_id: SeqId,
         stream: BoxedMessageStream,
@@ -839,7 +825,7 @@ impl<S: StateStore> SyncedKvLogStoreExecutor<S> {
                                     clean_state = false;
                                     self.logstore_context.metrics.unclean_state.inc();
                                 } else {
-                                    Self::apply_pause_resume_mutation(&barrier, &mut pause_stream);
+                                    barrier.apply_pause_resume(&mut pause_stream);
                                     let write_state_post_write_barrier = Self::write_barrier(
                                         self.actor_context.id,
                                         &mut write_state,

--- a/src/tests/simulation/tests/integration_tests/recovery/mod.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/mod.rs
@@ -20,6 +20,7 @@ mod drop_streaming_job;
 mod event_log;
 mod locality_backfill;
 mod nexmark_recovery;
+mod pause;
 mod recovery_info;
 mod serving_mapping;
 mod serving_mapping_start_order;

--- a/src/tests/simulation/tests/integration_tests/recovery/pause.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/pause.rs
@@ -1,0 +1,228 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use anyhow::{Result, bail};
+use risingwave_simulation::cluster::{Cluster, Configuration, Session};
+use tokio::time::sleep;
+
+use crate::utils::wait_all_database_recovered;
+
+const SEED_ROWS: u64 = 10000;
+const CREATE_TABLE: &str = "CREATE TABLE t (v int);";
+const SEED_TABLE: &str = "INSERT INTO t SELECT * FROM generate_series(1, 10000);";
+const CREATE_MV: &str = "CREATE MATERIALIZED VIEW mv AS SELECT * FROM t;";
+const ALTER_RATE_LIMIT_DEFAULT: &str =
+    "ALTER MATERIALIZED VIEW mv SET BACKFILL_RATE_LIMIT = DEFAULT;";
+
+async fn seed_table(session: &mut Session) -> Result<()> {
+    session.run(CREATE_TABLE).await?;
+    session.run(SEED_TABLE).await?;
+    session.flush().await
+}
+
+/// Starts a rate-limited snapshot backfill in the background.
+async fn start_slow_snapshot_backfill(cluster: &mut Cluster) -> Result<Session> {
+    let mut session = cluster.start_session();
+    session
+        .run("SET streaming_use_snapshot_backfill = true;")
+        .await?;
+    session.run("SET background_ddl = true;").await?;
+    session.run("SET backfill_rate_limit = 10;").await?;
+    seed_table(&mut session).await?;
+    session.run(CREATE_MV).await?;
+    Ok(session)
+}
+
+/// Rows consumed by the only creating job, parsed from a progress like
+/// `Snapshot [1.23% (123/10000)]`.
+async fn consumed_rows(session: &mut Session) -> Result<u64> {
+    let progress = session
+        .run("SELECT progress FROM rw_catalog.rw_ddl_progress;")
+        .await?;
+    let Some((_, rest)) = progress.split_once('(') else {
+        bail!("unexpected progress: {progress}");
+    };
+    let Some((consumed, _)) = rest.split_once('/') else {
+        bail!("unexpected progress: {progress}");
+    };
+    Ok(consumed.parse()?)
+}
+
+async fn wait_backfill_started(session: &mut Session) -> Result<()> {
+    for _ in 0..60 {
+        if consumed_rows(session).await.unwrap_or(0) > 0 {
+            return Ok(());
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+    bail!("backfill did not start");
+}
+
+/// Asserts the backfill makes no progress once the pause barrier has settled and returns the
+/// frozen count.
+async fn assert_backfill_frozen(session: &mut Session) -> Result<u64> {
+    sleep(Duration::from_secs(3)).await;
+    let before = consumed_rows(session).await?;
+    sleep(Duration::from_secs(10)).await;
+    let after = consumed_rows(session).await?;
+    assert_eq!(before, after, "backfill progressed while paused");
+    Ok(after)
+}
+
+async fn resume_and_finish(
+    cluster: &mut Cluster,
+    session: &mut Session,
+    frozen: u64,
+) -> Result<()> {
+    cluster.resume().await?;
+    sleep(Duration::from_secs(5)).await;
+    assert!(
+        consumed_rows(session).await? > frozen,
+        "backfill did not resume"
+    );
+
+    session.run(ALTER_RATE_LIMIT_DEFAULT).await?;
+    session.run("WAIT;").await?;
+    let count = session.run("SELECT count(*) FROM mv;").await?;
+    assert_eq!(count, SEED_ROWS.to_string());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_pause_freezes_snapshot_backfill() -> Result<()> {
+    let mut cluster = Cluster::start(Configuration::for_background_ddl()).await?;
+    let mut session = start_slow_snapshot_backfill(&mut cluster).await?;
+    wait_backfill_started(&mut session).await?;
+
+    cluster.pause().await?;
+    let frozen = assert_backfill_frozen(&mut session).await?;
+
+    resume_and_finish(&mut cluster, &mut session, frozen).await
+}
+
+#[tokio::test]
+async fn test_pause_on_next_bootstrap_with_snapshot_backfill_job() -> Result<()> {
+    let mut cluster = Cluster::start(Configuration::for_background_ddl()).await?;
+    let mut session = start_slow_snapshot_backfill(&mut cluster).await?;
+    wait_backfill_started(&mut session).await?;
+
+    session
+        .run("ALTER SYSTEM SET pause_on_next_bootstrap = true;")
+        .await?;
+    cluster.kill_nodes_and_restart(["meta-1"], 5).await;
+    cluster.wait_for_recovery().await?;
+    wait_all_database_recovered(&mut cluster).await;
+
+    let mut session = cluster.start_session();
+    let frozen = assert_backfill_frozen(&mut session).await?;
+
+    resume_and_finish(&mut cluster, &mut session, frozen).await
+}
+
+/// The compute nodes come back after meta, so the database fails the global recovery attempt and
+/// is recovered on its own. The paused bootstrap must survive that path.
+#[tokio::test]
+async fn test_pause_on_next_bootstrap_with_late_compute_nodes() -> Result<()> {
+    let mut cluster = Cluster::start(Configuration::for_background_ddl()).await?;
+    let mut session = start_slow_snapshot_backfill(&mut cluster).await?;
+    wait_backfill_started(&mut session).await?;
+
+    session
+        .run("ALTER SYSTEM SET pause_on_next_bootstrap = true;")
+        .await?;
+    tokio::join!(
+        cluster.kill_nodes_and_restart(["meta-1"], 2),
+        cluster.kill_nodes_and_restart(["compute-1", "compute-2", "compute-3"], 8),
+    );
+    cluster.wait_for_recovery().await?;
+    wait_all_database_recovered(&mut cluster).await;
+
+    let mut session = cluster.start_session();
+    let frozen = assert_backfill_frozen(&mut session).await?;
+
+    resume_and_finish(&mut cluster, &mut session, frozen).await
+}
+
+/// A paused database stays paused after it recovers from a compute node failure.
+#[tokio::test]
+async fn test_pause_survives_database_recovery() -> Result<()> {
+    let mut cluster = Cluster::start(Configuration::for_background_ddl()).await?;
+    let mut session = start_slow_snapshot_backfill(&mut cluster).await?;
+    wait_backfill_started(&mut session).await?;
+
+    cluster.pause().await?;
+    assert_backfill_frozen(&mut session).await?;
+
+    cluster.kill_nodes_and_restart(["compute-1"], 3).await;
+    wait_all_database_recovered(&mut cluster).await;
+
+    let mut session = cluster.start_session();
+    let frozen = assert_backfill_frozen(&mut session).await?;
+
+    resume_and_finish(&mut cluster, &mut session, frozen).await
+}
+
+/// Creates `mv` with `create_mv` while the cluster is paused, checks that it consumes nothing
+/// until `resume`, then lets it finish.
+async fn assert_create_while_paused(
+    cluster: &mut Cluster,
+    session: &mut Session,
+    create_mv: &str,
+) -> Result<()> {
+    cluster.pause().await?;
+    session.run("SET background_ddl = true;").await?;
+    session.run("SET backfill_rate_limit = 10;").await?;
+    session.run(create_mv).await?;
+    sleep(Duration::from_secs(10)).await;
+    assert_eq!(consumed_rows(session).await?, 0, "backfill ran while paused");
+
+    cluster.resume().await?;
+    wait_backfill_started(session).await?;
+    session.run(ALTER_RATE_LIMIT_DEFAULT).await?;
+    session.run("WAIT;").await?;
+    let count = session.run("SELECT count(*) FROM mv;").await?;
+    assert_eq!(count, SEED_ROWS.to_string());
+    Ok(())
+}
+
+/// A job created while the cluster is paused starts paused and only runs after `resume`.
+#[tokio::test]
+async fn test_create_while_paused() -> Result<()> {
+    let mut cluster = Cluster::start(Configuration::for_background_ddl()).await?;
+    let mut session = cluster.start_session();
+    seed_table(&mut session).await?;
+    session
+        .run("SET streaming_use_snapshot_backfill = true;")
+        .await?;
+    assert_create_while_paused(&mut cluster, &mut session, CREATE_MV).await
+}
+
+/// Same for a batch refresh job, whose partial graph is created by its own path in meta.
+#[tokio::test]
+async fn test_create_batch_refresh_while_paused() -> Result<()> {
+    let mut cluster = Cluster::start(Configuration::for_background_ddl()).await?;
+    let mut session = cluster.start_session();
+    seed_table(&mut session).await?;
+    session
+        .run("CREATE MATERIALIZED VIEW mv_up AS SELECT * FROM t;")
+        .await?;
+    assert_create_while_paused(
+        &mut cluster,
+        &mut session,
+        "CREATE MATERIALIZED VIEW mv WITH (refresh.interval.sec = 600) AS SELECT * FROM mv_up;",
+    )
+    .await
+}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Two executors that produce rows on their own ignored cluster pause, so `risectl meta pause` and `pause_on_next_bootstrap` could not quiesce a graph with either in flight:

- Snapshot backfill (both `SnapshotBackfillExecutor` and the cross-db `UpstreamTableExecutor`) only reacted to `BACKFILL_RATE_LIMIT`. The snapshot read is now also gated by `is_pause_on_startup()` and `Pause` / `Resume`.
- `LocalityProvider` reacted to nothing. Its drain phase now polls only the upstream while paused.
- `Barrier::apply_pause_resume` replaces the private helper in the sync log store.

The log-store catch-up phase of snapshot backfill is deliberately left running: it consumes upstream changes (the log-store analogue of arrangement backfill forwarding upstream chunks) and is bounded while the upstream is paused, whereas deferring it would also defer `UpstreamBuffer::consumed_epoch` and back-pressure the upstream.

Tests (`recovery::pause`, simulation): `risectl meta pause` freezes a snapshot backfill; `pause_on_next_bootstrap` with an in-flight snapshot backfill job across a meta restart, both when the compute nodes stay up and when they come back after meta (per-database recovery); a paused database stays paused after a compute node failure; a snapshot backfill job and a batch refresh job created while the cluster is paused start paused. The locality provider is covered by the stacked PR that gives it a rate limit, which is needed to observe its drain.

Verified locally on a `meta-1cn-1fe-sqlite` cluster: a snapshot backfill at `backfill_rate_limit = 50` stayed at 7000/100000 rows for 13s after `risectl meta pause`, advanced again after `resume`, and completed with 100000 rows. A batch refresh MV created while paused stayed at 0/100000 rows for 15s and completed after `resume`.

- Closes #27015

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
