### PR TITLE
feat(planner): always shuffle the LHS of broadcast temporal join by stream key

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
@@ -6,9 +6,25 @@
   expected_outputs:
   - batch_error
   - stream_plan
-- name: Broadcast temporal join keeps the left distribution
+- name: Broadcast temporal join shuffles the left input by its stream key into an independent fragment
   sql: |
     create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    select id1, a1, id2, a2 from stream broadcast left join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
+  expected_outputs:
+  - stream_plan
+  - stream_dist_plan
+- name: Broadcast temporal join on a kafka source is not fused into the source fragment
+  with_config_map:
+    streaming_use_shared_source: true
+  sql: |
+    create source stream(id1 int, a1 int, b1 int)
+    with (
+        connector = 'kafka',
+        topic = 'mytopic',
+        properties.bootstrap.server = '6',
+        scan.startup.mode = 'earliest'
+    ) format plain encode json;
     create table version(id2 int, a2 int, b2 int, primary key (id2));
     select id1, a1, id2, a2 from stream broadcast left join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
   expected_outputs:

--- a/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
@@ -15,7 +15,7 @@
   batch_error: |-
     Not supported: do not support temporal join for batch queries
     HINT: please use temporal join in streaming queries
-- name: Broadcast temporal join keeps the left distribution
+- name: Broadcast temporal join shuffles the left input by its stream key into an independent fragment
   sql: |
     create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
     create table version(id2 int, a2 int, b2 int, primary key (id2));
@@ -24,7 +24,8 @@
     StreamMaterialize { columns: [id1, a1, id2, a2, stream._row_id(hidden)], stream_key: [stream._row_id, id1], pk_columns: [stream._row_id, id1], pk_conflict: NoCheck }
     └─StreamExchange { dist: HashShard(stream.id1, stream._row_id) }
       └─StreamTemporalJoin { type: LeftOuter, append_only: true, predicate: stream.id1 = version.id2, nested_loop: false, broadcast: true, output: [stream.id1, stream.a1, version.id2, version.a2, stream._row_id] }
-        ├─StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream._row_id], stream_scan_type: ArrangementBackfill, stream_key: [stream._row_id], pk: [_row_id], dist: UpstreamHashShard(stream._row_id) }
+        ├─StreamExchange { dist: HashShard(stream._row_id) }
+        │ └─StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream._row_id], stream_scan_type: ArrangementBackfill, stream_key: [stream._row_id], pk: [_row_id], dist: UpstreamHashShard(stream._row_id) }
         └─StreamExchange { dist: Broadcast }
           └─StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) }
   stream_dist_plan: |+
@@ -34,23 +35,93 @@
 
     Fragment 1
     StreamTemporalJoin { type: LeftOuter, append_only: true, predicate: stream.id1 = version.id2, nested_loop: false, broadcast: true, output: [stream.id1, stream.a1, version.id2, version.a2, stream._row_id] }
-    ├── StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream._row_id], stream_scan_type: ArrangementBackfill, stream_key: [stream._row_id], pk: [_row_id], dist: UpstreamHashShard(stream._row_id) }
-    │   ├── tables: [ StreamScan: 0 ]
-    │   ├── Upstream
-    │   └── BatchPlanNode
-    └── StreamExchange Broadcast from 2
+    ├── StreamExchange Hash([2]) from 2
+    └── StreamExchange Broadcast from 3
 
     Fragment 2
-    StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) } { tables: [ StreamScan: 1 ] }
+    StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream._row_id], stream_scan_type: ArrangementBackfill, stream_key: [stream._row_id], pk: [_row_id], dist: UpstreamHashShard(stream._row_id) }
+    ├── tables: [ StreamScan: 0 ]
     ├── Upstream
     └── BatchPlanNode
 
-    Table 0 { columns: [ vnode, _row_id, backfill_finished, row_count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3 ], distribution key: [ 0 ], read pk prefix len hint: 1, vnode column idx: 0 }
+    Fragment 3
+    StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) }
+    ├── tables: [ StreamScan: 1 ]
+    ├── Upstream
+    └── BatchPlanNode
+
+    Table 0
+    ├── columns: [ vnode, _row_id, backfill_finished, row_count, _rw_timestamp ]
+    ├── primary key: [ $0 ASC ]
+    ├── value indices: [ 1, 2, 3 ]
+    ├── distribution key: [ 0 ]
+    ├── read pk prefix len hint: 1
+    └── vnode column idx: 0
 
     Table 1 { columns: [ vnode, id2, backfill_finished, row_count, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3 ], distribution key: [ 0 ], read pk prefix len hint: 1, vnode column idx: 0 }
 
     Table 4294967294 { columns: [ id1, a1, id2, a2, stream._row_id, _rw_timestamp ], primary key: [ $4 ASC, $0 ASC ], value indices: [ 0, 1, 2, 3, 4 ], distribution key: [ 0, 4 ], read pk prefix len hint: 2 }
 
+- name: Broadcast temporal join on a kafka source is not fused into the source fragment
+  sql: |
+    create source stream(id1 int, a1 int, b1 int)
+    with (
+        connector = 'kafka',
+        topic = 'mytopic',
+        properties.bootstrap.server = '6',
+        scan.startup.mode = 'earliest'
+    ) format plain encode json;
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    select id1, a1, id2, a2 from stream broadcast left join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
+  stream_plan: |-
+    StreamMaterialize { columns: [id1, a1, id2, a2, _row_id(hidden)], stream_key: [_row_id, id1], pk_columns: [_row_id, id1], pk_conflict: NoCheck }
+    └─StreamExchange { dist: HashShard(id1, _row_id) }
+      └─StreamTemporalJoin { type: LeftOuter, append_only: true, predicate: id1 = version.id2, nested_loop: false, broadcast: true, output: [id1, a1, version.id2, version.a2, _row_id] }
+        ├─StreamExchange { dist: HashShard(_row_id) }
+        │ └─StreamRowIdGen { row_id_index: 6 }
+        │   └─StreamSourceScan { columns: [id1, a1, b1, _rw_kafka_timestamp, _rw_kafka_partition, _rw_kafka_offset, _row_id] }
+        └─StreamExchange { dist: Broadcast }
+          └─StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) }
+  stream_dist_plan: |+
+    Fragment 0
+    StreamMaterialize { columns: [id1, a1, id2, a2, _row_id(hidden)], stream_key: [_row_id, id1], pk_columns: [_row_id, id1], pk_conflict: NoCheck }
+    └── StreamExchange Hash([0, 4]) from 1
+
+    Fragment 1
+    StreamTemporalJoin { type: LeftOuter, append_only: true, predicate: id1 = version.id2, nested_loop: false, broadcast: true, output: [id1, a1, version.id2, version.a2, _row_id] }
+    ├── StreamExchange Hash([6]) from 2
+    └── StreamExchange Broadcast from 3
+
+    Fragment 2
+    StreamRowIdGen { row_id_index: 6 }
+    └── StreamSourceScan { columns: [id1, a1, b1, _rw_kafka_timestamp, _rw_kafka_partition, _rw_kafka_offset, _row_id] } { tables: [ SourceBackfill: 0 ] }
+        └── Upstream
+
+    Fragment 3
+    StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) }
+    ├── tables: [ StreamScan: 1 ]
+    ├── Upstream
+    └── BatchPlanNode
+
+    Table 0 { columns: [ partition_id, backfill_progress, _rw_timestamp ], primary key: [ $0 ASC ], value indices: [ 0, 1 ], distribution key: [], read pk prefix len hint: 0 }
+
+    Table 1
+    ├── columns: [ vnode, id2, backfill_finished, row_count, _rw_timestamp ]
+    ├── primary key: [ $0 ASC ]
+    ├── value indices: [ 1, 2, 3 ]
+    ├── distribution key: [ 0 ]
+    ├── read pk prefix len hint: 1
+    └── vnode column idx: 0
+
+    Table 4294967294
+    ├── columns: [ id1, a1, id2, a2, _row_id, _rw_timestamp ]
+    ├── primary key: [ $4 ASC, $0 ASC ]
+    ├── value indices: [ 0, 1, 2, 3, 4 ]
+    ├── distribution key: [ 0, 4 ]
+    └── read pk prefix len hint: 2
+
+  with_config_map:
+    streaming_use_shared_source: 'true'
 - name: Broadcast temporal join memo table follows the non-append-only left distribution
   sql: |
     create table stream(id1 int primary key, a1 int, b1 int);
@@ -60,7 +131,8 @@
     StreamMaterialize { columns: [id1, a1, id2, a2], stream_key: [id1, a1], pk_columns: [id1, a1], pk_conflict: NoCheck }
     └─StreamExchange { dist: HashShard(stream.id1, stream.a1) }
       └─StreamTemporalJoin { type: Inner, append_only: false, predicate: stream.a1 = version.id2, nested_loop: false, broadcast: true, output: all }
-        ├─StreamTableScan { table: stream, columns: [stream.id1, stream.a1], stream_scan_type: ArrangementBackfill, stream_key: [stream.id1], pk: [id1], dist: UpstreamHashShard(stream.id1) }
+        ├─StreamExchange { dist: HashShard(stream.id1) }
+        │ └─StreamTableScan { table: stream, columns: [stream.id1, stream.a1], stream_scan_type: ArrangementBackfill, stream_key: [stream.id1], pk: [id1], dist: UpstreamHashShard(stream.id1) }
         └─StreamExchange { dist: Broadcast }
           └─StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) }
   stream_dist_plan: |+
@@ -69,14 +141,18 @@
     └── StreamExchange Hash([0, 1]) from 1
 
     Fragment 1
-    StreamTemporalJoin { type: Inner, append_only: false, predicate: stream.a1 = version.id2, nested_loop: false, broadcast: true, output: all } { tables: [ TemporalJoinMemo: 0 ] }
-    ├── StreamTableScan { table: stream, columns: [stream.id1, stream.a1], stream_scan_type: ArrangementBackfill, stream_key: [stream.id1], pk: [id1], dist: UpstreamHashShard(stream.id1) }
-    │   ├── tables: [ StreamScan: 1 ]
-    │   ├── Upstream
-    │   └── BatchPlanNode
-    └── StreamExchange Broadcast from 2
+    StreamTemporalJoin { type: Inner, append_only: false, predicate: stream.a1 = version.id2, nested_loop: false, broadcast: true, output: all }
+    ├── tables: [ TemporalJoinMemo: 0 ]
+    ├── StreamExchange Hash([0]) from 2
+    └── StreamExchange Broadcast from 3
 
     Fragment 2
+    StreamTableScan { table: stream, columns: [stream.id1, stream.a1], stream_scan_type: ArrangementBackfill, stream_key: [stream.id1], pk: [id1], dist: UpstreamHashShard(stream.id1) }
+    ├── tables: [ StreamScan: 1 ]
+    ├── Upstream
+    └── BatchPlanNode
+
+    Fragment 3
     StreamTableScan { table: version, columns: [version.id2, version.a2], stream_scan_type: UpstreamOnly, stream_key: [version.id2], pk: [id2], dist: UpstreamHashShard(version.id2) }
     ├── tables: [ StreamScan: 2 ]
     ├── Upstream

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -1324,7 +1324,18 @@ impl LogicalJoin {
 
         let left = self.left().to_stream(ctx)?;
         let left = if is_broadcast {
-            left.enforce_concrete_distribution()
+            // Always shuffle the LHS by its stream key. The point of a broadcast temporal join is
+            // to make the join fragment independent: without an exchange here, the join would be
+            // fused into the upstream fragment whenever the LHS already declares a concrete
+            // distribution (e.g. a source with `HashShard(_row_id)` or a table scan with
+            // `UpstreamHashShard`), which ties the join parallelism to the upstream and inherits
+            // its key skew. One extra hash exchange buys an independently scalable join fragment
+            // and evenly spread rows. A singleton LHS cannot be sharded, so keep it as is.
+            match left.distribution() {
+                Distribution::Single => left,
+                _ => RequiredDist::shard_by_key(left.schema().len(), left.expect_stream_key())
+                    .stream_enforce(left),
+            }
         } else {
             // Enforce a shuffle for the temporal join LHS to let the scheduler be able to schedule
             // the join fragment together with the RHS with a `no_shuffle` exchange.

--- a/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
@@ -147,8 +147,9 @@ impl StreamTemporalJoin {
     /// Return the memo-table catalog.
     ///
     /// The memo prefix is `join_key + left_stream_key`. A regular temporal join is distributed by
-    /// the lookup key, while a broadcast temporal join preserves the left input distribution and
-    /// maps that distribution key to its copy in the `left_stream_key` part of the prefix.
+    /// the lookup key, while a broadcast temporal join shuffles the left input by its stream key
+    /// (or keeps it singleton) and maps that distribution key to its copy in the
+    /// `left_stream_key` part of the prefix.
     ///
     /// Write pattern:
     ///   for each left input row (with insert op), persist the matched right row followed by the


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

The broadcast temporal join (`... BROADCAST JOIN dim FOR SYSTEM_TIME AS OF PROCTIME()`) currently only enforces a shuffle on its LHS when the LHS distribution is `SomeShard` (`enforce_concrete_distribution`). Whenever the LHS already declares a concrete distribution the join is fused into the upstream fragment:

- a Kafka source (or any source with `_row_id`) ends with `StreamRowIdGen` which declares `HashShard(_row_id)`, so the join lands in the source (backfill) fragment and its parallelism is bound to the source job / partition layout;
- a direct table/MV scan gives `UpstreamHashShard(pk)`, so the join is bound to the upstream table's fragment via the no-shuffle edge.

This defeats the main point of the broadcast variant, which is to make the join fragment independent from both the lookup table (regular temporal join) and the upstream.

This PR always inserts a hash exchange on the LHS keyed by the left stream key (a singleton LHS is kept as is, since it cannot be sharded). One extra exchange buys:

- an independent join fragment whose parallelism can be adjusted with `ALTER FRAGMENT ... SET PARALLELISM`, regardless of the source / upstream table parallelism;
- rows evenly spread across join actors (upstream key skew, e.g. Kafka partition skew, is smoothed out).

The non-append-only memo table still follows the left distribution, which is now the left stream key; no change in the memo table layout for the existing cases.

Planner tests: renamed the existing broadcast case and added a Kafka shared-source LHS case to show the join is no longer fused into the source fragment.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [ ] <!-- OPTIONAL --> I have added test labels as necessary. <!-- See https://github.com/risingwavelabs/risingwave/blob/main/docs/dev/src/ci.md#ci-labels-guide -->
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them. <!-- Recommended for new SQL features, see #7934 -->
- [ ] <!-- OPTIONAL --> My PR contains breaking changes. <!-- If it deprecates some features, please create a tracking issue to remove them in the future -->
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results. <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] <!-- OPTIONAL --> I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into. <!-- Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md) -->

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates. <!-- Please use the **Release note** section below to summarize the impact on users -->

<details>
<summary><b>Release note</b></summary>

The LHS of a broadcast temporal join is now always shuffled by its stream key, so the join runs in its own fragment whose parallelism can be adjusted independently of the upstream source or table.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved planning for broadcast temporal joins by distributing the streaming input using its stream key before joining.
  * Preserved singleton inputs without unnecessary redistribution.
  * Corrected Kafka-based temporal join planning when shared-source streaming is enabled, preventing inappropriate source-fragment fusion.

* **Tests**
  * Added and updated planner coverage for broadcast temporal joins, including shuffled inputs and Kafka sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->