### PR TITLE
feat(risedev): support Docker-backed Cassandra sink tests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -227,6 +227,10 @@ labels:
 
 - label: "ci/run-e2e-cassandra-sink-tests"
   files:
+  - "ci\\/scripts\\/e2e-cassandra-sink-test\\.sh"
+  - "e2e_test\\/commands\\/cassandra-cqlsh"
+  - "e2e_test\\/sink\\/cassandra_sink\\.slt"
+  - "java\\/connector-node\\/risingwave-sink-cassandra\\/.*"
   - "src\\/connector\\/src\\/sink\\/remote\\.rs"
 
 - label: "ci/run-e2e-mongodb-sink-tests"

--- a/ci/scripts/e2e-cassandra-sink-test.sh
+++ b/ci/scripts/e2e-cassandra-sink-test.sh
@@ -38,8 +38,13 @@ apt-get install -y python3.11-venv
 python3.11 -m venv cqlsh_env
 source cqlsh_env/bin/activate
 
+# Keep cqlsh on this virtualenv's Python when the SLT helpers are added to PATH.
+export CQLSH_PYTHON="${VIRTUAL_ENV}/bin/python3.11"
 export CQLSH_HOST=cassandra-server
 export CQLSH_PORT=9042
+export CASSANDRA_DATACENTER=datacenter1
+export RISEDEV_CASSANDRA_WITH_OPTIONS_COMMON="connector='cassandra',cassandra.url='${CQLSH_HOST}:${CQLSH_PORT}',cassandra.datacenter='${CASSANDRA_DATACENTER}'"
+export PATH="${PWD}/e2e_test/commands:${PATH}"
 
 echo "--- testing sinks"
 sqllogictest -p 4566 -d dev './e2e_test/sink/cassandra_sink.slt'

--- a/docs/dev/src/connector/intro.md
+++ b/docs/dev/src/connector/intro.md
@@ -167,6 +167,19 @@ Run the ClickHouse sink test in the same way:
 ./risedev k
 ```
 
+For the Cassandra sink test, Start your Docker daemon and enable `ENABLE_MINIO=true` and
+`ENABLE_BUILD_RW_CONNECTOR=true` in `risedev-components.user.env` (or use `./risedev configure`).
+The Cassandra sink requires the Java connector libraries even though Cassandra itself runs in Docker.
+Ensure JDK 21 is available to the build and runtime, and rebuild with `./risedev b` after enabling the connector.
+
+From the repository root, run:
+
+```sh
+./risedev d local-cassandra-sink-test
+./risedev slt './e2e_test/sink/cassandra_sink.slt'
+./risedev k
+```
+
 ### Tips for writing `system` commands
 
 Refer to

--- a/e2e_test/commands/cassandra-cqlsh
+++ b/e2e_test/commands/cassandra-cqlsh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# The managed container always listens on 9042, regardless of the published port.
+if [[ -n "${CASSANDRA_CONTAINER:-}" ]]; then
+  exec docker exec -i "${CASSANDRA_CONTAINER}" cqlsh \
+    --connect-timeout=5 --request-timeout=20 "$@" 127.0.0.1 9042
+fi
+
+if [[ -n "${CASSANDRA_CQLSH:-}" ]]; then
+  cqlsh="${CASSANDRA_CQLSH}"
+elif [[ -n "${CASSANDRA_DIR:-}" ]]; then
+  cqlsh="${CASSANDRA_DIR}/bin/cqlsh"
+else
+  cqlsh=cqlsh
+fi
+
+exec "$cqlsh" --connect-timeout=5 --request-timeout=20 "$@" \
+  "${CQLSH_HOST:?CQLSH_HOST is required for an external Cassandra service}" "${CQLSH_PORT:-9042}"

--- a/e2e_test/sink/cassandra_sink.slt
+++ b/e2e_test/sink/cassandra_sink.slt
@@ -1,8 +1,26 @@
+control substitution on
+
+statement ok
+DROP SINK IF EXISTS s6;
+
+statement ok
+DROP SINK IF EXISTS s7;
+
+statement ok
+DROP TABLE IF EXISTS t6;
+
+statement ok
+DROP TABLE IF EXISTS t7;
+
+system ok retry 30 backoff 1s
+cassandra-cqlsh -e "SELECT release_version FROM system.local;"
+
+# Recreate only this test's keyspace so a failed run cannot leave stale rows.
 system ok
-${CASSANDRA_DIR}/bin/cqlsh --request-timeout=20 -e "CREATE KEYSPACE demo WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};use demo;CREATE table demo_bhv_table(v1 int primary key,v2 smallint,v3 bigint,v4 float,v5 double,v6 text,v7 date,v8 timestamp,v9 boolean);"
+cassandra-cqlsh -e "DROP KEYSPACE IF EXISTS risedev_cassandra_sink_test; CREATE KEYSPACE risedev_cassandra_sink_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}; USE risedev_cassandra_sink_test; CREATE TABLE demo_bhv_table(v1 int primary key,v2 smallint,v3 bigint,v4 float,v5 double,v6 text,v7 date,v8 timestamp,v9 boolean);"
 
 system ok
-${CASSANDRA_DIR}/bin/cqlsh --request-timeout=20 -e "use demo;CREATE table \"Test_uppercase\"(\"TEST_V1\" int primary key, \"TEST_V2\" int,\"TEST_V3\" int);"
+cassandra-cqlsh -e 'USE risedev_cassandra_sink_test; CREATE TABLE "Test_uppercase"("TEST_V1" int primary key, "TEST_V2" int,"TEST_V3" int);'
 
 statement ok
 CREATE TABLE t6 (v1 int primary key, v2 smallint, v3 bigint, v4 real, v5 float, v6 varchar, v7 date, v8 timestamptz, v9 boolean);
@@ -17,26 +35,22 @@ statement ok
 CREATE SINK s6
 FROM
     t6 WITH (
-    connector = 'cassandra',
+    ${RISEDEV_CASSANDRA_WITH_OPTIONS_COMMON},
     type = 'append-only',
     force_append_only='true',
-    cassandra.url = 'cassandra-server:9042',
-    cassandra.keyspace  = 'demo',
+    cassandra.keyspace = 'risedev_cassandra_sink_test',
     cassandra.table = 'demo_bhv_table',
-    cassandra.datacenter = 'datacenter1',
 );
 
 statement ok
 CREATE SINK s7
 FROM
     t7 WITH (
-    connector = 'cassandra',
+    ${RISEDEV_CASSANDRA_WITH_OPTIONS_COMMON},
     type = 'append-only',
     force_append_only='true',
-    cassandra.url = 'cassandra-server:9042',
-    cassandra.keyspace  = 'demo',
+    cassandra.keyspace = 'risedev_cassandra_sink_test',
     cassandra.table = 'Test_uppercase',
-    cassandra.datacenter = 'datacenter1',
 );
 
 statement ok
@@ -47,6 +61,19 @@ INSERT INTO t7 VALUES (1, 1, 1);
 
 statement ok
 FLUSH;
+
+# COPY TO STDOUT works with both a container client and a host client, without shared files.
+system ok retry 30 backoff 1s
+cassandra-cqlsh -e "COPY risedev_cassandra_sink_test.demo_bhv_table TO STDOUT WITH HEADER = false AND ENCODING = 'UTF-8';"
+----
+1,1,1,1.1,1.2,test,2013-01-01,2013-01-01 01:01:01.000+0000,False
+
+
+system ok retry 30 backoff 1s
+cassandra-cqlsh -e "COPY risedev_cassandra_sink_test.\"Test_uppercase\" TO STDOUT WITH HEADER = false AND ENCODING = 'UTF-8';"
+----
+1,1,1
+
 
 statement ok
 DROP SINK s6;
@@ -61,18 +88,4 @@ statement ok
 DROP TABLE t7;
 
 system ok
-${CASSANDRA_DIR}/bin/cqlsh --request-timeout=20 -e "COPY demo.demo_bhv_table TO './query_result.csv' WITH HEADER = false AND ENCODING = 'UTF-8';"
-
-system ok
-${CASSANDRA_DIR}/bin/cqlsh --request-timeout=20 -e "COPY demo.\"Test_uppercase\" TO './query_result2.csv' WITH HEADER = false AND ENCODING = 'UTF-8';"
-
-system ok
-cat ./query_result.csv
-----
-1,1,1,1.1,1.2,test,2013-01-01,2013-01-01 01:01:01.000+0000,False
-
-
-system ok
-cat ./query_result2.csv
-----
-1,1,1
+cassandra-cqlsh -e "DROP KEYSPACE risedev_cassandra_sink_test;"

--- a/risedev.yml
+++ b/risedev.yml
@@ -1314,6 +1314,21 @@ profile:
       - use: compactor
       - use: redis
 
+  local-cassandra-sink-test:
+    config-path: src/config/ci.toml
+    steps:
+      - use: minio
+        id: minio-local-cassandra-sink-test
+      - use: sqlite
+        id: sqlite-local-cassandra-sink-test
+      - use: meta-node
+        meta-backend: sqlite
+      - use: compute-node
+        enable-tiered-cache: true
+      - use: frontend
+      - use: compactor
+      - use: cassandra
+
   local-clickhouse-sink-test:
     config-path: src/config/ci.toml
     steps:
@@ -1857,6 +1872,23 @@ template:
     image: "redis:7.2.14"
 
     persist-data: false
+
+  # Cassandra service backed by Docker.
+  cassandra:
+    id: cassandra
+
+    address: "127.0.0.1"
+    port: 9042
+    datacenter: datacenter1
+
+    user-managed: false
+
+    # Only effective when NOT user managed
+    image: "cassandra:4.0"
+    persist-data: false
+
+    # Path to the local cqlsh executable when user-managed (defaults to PATH lookup).
+    cqlsh: null
 
   # ClickHouse service backed by Docker.
   clickhouse:

--- a/src/risedevtool/Cargo.toml
+++ b/src/risedevtool/Cargo.toml
@@ -31,7 +31,7 @@ serde_yaml = "0.9"
 sqlx = { workspace = true, features = ["any"] }
 tempfile = "3"
 thiserror-ext = { workspace = true }
-tokio = { workspace = true, features = ["fs"] }
+tokio = { workspace = true, features = ["fs", "process"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2"

--- a/src/risedevtool/src/bin/risedev-dev.rs
+++ b/src/risedevtool/src/bin/risedev-dev.rs
@@ -28,13 +28,14 @@ use fs_err::OpenOptions;
 use indicatif::{MultiProgress, ProgressBar};
 use risedev::util::{begin_spin, complete_spin, fail_spin};
 use risedev::{
-    ClickHouseService, CompactorService, ComputeNodeService, ConfigExpander, ConfigureTmuxTask,
-    DummyService, ElasticSearchService, EnsureStopService, ExecuteContext, FrontendService,
-    GrafanaService, KafkaService, LakekeeperService, MetaNodeService, MinioService, MoatService,
-    MongoDbService, MongoDbSetupTask, MotoService, MqttService, MySqlService, NatsService,
-    OpenSearchService, PostgresService, PrometheusService, PubsubService, PulsarService,
-    RISEDEV_NAME, RedisService, SchemaRegistryService, ServiceConfig, SqlServerService,
-    SqliteConfig, Task, TaskGroup, TempoService, generate_risedev_env, preflight_check,
+    CassandraService, ClickHouseService, CompactorService, ComputeNodeService, ConfigExpander,
+    ConfigureTmuxTask, DummyService, ElasticSearchService, EnsureStopService, ExecuteContext,
+    FrontendService, GrafanaService, KafkaService, LakekeeperService, MetaNodeService,
+    MinioService, MoatService, MongoDbService, MongoDbSetupTask, MotoService, MqttService,
+    MySqlService, NatsService, OpenSearchService, PostgresService, PrometheusService,
+    PubsubService, PulsarService, RISEDEV_NAME, RedisService, SchemaRegistryService, ServiceConfig,
+    SqlServerService, SqliteConfig, Task, TaskGroup, TempoService, generate_risedev_env,
+    preflight_check,
 };
 use sqlx::mysql::MySqlConnectOptions;
 use sqlx::postgres::PgConnectOptions;
@@ -309,6 +310,12 @@ fn task_main(
                     task.execute(&mut ctx)?;
                     ctx.pb
                         .set_message(format!("redis {}:{}", c.address, c.port));
+                }
+                ServiceConfig::Cassandra(c) => {
+                    CassandraService::new(c.clone()).execute(&mut ctx)?;
+                    risedev::CassandraReadyCheckTask::new(c.clone()).execute(&mut ctx)?;
+                    ctx.pb
+                        .set_message(format!("cassandra {}:{}", c.address, c.port));
                 }
                 ServiceConfig::ClickHouse(c) => {
                     let mut service = ClickHouseService::new(c.clone());

--- a/src/risedevtool/src/config.rs
+++ b/src/risedevtool/src/config.rs
@@ -211,6 +211,7 @@ impl ConfigExpander {
                     "pubsub" => ServiceConfig::Pubsub(serde_yaml::from_str(&out_str)?),
                     "pulsar" => ServiceConfig::Pulsar(serde_yaml::from_str(&out_str)?),
                     "redis" => ServiceConfig::Redis(serde_yaml::from_str(&out_str)?),
+                    "cassandra" => ServiceConfig::Cassandra(serde_yaml::from_str(&out_str)?),
                     "clickhouse" => ServiceConfig::ClickHouse(serde_yaml::from_str(&out_str)?),
                     "mysql" => ServiceConfig::MySql(serde_yaml::from_str(&out_str)?),
                     "postgres" => ServiceConfig::Postgres(serde_yaml::from_str(&out_str)?),

--- a/src/risedevtool/src/risedev_env.rs
+++ b/src/risedevtool/src/risedev_env.rs
@@ -116,6 +116,27 @@ pub fn generate_risedev_env(services: &Vec<ServiceConfig>) -> String {
                 )
                 .unwrap();
             }
+            ServiceConfig::Cassandra(c) => {
+                let host = &c.address;
+                let port = &c.port;
+                let datacenter = &c.datacenter;
+                let url = format!("{host}:{port}");
+                writeln!(env, r#"CQLSH_HOST="{host}""#).unwrap();
+                writeln!(env, r#"CQLSH_PORT="{port}""#).unwrap();
+                writeln!(env, r#"CASSANDRA_DATACENTER="{datacenter}""#).unwrap();
+                writeln!(env, r#"RISEDEV_CASSANDRA_URL="{url}""#).unwrap();
+                if c.user_managed {
+                    let cqlsh = c.cqlsh.as_deref().unwrap_or("cqlsh");
+                    writeln!(env, r#"CASSANDRA_CQLSH="{cqlsh}""#).unwrap();
+                } else {
+                    writeln!(env, r#"CASSANDRA_CONTAINER="risedev-{}""#, c.id).unwrap();
+                }
+                writeln!(
+                    env,
+                    r#"RISEDEV_CASSANDRA_WITH_OPTIONS_COMMON="connector='cassandra',cassandra.url='{url}',cassandra.datacenter='{datacenter}'""#,
+                )
+                .unwrap();
+            }
             ServiceConfig::ClickHouse(c) => {
                 let host = &c.address;
                 let http_port = &c.http_port;
@@ -367,4 +388,66 @@ pub fn generate_risedev_env(services: &Vec<ServiceConfig>) -> String {
         }
     }
     env
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ConfigExpander;
+
+    #[test]
+    fn test_cassandra_profile_env() {
+        let root = tempfile::tempdir().unwrap();
+        fs_err::write(
+            root.path().join("risedev.yml"),
+            include_str!("../../../risedev.yml"),
+        )
+        .unwrap();
+        let (config_path, _, steps) =
+            ConfigExpander::expand(root.path(), "local-cassandra-sink-test").unwrap();
+        assert_eq!(config_path.as_deref(), Some("src/config/ci.toml"));
+        let services = ConfigExpander::deserialize(&steps).unwrap();
+        let env = generate_risedev_env(&services);
+        assert!(env.contains("RISEDEV_RW_FRONTEND_PORT=\"4566\""));
+        assert!(env.contains("CASSANDRA_CONTAINER=\"risedev-cassandra\""));
+        assert!(env.contains("CQLSH_HOST=\"127.0.0.1\""));
+        assert!(env.contains("CQLSH_PORT=\"9042\""));
+        assert!(env.contains("cassandra.url='127.0.0.1:9042'"));
+        assert!(env.contains("cassandra.datacenter='datacenter1'"));
+        assert!(!env.contains("CASSANDRA_CQLSH="));
+
+        // User profiles must be able to override the service template and export the
+        // same endpoint used by the readiness check, without a managed container.
+        fs_err::write(
+            root.path().join("risedev-profiles.user.yml"),
+            "external-cassandra:
+  steps:
+    - use: cassandra
+      user-managed: true
+      address: cassandra.example
+      port: 19042
+      datacenter: test-dc
+      cqlsh: /path with spaces/cqlsh
+",
+        )
+        .unwrap();
+        let (_, _, steps) = ConfigExpander::expand(root.path(), "external-cassandra").unwrap();
+        let services = ConfigExpander::deserialize(&steps).unwrap();
+        let env = generate_risedev_env(&services);
+        assert!(env.contains("CQLSH_HOST=\"cassandra.example\""));
+        assert!(env.contains("CQLSH_PORT=\"19042\""));
+        assert!(env.contains("RISEDEV_CASSANDRA_URL=\"cassandra.example:19042\""));
+        assert!(env.contains("CASSANDRA_DATACENTER=\"test-dc\""));
+        assert!(env.contains("cassandra.url='cassandra.example:19042'"));
+        assert!(env.contains("cassandra.datacenter='test-dc'"));
+        assert!(env.contains("CASSANDRA_CQLSH=\"/path with spaces/cqlsh\""));
+        assert!(!env.contains("CASSANDRA_CONTAINER="));
+
+        let ServiceConfig::Cassandra(mut config) = services.into_iter().next().unwrap() else {
+            panic!("expected Cassandra service");
+        };
+        config.cqlsh = None;
+        let env = generate_risedev_env(&vec![ServiceConfig::Cassandra(config)]);
+        assert!(env.contains("CASSANDRA_CQLSH=\"cqlsh\""));
+    }
 }

--- a/src/risedevtool/src/service_config.rs
+++ b/src/risedevtool/src/service_config.rs
@@ -372,6 +372,26 @@ pub struct RedisConfig {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
+pub struct CassandraConfig {
+    #[serde(rename = "use")]
+    phantom_use: Option<String>,
+    pub id: String,
+
+    pub address: String,
+    pub port: u16,
+    pub datacenter: String,
+    pub image: String,
+    pub user_managed: bool,
+    pub persist_data: bool,
+
+    /// Path to the local cqlsh executable for user-managed services. Defaults to PATH lookup.
+    #[serde(default)]
+    pub cqlsh: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields)]
 pub struct ClickHouseConfig {
     #[serde(rename = "use")]
     phantom_use: Option<String>,
@@ -604,6 +624,7 @@ pub enum ServiceConfig {
     Pubsub(PubsubConfig),
     Pulsar(PulsarConfig),
     Redis(RedisConfig),
+    Cassandra(CassandraConfig),
     ClickHouse(ClickHouseConfig),
     MySql(MySqlConfig),
     Postgres(PostgresConfig),
@@ -633,6 +654,7 @@ pub enum TaskGroup {
     Nats,
     Mqtt,
     Redis,
+    Cassandra,
     ClickHouse,
     Lakekeeper,
     Moat,
@@ -656,6 +678,7 @@ impl ServiceConfig {
             Self::Pubsub(c) => &c.id,
             Self::Pulsar(c) => &c.id,
             Self::Redis(c) => &c.id,
+            Self::Cassandra(c) => &c.id,
             Self::ClickHouse(c) => &c.id,
             Self::Opendal(c) => &c.id,
             Self::MySql(c) => &c.id,
@@ -690,6 +713,7 @@ impl ServiceConfig {
             Self::Pubsub(c) => Some(c.port),
             Self::Pulsar(c) => Some(c.http_port),
             Self::Redis(c) => Some(c.port),
+            Self::Cassandra(c) => Some(c.port),
             Self::ClickHouse(c) => Some(c.http_port),
             Self::Opendal(_) => None,
             Self::MySql(c) => Some(c.port),
@@ -723,6 +747,7 @@ impl ServiceConfig {
             Self::Pubsub(c) => c.user_managed,
             Self::Pulsar(c) => c.user_managed,
             Self::Redis(c) => c.user_managed,
+            Self::Cassandra(c) => c.user_managed,
             Self::ClickHouse(c) => c.user_managed,
             Self::Opendal(_c) => false,
             Self::MySql(c) => c.user_managed,
@@ -757,6 +782,7 @@ impl ServiceConfig {
             ServiceConfig::Pubsub(_) => Pubsub,
             ServiceConfig::Pulsar(_) => Pulsar,
             ServiceConfig::Redis(_) => Redis,
+            ServiceConfig::Cassandra(_) => Cassandra,
             ServiceConfig::ClickHouse(_) => ClickHouse,
             ServiceConfig::MySql(my_sql_config) => {
                 if matches!(my_sql_config.application, Application::Metastore) {

--- a/src/risedevtool/src/task/cassandra_service.rs
+++ b/src/risedevtool/src/task/cassandra_service.rs
@@ -1,0 +1,125 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::docker_service::{DockerService, DockerServiceConfig};
+use crate::CassandraConfig;
+
+impl DockerServiceConfig for CassandraConfig {
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+
+    fn is_user_managed(&self) -> bool {
+        self.user_managed
+    }
+
+    fn image(&self) -> String {
+        self.image.clone()
+    }
+
+    fn envs(&self) -> Vec<(String, String)> {
+        vec![
+            ("CASSANDRA_DC".to_owned(), self.datacenter.clone()),
+            (
+                "CASSANDRA_ENDPOINT_SNITCH".to_owned(),
+                "GossipingPropertyFileSnitch".to_owned(),
+            ),
+        ]
+    }
+
+    fn ports(&self) -> Vec<(String, String)> {
+        vec![(self.port.to_string(), "9042".to_owned())]
+    }
+
+    fn data_path(&self) -> Option<String> {
+        self.persist_data.then(|| "/var/lib/cassandra".to_owned())
+    }
+}
+
+/// Docker-backed Cassandra service.
+pub type CassandraService = DockerService<CassandraConfig>;
+
+#[cfg(test)]
+mod tests {
+    use yaml_rust::YamlLoader;
+
+    use super::*;
+    use crate::{ConfigExpander, ServiceConfig, TaskGroup};
+
+    const CONFIG: &str = "
+- use: cassandra
+  id: cassandra-test
+  address: localhost
+  port: 19042
+  datacenter: test-dc
+  image: cassandra:4.0
+  user-managed: false
+  persist-data: false
+";
+
+    #[test]
+    fn test_cassandra_config_and_docker_options() {
+        let yaml = YamlLoader::load_from_str(CONFIG).unwrap();
+        let services = ConfigExpander::deserialize(&yaml[0]).unwrap();
+        let service = &services[0];
+        assert_eq!(service.id(), "cassandra-test");
+        assert_eq!(service.port(), Some(19042));
+        assert_eq!(service.task_group(), TaskGroup::Cassandra);
+        assert!(!service.user_managed());
+
+        let ServiceConfig::Cassandra(config) = service else {
+            panic!("expected Cassandra service");
+        };
+        assert_eq!(config.image(), "cassandra:4.0");
+        assert_eq!(config.ports(), vec![("19042".into(), "9042".into())]);
+        assert_eq!(
+            config.envs(),
+            vec![
+                ("CASSANDRA_DC".into(), "test-dc".into()),
+                (
+                    "CASSANDRA_ENDPOINT_SNITCH".into(),
+                    "GossipingPropertyFileSnitch".into()
+                ),
+            ]
+        );
+        assert_eq!(config.data_path(), None);
+        assert_eq!(config.cqlsh, None);
+
+        let mut config = config.clone();
+        config.persist_data = true;
+        assert_eq!(config.data_path().as_deref(), Some("/var/lib/cassandra"));
+    }
+
+    #[test]
+    fn test_cassandra_user_managed_config() {
+        let yaml = YamlLoader::load_from_str(&format!(
+            "{}  cqlsh: /opt/cassandra/bin/cqlsh\n",
+            CONFIG.replace("user-managed: false", "user-managed: true")
+        ))
+        .unwrap();
+        let services = ConfigExpander::deserialize(&yaml[0]).unwrap();
+        assert!(services[0].user_managed());
+        let ServiceConfig::Cassandra(config) = &services[0] else {
+            panic!("expected Cassandra service");
+        };
+        assert!(config.is_user_managed());
+        assert_eq!(config.cqlsh.as_deref(), Some("/opt/cassandra/bin/cqlsh"));
+    }
+
+    #[test]
+    fn test_cassandra_rejects_unknown_options() {
+        let yaml = YamlLoader::load_from_str(&format!("{CONFIG}  unknown-option: true\n")).unwrap();
+        assert!(ConfigExpander::deserialize(&yaml[0]).is_err());
+    }
+}

--- a/src/risedevtool/src/task/mod.rs
+++ b/src/risedevtool/src/task/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod cassandra_service;
 mod clickhouse_service;
 mod compactor_service;
 mod compute_node_service;
@@ -40,6 +41,7 @@ mod pulsar_service;
 mod redis_service;
 mod schema_registry_service;
 mod sql_server_service;
+mod task_cassandra_ready_check;
 mod task_clickhouse_ready_check;
 mod task_configure_minio;
 mod task_db_ready_check;
@@ -66,6 +68,7 @@ use reqwest::blocking::{Client, Response};
 use tempfile::TempDir;
 pub use utils::*;
 
+pub use self::cassandra_service::*;
 pub use self::clickhouse_service::*;
 pub use self::compactor_service::*;
 pub use self::compute_node_service::*;
@@ -93,6 +96,7 @@ pub use self::pulsar_service::*;
 pub use self::redis_service::*;
 pub use self::schema_registry_service::SchemaRegistryService;
 pub use self::sql_server_service::*;
+pub use self::task_cassandra_ready_check::*;
 pub use self::task_clickhouse_ready_check::*;
 pub use self::task_configure_minio::*;
 pub use self::task_db_ready_check::*;

--- a/src/risedevtool/src/task/task_cassandra_ready_check.rs
+++ b/src/risedevtool/src/task/task_cassandra_ready_check.rs
@@ -1,0 +1,173 @@
+// Copyright 2026 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use anyhow::{Context, Result, ensure};
+
+use crate::wait::wait;
+use crate::{CassandraConfig, ExecuteContext, Task};
+
+pub struct CassandraReadyCheckTask {
+    config: CassandraConfig,
+}
+
+impl CassandraReadyCheckTask {
+    pub fn new(config: CassandraConfig) -> Self {
+        Self { config }
+    }
+
+    fn command(&self) -> Command {
+        let mut cmd = if self.config.user_managed {
+            let mut cmd = Command::new(self.config.cqlsh.as_deref().unwrap_or("cqlsh"));
+            cmd.arg(&self.config.address)
+                .arg(self.config.port.to_string());
+            cmd
+        } else {
+            let mut cmd = Command::new("docker");
+            cmd.arg("exec")
+                .arg(format!("risedev-{}", self.config.id))
+                .args(["cqlsh", "127.0.0.1", "9042"]);
+            cmd
+        };
+        cmd.args([
+            "--connect-timeout=5",
+            "--request-timeout=5",
+            "-e",
+            "SELECT release_version FROM system.local;",
+        ]);
+        cmd
+    }
+}
+
+async fn check_cql(cmd: Command, timeout: Duration) -> Result<()> {
+    let output = tokio::time::timeout(
+        timeout,
+        tokio::process::Command::from(cmd)
+            .stdin(Stdio::null())
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    .context("Cassandra readiness command timed out")?
+    .context("failed to run Cassandra readiness command")?;
+    ensure!(
+        output.status.success(),
+        "Cassandra readiness query failed ({}): {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+    Ok(())
+}
+
+impl Task for CassandraReadyCheckTask {
+    fn execute(&mut self, ctx: &mut ExecuteContext<impl Write>) -> Result<()> {
+        ctx.pb.set_message("waiting for CQL readiness...");
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+
+        // Cassandra's JVM and storage initialization can exceed the usual 30-second wait.
+        wait(
+            || rt.block_on(check_cql(self.command(), Duration::from_secs(15))),
+            &mut ctx.log,
+            ctx.status_file.as_ref().unwrap(),
+            &self.config.id,
+            Some(Duration::from_secs(120)),
+            !self.config.user_managed,
+        )
+        .with_context(|| {
+            format!(
+                "failed to wait for Cassandra service `{}` to be ready",
+                self.config.id
+            )
+        })?;
+
+        ctx.complete_spin();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> CassandraConfig {
+        serde_yaml::from_str(
+            "id: cassandra-test
+address: cassandra.example
+port: 19042
+datacenter: test-dc
+image: cassandra:4.0
+user-managed: false
+persist-data: false
+",
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_cassandra_ready_command_targets() {
+        let mut config = config();
+        let cmd = CassandraReadyCheckTask::new(config.clone()).command();
+        assert_eq!(cmd.get_program(), "docker");
+        assert_eq!(
+            cmd.get_args().collect::<Vec<_>>(),
+            [
+                "exec",
+                "risedev-cassandra-test",
+                "cqlsh",
+                "127.0.0.1",
+                "9042",
+                "--connect-timeout=5",
+                "--request-timeout=5",
+                "-e",
+                "SELECT release_version FROM system.local;",
+            ]
+        );
+
+        config.user_managed = true;
+        let cmd = CassandraReadyCheckTask::new(config.clone()).command();
+        assert_eq!(cmd.get_program(), "cqlsh");
+        config.cqlsh = Some("/path with spaces/cqlsh".into());
+        let cmd = CassandraReadyCheckTask::new(config).command();
+        assert_eq!(cmd.get_program(), "/path with spaces/cqlsh");
+        assert_eq!(
+            cmd.get_args().take(2).collect::<Vec<_>>(),
+            ["cassandra.example", "19042"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cassandra_ready_query_exit_status() {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "exit 0"]);
+        check_cql(cmd, Duration::from_secs(5)).await.unwrap();
+
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "echo 'CQL unavailable' >&2; exit 1"]);
+        let err = check_cql(cmd, Duration::from_secs(5)).await.unwrap_err();
+        assert!(err.to_string().contains("CQL unavailable"));
+    }
+
+    #[tokio::test]
+    async fn test_cassandra_ready_query_timeout() {
+        let mut cmd = Command::new("sleep");
+        cmd.arg("10");
+        let err = check_cql(cmd, Duration::from_millis(50)).await.unwrap_err();
+        assert!(err.to_string().contains("timed out"));
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

- Related issues:
   -  #26099
   -  #25120


Cassandra sink tests currently depend on a separately managed Cassandra instance and a host-installed `cqlsh`, with the sink endpoint hardcoded to the CI service address. This PR adds a local risedev workflow and makes the existing test runnable in both local and CI environments.

- Add a Docker-backed Cassandra service with configurable image, port, datacenter, optional persistence, and support for user-managed instances. Startup waits for a successful CQL query with bounded retries and command timeouts.
- Add the `local-cassandra-sink-test` profile and export Cassandra connection and client settings through `risedev-env`.
- Introduce a shared `cassandra-cqlsh` helper for container and host clients. Parameterize the existing SLT, use a dedicated keyspace with cleanup, and assert `COPY TO STDOUT` results with retries instead of writing shared CSV files.
- Update the CI script to supply the same connection settings and preserve its Python 3.11 client environment.
- Document the local workflow and its Docker, MinIO, JDK 21, and Java connector build prerequisites.


Local end-to-end validation:
```sh
./risedev d local-cassandra-sink-test
./risedev slt './e2e_test/sink/cassandra_sink.slt'
./risedev k
```

## Checklist

- [ ] I have written necessary rustdoc comments.
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->


## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

<!--
If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes.

Please prioritize highlighting the impact these changes will have on users.
Discuss technical details in the "What's changed" section, and focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for running Cassandra in local development environments.
  - Added configurable Cassandra connectivity, persistence, datacenter settings, and readiness checks.
  - Added a local Cassandra sink test profile with required supporting services and improved command-line access.

- **Documentation**
  - Added setup and usage instructions for running Cassandra sink tests locally, including prerequisites and cleanup commands.

- **Bug Fixes**
  - Improved test isolation, startup handling, connection reliability, retries, and cleanup for Cassandra sink tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->