### PR TITLE
feat(stream): apply backfill rate limit to the locality provider drain

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -1167,6 +1167,8 @@ message LocalityProviderNode {
   optional catalog.Table state_table = 2;
   // Progress table for tracking backfill progress
   optional catalog.Table progress_table = 3;
+  // Rate limit of the drain phase, set by `BACKFILL_RATE_LIMIT`.
+  optional uint32 rate_limit = 4;
 }
 
 message EowcGapFillNode {

--- a/src/common/src/catalog/mod.rs
+++ b/src/common/src/catalog/mod.rs
@@ -424,7 +424,12 @@ impl FragmentTypeFlag {
 
     /// Fragments that may be affected by `BACKFILL_RATE_LIMIT`.
     pub fn backfill_rate_limit_fragments() -> impl Iterator<Item = FragmentTypeFlag> {
-        [FragmentTypeFlag::SourceScan, FragmentTypeFlag::StreamScan].into_iter()
+        [
+            FragmentTypeFlag::SourceScan,
+            FragmentTypeFlag::StreamScan,
+            FragmentTypeFlag::LocalityProvider,
+        ]
+        .into_iter()
     }
 
     /// Fragments that may be affected by `SOURCE_RATE_LIMIT`.

--- a/src/frontend/src/optimizer/plan_node/stream_locality_provider.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_locality_provider.rs
@@ -108,6 +108,7 @@ impl StreamNode for StreamLocalityProvider {
             state_table: Some(state_table.to_prost()),
             // Progress table for tracking backfill progress
             progress_table: Some(progress_table.to_prost()),
+            rate_limit: self.base.ctx().overwrite_options().backfill_rate_limit,
         };
 
         PbNodeBody::LocalityProvider(Box::new(locality_provider_node))

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -2783,6 +2783,10 @@ impl CatalogController {
                             node.rate_limit = rate_limit;
                             found = true;
                         }
+                        PbNodeBody::LocalityProvider(node) => {
+                            node.rate_limit = rate_limit;
+                            found = true;
+                        }
                         _ => {}
                     });
                 }
@@ -3815,6 +3819,10 @@ impl CatalogController {
                                 node.rate_limit = rate_limit;
                                 found = Ok(true);
                             }
+                            PbNodeBody::LocalityProvider(node) => {
+                                node.rate_limit = rate_limit;
+                                found = Ok(true);
+                            }
                             _ => {}
                         });
                     }
@@ -3912,6 +3920,10 @@ impl CatalogController {
                     PbNodeBody::StreamCdcScan(node) => {
                         rate_limit = node.rate_limit;
                         node_name = Some("STREAM_CDC_SCAN");
+                    }
+                    PbNodeBody::LocalityProvider(node) => {
+                        rate_limit = node.rate_limit;
+                        node_name = Some("LOCALITY_PROVIDER");
                     }
                     PbNodeBody::Sink(node) => {
                         rate_limit = node.rate_limit;

--- a/src/stream/src/executor/locality_provider.rs
+++ b/src/stream/src/executor/locality_provider.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use futures::future::{Either as FutureEither, select};
+use futures::future::{Either as FutureEither, pending, select};
 use futures::{StreamExt, TryStreamExt, pin_mut};
 use futures_async_stream::try_stream;
 use itertools::Itertools;
@@ -26,7 +26,8 @@ use risingwave_common::row::{OwnedRow, Row, RowExt};
 use risingwave_common::types::{Datum, ToOwnedDatum};
 use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
 use risingwave_common::util::sort_util::cmp_datum_iter;
-use risingwave_common_rate_limit::RateLimit;
+use risingwave_common_rate_limit::{MonitoredRateLimiter, RateLimit, RateLimiter};
+use risingwave_pb::common::ThrottleType;
 use risingwave_storage::StateStore;
 use risingwave_storage::store::PrefetchOptions;
 
@@ -188,6 +189,8 @@ pub struct LocalityProviderExecutor<S: StateStore> {
 
     /// Chunk size for output
     chunk_size: usize,
+
+    rate_limiter: MonitoredRateLimiter,
 }
 
 impl<S: StateStore> LocalityProviderExecutor<S> {
@@ -202,7 +205,9 @@ impl<S: StateStore> LocalityProviderExecutor<S> {
         metrics: Arc<StreamingMetrics>,
         chunk_size: usize,
         fragment_id: FragmentId,
+        rate_limit: RateLimit,
     ) -> Self {
+        let rate_limiter = RateLimiter::new(rate_limit).monitored(state_table.table_id());
         Self {
             upstream,
             locality_columns,
@@ -214,14 +219,42 @@ impl<S: StateStore> LocalityProviderExecutor<S> {
             metrics,
             chunk_size,
             fragment_id,
+            rate_limiter,
         }
+    }
+
+    /// Returns the new rate limit if it changed.
+    fn apply_throttle(
+        rate_limiter: &MonitoredRateLimiter,
+        fragment_id: FragmentId,
+        barrier: &Barrier,
+    ) -> Option<RateLimit> {
+        let Some(Mutation::Throttle(fragment_to_apply)) = barrier.mutation.as_deref() else {
+            return None;
+        };
+        let entry = fragment_to_apply.get(&fragment_id)?;
+        if entry.throttle_type() != ThrottleType::Backfill {
+            return None;
+        }
+        let new_rate_limit = entry.rate_limit.into();
+        let old_rate_limit = rate_limiter.update(new_rate_limit);
+        (old_rate_limit != new_rate_limit).then(|| {
+            tracing::info!(
+                ?old_rate_limit,
+                ?new_rate_limit,
+                %fragment_id,
+                "locality backfill rate limit changed"
+            );
+            new_rate_limit
+        })
     }
 
     /// Creates a snapshot stream that reads from state table in locality order
     #[try_stream(ok = (VirtualNode, OwnedRow), error = StreamExecutorError)]
-    async fn make_snapshot_stream(
+    async fn make_snapshot_stream<'a>(
         reader: FlushedStateTableReader<S>,
         backfill_state: LocalityBackfillState,
+        rate_limiter: &'a MonitoredRateLimiter,
     ) {
         // Read from state table per vnode in locality order
         for vnode in reader.vnodes().iter_vnodes() {
@@ -260,6 +293,7 @@ impl<S: StateStore> LocalityProviderExecutor<S> {
             pin_mut!(iter);
 
             while let Some(row) = iter.try_next().await? {
+                rate_limiter.wait(1).await;
                 yield (vnode, row);
             }
         }
@@ -445,6 +479,7 @@ impl<S: StateStore> LocalityProviderExecutor<S> {
 
         let mut state_table = self.state_table;
         let mut progress_table = self.progress_table;
+        let rate_limiter = self.rate_limiter;
 
         // Initialize state tables
         state_table.init_epoch(first_epoch).await?;
@@ -482,6 +517,7 @@ impl<S: StateStore> LocalityProviderExecutor<S> {
                     }
                     Message::Barrier(barrier) => {
                         let epoch = barrier.epoch;
+                        Self::apply_throttle(&rate_limiter, self.fragment_id, &barrier);
 
                         // Check for StartFragmentBackfill mutation
                         if let Some(mutation) = barrier.mutation.as_deref() {
@@ -552,22 +588,28 @@ impl<S: StateStore> LocalityProviderExecutor<S> {
 
             // Create builders for snapshot data chunks
             let snapshot_data_types = self.input_schema.data_types();
-            let mut builders: Builders = state_table
-                .vnodes()
-                .iter_vnodes()
-                .map(|vnode| {
-                    let builder = create_builder(
-                        RateLimit::Disabled,
-                        self.chunk_size,
-                        snapshot_data_types.clone(),
-                    );
-                    (vnode, builder)
-                })
-                .collect();
+            let vnodes = state_table.vnodes().clone();
+            let new_builders = |rate_limit| -> Builders {
+                vnodes
+                    .iter_vnodes()
+                    .map(|vnode| {
+                        let builder = create_builder(
+                            rate_limit,
+                            self.chunk_size,
+                            snapshot_data_types.clone(),
+                        );
+                        (vnode, builder)
+                    })
+                    .collect()
+            };
+            let mut builders = new_builders(rate_limiter.rate_limit());
 
             let snapshot_reader = state_table.flushed_snapshot_reader();
-            let snapshot_stream =
-                Self::make_snapshot_stream(snapshot_reader.clone(), backfill_state.clone());
+            let snapshot_stream = Self::make_snapshot_stream(
+                snapshot_reader.clone(),
+                backfill_state.clone(),
+                &rate_limiter,
+            );
             pin_mut!(snapshot_stream);
 
             'backfill_loop: loop {
@@ -579,7 +621,14 @@ impl<S: StateStore> LocalityProviderExecutor<S> {
                 let barrier = loop {
                     let upstream_next = upstream.next();
                     let mut snapshot_stream_ref = snapshot_stream.as_mut();
-                    let snapshot_next = snapshot_stream_ref.next();
+                    let snapshot_paused = rate_limiter.rate_limit().is_paused();
+                    let snapshot_next = async move {
+                        if snapshot_paused {
+                            pending().await
+                        } else {
+                            snapshot_stream_ref.next().await
+                        }
+                    };
                     pin_mut!(upstream_next);
                     pin_mut!(snapshot_next);
 
@@ -669,6 +718,12 @@ impl<S: StateStore> LocalityProviderExecutor<S> {
                     }
                 }
 
+                if let Some(new_rate_limit) =
+                    Self::apply_throttle(&rate_limiter, self.fragment_id, &barrier)
+                {
+                    builders = new_builders(new_rate_limit);
+                }
+
                 // Process upstream buffer chunks with marking
                 let should_refresh_snapshot = !upstream_chunk_buffer.is_empty();
                 for chunk in upstream_chunk_buffer.drain(..) {
@@ -731,6 +786,7 @@ impl<S: StateStore> LocalityProviderExecutor<S> {
                     snapshot_stream.set(Self::make_snapshot_stream(
                         snapshot_reader.clone(),
                         backfill_state.clone(),
+                        &rate_limiter,
                     ));
                 }
             }

--- a/src/stream/src/from_proto/locality_provider.rs
+++ b/src/stream/src/from_proto/locality_provider.rs
@@ -79,6 +79,7 @@ impl ExecutorBuilder for LocalityProviderBuilder {
             params.executor_stats.clone(),
             params.config.developer.chunk_size,
             params.actor_context.fragment_id,
+            node.rate_limit.into(),
         );
 
         Ok((params.info, exec).into())

--- a/src/tests/simulation/tests/integration_tests/recovery/locality_backfill.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/locality_backfill.rs
@@ -29,6 +29,8 @@ const ALTER_RATE_LIMIT_DEFAULT: &str =
     "ALTER MATERIALIZED VIEW mv SET BACKFILL_RATE_LIMIT = DEFAULT;";
 const WAIT: &str = "WAIT;";
 const WAIT_INTERNAL_STATE_SECS: u64 = 60;
+const MV_RATE_LIMITS: &str = "SELECT node_name, rate_limit FROM rw_catalog.rw_rate_limit \
+     JOIN rw_catalog.rw_relations ON table_id = id WHERE name = 'mv' ORDER BY node_name;";
 
 async fn wait_internal_table_name(
     session: &mut Session,
@@ -167,5 +169,79 @@ async fn test_locality_backfill_recovery_internal_tables() -> Result<()> {
     session.run("DROP MATERIALIZED VIEW mv;").await?;
     session.run("DROP TABLE t;").await?;
 
+    Ok(())
+}
+
+async fn drained_rows(session: &mut Session, progress_table: &str) -> Result<u64> {
+    let sum = session
+        .run(&format!(
+            "SELECT coalesce(sum(row_count), 0) FROM {progress_table};"
+        ))
+        .await?;
+    Ok(sum.parse()?)
+}
+
+async fn wait_drain_started(session: &mut Session) -> Result<String> {
+    let progress_table = wait_internal_table_name(
+        session,
+        "%localityproviderprogress%",
+        "for locality provider progress",
+    )
+    .await?;
+    for _ in 0..180 {
+        if drained_rows(session, &progress_table).await? > 0 {
+            return Ok(progress_table);
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+    bail!("locality backfill did not start draining");
+}
+
+#[tokio::test]
+async fn test_locality_backfill_rate_limit() -> Result<()> {
+    let mut cluster = Cluster::start(Configuration::for_background_ddl()).await?;
+    let mut session = cluster.start_session();
+    session.run(SET_LOCALITY_BACKFILL).await?;
+    session.run(SET_LOCALITY_BACKFILL_ALWAYS).await?;
+    session.run(SET_BACKGROUND_DDL).await?;
+    session.run("SET backfill_rate_limit = 10;").await?;
+    session.run(CREATE_TABLE).await?;
+    session
+        .run("INSERT INTO t SELECT * FROM generate_series(1, 500);")
+        .await?;
+    session.flush().await?;
+    session.run(CREATE_MV).await?;
+    assert_eq!(
+        session.run(MV_RATE_LIMITS).await?,
+        "LOCALITY_PROVIDER 10\nSTREAM_SCAN 10"
+    );
+
+    let progress_table = wait_drain_started(&mut session).await?;
+    session
+        .run("ALTER MATERIALIZED VIEW mv SET BACKFILL_RATE_LIMIT = 0;")
+        .await?;
+    sleep(Duration::from_secs(3)).await;
+    let frozen = drained_rows(&mut session, &progress_table).await?;
+    sleep(Duration::from_secs(10)).await;
+    assert_eq!(
+        drained_rows(&mut session, &progress_table).await?,
+        frozen,
+        "locality backfill drained at rate limit 0"
+    );
+
+    session
+        .run("ALTER MATERIALIZED VIEW mv SET BACKFILL_RATE_LIMIT = 10;")
+        .await?;
+    sleep(Duration::from_secs(5)).await;
+    assert!(
+        drained_rows(&mut session, &progress_table).await? > frozen,
+        "locality backfill did not resume"
+    );
+
+    session.run(ALTER_RATE_LIMIT_DEFAULT).await?;
+    // Fragments without a rate limit are not listed.
+    assert_eq!(session.run(MV_RATE_LIMITS).await?, "");
+    session.run(WAIT).await?;
+    assert_eq!(session.run("SELECT count(*) FROM mv;").await?, "500");
     Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

The drain phase of `LocalityProvider` ignored `BACKFILL_RATE_LIMIT`, so a locality backfill could not be throttled or stopped, and it did not show up in `rw_catalog.rw_rate_limit`. It now follows the rate limit like the other backfill nodes:

- `LocalityProviderNode.rate_limit` is set from `backfill_rate_limit` at plan time.
- `FragmentTypeFlag::LocalityProvider` joins `backfill_rate_limit_fragments()`, so `ALTER ... SET BACKFILL_RATE_LIMIT` updates the node, the `Throttle` mutation reaches the fragment, and `rw_rate_limit` lists it as `LOCALITY_PROVIDER`.
- The executor rate-limits its snapshot rows, stops reading them at rate limit `0`, and rebuilds its chunk builders when the limit changes, like arrangement backfill.

Test: `recovery::locality_backfill::test_locality_backfill_rate_limit` checks the `rw_rate_limit` rows, that `BACKFILL_RATE_LIMIT = 0` freezes the drain and raising it resumes it, and that the job completes after `= DEFAULT`.

Verified on a `meta-1cn-1fe-sqlite` cluster: `rw_rate_limit` listed `LOCALITY_PROVIDER 20` and `STREAM_SCAN 20`. At `BACKFILL_RATE_LIMIT = 0` the drain stayed at 156 rows for 10s, it reached 540 rows 5s after raising the limit back to 20, both rows left `rw_rate_limit` after `= DEFAULT`, and the view completed with 4000 rows.

- Related: #27015, #23338

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [x] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

`BACKFILL_RATE_LIMIT` (session variable `backfill_rate_limit` and `ALTER MATERIALIZED VIEW ... SET BACKFILL_RATE_LIMIT`) now also throttles the locality backfill drain, and `rw_catalog.rw_rate_limit` lists those fragments as `LOCALITY_PROVIDER`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable rate limiting for locality-provider backfills.
  - Locality-provider backfills now honor configured limits during snapshot reads.
  - Setting the backfill rate limit to `0` pauses progress; restoring a positive limit resumes processing.
  - Locality-provider rate limits are now included in rate-limit listings and can be updated through existing controls.
- **Bug Fixes**
  - Ensured locality-provider backfill rate-limit settings are consistently propagated and applied during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->