### PR TITLE
chore: update version to v3.1.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "delta_btree_map"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "educe",
  "enum-as-inner 0.7.0",
@@ -8973,7 +8973,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openai_embedding_service"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "async-openai",
  "axum",
@@ -9688,7 +9688,7 @@ dependencies = [
 
 [[package]]
 name = "pgwire"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "auto_enums",
@@ -11409,7 +11409,7 @@ dependencies = [
 
 [[package]]
 name = "risedev"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11441,7 +11441,7 @@ dependencies = [
 
 [[package]]
 name = "risedev-config"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -11454,7 +11454,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave-fields-derive"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "expect-test",
  "indoc",
@@ -11466,7 +11466,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_backup"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11489,7 +11489,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_batch"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11534,7 +11534,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_batch_executors"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "allocator-api2",
  "anyhow",
@@ -11579,7 +11579,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_bench"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -11600,7 +11600,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_cmd"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "clap",
  "madsim-tokio",
@@ -11620,7 +11620,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_cmd_all"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "clap",
  "console",
@@ -11653,7 +11653,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "ahash 0.8.11",
  "allocator-api2",
@@ -11774,7 +11774,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_estimate_size"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "bytes",
  "educe",
@@ -11788,7 +11788,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_heap_profiling"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "chrono",
  "itertools 0.14.0",
@@ -11807,7 +11807,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_log"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "governor",
  "madsim-tokio",
@@ -11817,7 +11817,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_metrics"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "auto_impl",
  "bytes",
@@ -11851,7 +11851,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_proc_macro"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "bae",
  "itertools 0.14.0",
@@ -11863,7 +11863,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_rate_limit"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "arc-swap",
  "madsim-tokio",
@@ -11877,7 +11877,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_secret"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
@@ -11901,7 +11901,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_service"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "async-trait",
  "await-tree",
@@ -11927,7 +11927,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_compaction_test"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -11948,7 +11948,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_compactor"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "async-trait",
  "await-tree",
@@ -11972,7 +11972,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_compute"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12017,7 +12017,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_connector"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "adbc_core",
  "adbc_snowflake",
@@ -12153,7 +12153,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_connector_codec"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "apache-avro 0.21.0 (git+https://github.com/risingwavelabs/avro-rs?rev=1f2723802d4fb77b97fa084f7bb81e3b60b9e03f)",
@@ -12190,7 +12190,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_ctl"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -12230,7 +12230,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_dml"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "assert_matches",
  "futures",
@@ -12248,7 +12248,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_e2e_extended_mode_test"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -12263,7 +12263,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_error"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -12279,7 +12279,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_expr"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12317,7 +12317,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_expr_impl"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -12390,7 +12390,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_frontend"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -12489,7 +12489,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_frontend_macro"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12498,7 +12498,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_hummock_sdk"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "bytes",
  "hex",
@@ -12513,7 +12513,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_hummock_test"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -12545,7 +12545,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_hummock_trace"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "async-trait",
  "bincode 2.0.1",
@@ -12617,7 +12617,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_license"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "auto_enums",
  "expect-test",
@@ -12636,7 +12636,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_mem_table_spill_test"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "madsim-tokio",
  "risingwave_common",
@@ -12647,7 +12647,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -12726,7 +12726,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_dashboard"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -12746,7 +12746,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_model"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "prost 0.14.3",
  "risingwave_common",
@@ -12760,7 +12760,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_model_migration"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "easy-ext",
  "madsim-tokio",
@@ -12776,7 +12776,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_node"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "clap",
  "educe",
@@ -12803,7 +12803,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta_service"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12832,7 +12832,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_mysql_test"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "futures",
  "madsim-tokio",
@@ -12841,7 +12841,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_object_store"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "async-trait",
  "await-tree",
@@ -12874,7 +12874,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_pb"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "enum-as-inner 0.7.0",
  "fs-err",
@@ -12901,7 +12901,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_planner_test"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -12924,7 +12924,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_regress_test"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -12938,7 +12938,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_rpc_client"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12969,7 +12969,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_rt"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "await-tree",
  "console",
@@ -13058,7 +13058,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_sqlparser"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "console",
@@ -13079,7 +13079,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_sqlsmith"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -13110,7 +13110,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_state_cleaning_test"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -13129,7 +13129,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_storage"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -13200,7 +13200,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_stream"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -13279,7 +13279,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_telemetry_event"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "jsonbb",
  "madsim-tokio",
@@ -13293,7 +13293,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_test_runner"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "fail",
  "sync-point",
@@ -13302,7 +13302,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_variables"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "chrono",
  "workspace-hack",
@@ -18094,7 +18094,7 @@ dependencies = [
 
 [[package]]
 name = "with_options"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -18114,7 +18114,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-config"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 dependencies = [
  "aws-lc-rs",
  "liblzma-sys",
@@ -18128,7 +18128,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-hack"
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "3.1.0-alpha"
+version = "3.1.0-rc.1"
 edition = "2024"
 homepage = "https://github.com/risingwavelabs/risingwave"
 keywords = ["sql", "database", "streaming"]

--- a/docker/docker-compose-distributed.yml
+++ b/docker/docker-compose-distributed.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.1.0-rc.1}
 services:
   compactor-0:
     <<: *image

--- a/docker/docker-compose-with-azblob.yml
+++ b/docker/docker-compose-with-azblob.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.1.0-rc.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-gcs.yml
+++ b/docker/docker-compose-with-gcs.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.1.0-rc.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-lakekeeper.yml
+++ b/docker/docker-compose-with-lakekeeper.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.1.0-rc.1}
 
 x-lakekeeper-image: &lakekeeper-image
   image: ${LAKEKEEPER__SERVER_IMAGE:-quay.io/lakekeeper/catalog:latest-main}

--- a/docker/docker-compose-with-local-fs.yml
+++ b/docker/docker-compose-with-local-fs.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.1.0-rc.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-obs.yml
+++ b/docker/docker-compose-with-obs.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.1.0-rc.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-oss.yml
+++ b/docker/docker-compose-with-oss.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.1.0-rc.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-s3.yml
+++ b/docker/docker-compose-with-s3.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.1.0-rc.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose-with-sqlite.yml
+++ b/docker/docker-compose-with-sqlite.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.1.0-rc.1}
 services:
   risingwave-standalone:
     <<: *image

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 ---
 x-image: &image
-  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.0.0}
+  image: ${RW_IMAGE:-risingwavelabs/risingwave:v3.1.0-rc.1}
 services:
   risingwave-standalone:
     <<: *image


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?
Release v3.1.0-rc.1 from release-3.1. Update the Cargo workspace version from 3.1.0-alpha and Docker Compose image defaults from v3.0.0 to the release candidate.

Validation: `cargo update -vv -w` and `git diff --check` passed. Cargo.lock changes only the versions of 63 workspace packages; external dependencies are unchanged.

## Checklist
- [x] Release branch scope confirmed by the scheduled release task: release-3.1.

## Release note
Release v3.1.0-rc.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the workspace version to `3.1.0-rc.1`.
  - Updated default Docker images across deployment configurations to RisingWave `v3.1.0-rc.1`.
  - Docker image overrides through the `RW_IMAGE` environment variable remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->