### PR TITLE
chore(deps): rustls-webpki, lru, h2 RUSTSEC-2026 security bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,7 @@ dependencies = [
  "ring",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "serde",
  "serde_json",
  "serde_nanos",
@@ -1628,7 +1628,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.26",
- "h2 0.4.12",
+ "h2 0.4.17",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -7227,9 +7227,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -7625,7 +7625,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.12",
+ "h2 0.4.17",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -9591,9 +9591,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -13514,7 +13514,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.12",
+ "h2 0.4.17",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -13563,7 +13563,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.12",
+ "h2 0.4.17",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -13962,7 +13962,7 @@ dependencies = [
  "jni",
  "jsonbb",
  "linkme",
- "lru 0.18.1",
+ "lru 0.18.2",
  "madsim-tokio",
  "memcomparable",
  "more-asserts",
@@ -15214,7 +15214,7 @@ dependencies = [
  "either",
  "futures",
  "http 1.4.0",
- "lru 0.18.1",
+ "lru 0.18.2",
  "madsim-tokio",
  "madsim-tonic",
  "moka",
@@ -15901,7 +15901,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -15972,7 +15972,7 @@ dependencies = [
  "rustls 0.23.35",
  "rustls-native-certs 0.8.1",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
@@ -16008,9 +16008,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -18389,7 +18389,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "flate2",
- "h2 0.4.12",
+ "h2 0.4.17",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Cargo.lock-only security bumps, all within existing version requirements — the intention is to close six RUSTSEC-2026 advisories affecting pinned dependencies without touching any manifest or code:

- **rustls-webpki 0.103.10 → 0.103.13** — closes four TLS-verification advisories at once:
  - RUSTSEC-2026-0049 / GHSA-pwjx-qhcg-rvj4 — CRLs not authoritative due to faulty distribution-point matching
  - RUSTSEC-2026-0098 / GHSA-965h-392x-2mh5 — URI name constraints incorrectly accepted
  - RUSTSEC-2026-0099 / GHSA-xgp8-3hg3-c2mh — name constraints accepted for wildcard names
  - RUSTSEC-2026-0104 / GHSA-82j2-j2ch-gfr8 — reachable panic in CRL parsing
- **lru 0.18.1 → 0.18.2** — RUSTSEC-2026-0253 (potential use-after-free on panic in `LruCache::pop`)
- **h2 0.4.12 → 0.4.17** — RUSTSEC-2026-0258 (unbounded empty DATA frame queuing → HTTP/2 DoS)

How it was validated: each new version's dependency list was verified identical to the pinned version against crates.io metadata, so every entry is a pure version+checksum swap; all bumps stay within existing version requirements (no manifest changes). Dep references in parent entries were updated for multi-version crates. Lock structure validated (TOML parse + full reference integrity across all package entries).

Limitations / out of scope:

- `tokio-postgres` is pinned to the madsim fork (`rev=ac00d88`), so RUSTSEC-2026-0178 (patched 0.7.18 upstream) needs the fork to rebase — out of scope for a lock-only PR.
- The webpki 0.101.7 / 0.102.8 and h2 0.3.26 legacy lines have no patched releases in-line (fixes live in 0.103 / 0.4); flagging for the dependency owners.

## Checklist

- [ ] I have written necessary rustdoc comments. (N/A — Cargo.lock-only change)
- [ ] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

No user-facing changes — dependency security maintenance (Cargo.lock-only).

</details>
