### PR TITLE
fix(connector/kafka): resolve startup timestamp offset once per partition

### DIFF
--- a/src/connector/src/source/kafka/enumerator.rs
+++ b/src/connector/src/source/kafka/enumerator.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, LazyLock, Weak};
 use std::time::Duration;
 
@@ -70,6 +70,13 @@ pub struct KafkaSplitEnumerator {
     topic: String,
     client: Arc<KafkaConsumer>,
     start_offset: KafkaEnumeratorOffset,
+    /// Start offsets already resolved from a `Timestamp` start offset, keyed by partition.
+    ///
+    /// The timestamp is fixed for the lifetime of the enumerator, and `offsets_for_times` is
+    /// expensive for the broker when the timestamp is older than the local log retention (it has
+    /// to consult tiered storage), so each partition is resolved only on the tick that first
+    /// observes it.
+    resolved_start_offsets: HashMap<i32, Option<i64>>,
 
     // maybe used in the future for batch processing
     stop_offset: KafkaEnumeratorOffset,
@@ -224,6 +231,7 @@ impl SplitEnumerator for KafkaSplitEnumerator {
             topic,
             client: client.unwrap(),
             start_offset: scan_start_offset,
+            resolved_start_offsets: HashMap::new(),
             stop_offset: KafkaEnumeratorOffset::None,
             sync_call_timeout: properties.common.sync_call_timeout,
             high_watermark_metrics: HashMap::new(),
@@ -473,7 +481,7 @@ impl KafkaSplitEnumerator {
     }
 
     async fn fetch_start_offset(
-        &self,
+        &mut self,
         partitions: &[i32],
         watermarks: &HashMap<i32, (i64, i64)>,
     ) -> KafkaResult<HashMap<i32, Option<i64>>> {
@@ -492,8 +500,15 @@ impl KafkaSplitEnumerator {
                 Ok(map)
             }
             KafkaEnumeratorOffset::Timestamp(time) => {
-                self.fetch_offset_for_time(partitions, time, watermarks)
-                    .await
+                let unresolved =
+                    sync_resolved_partitions(&mut self.resolved_start_offsets, partitions);
+                if !unresolved.is_empty() {
+                    let resolved = self
+                        .fetch_offset_for_time(&unresolved, time, watermarks)
+                        .await?;
+                    self.resolved_start_offsets.extend(resolved);
+                }
+                Ok(self.resolved_start_offsets.clone())
             }
             KafkaEnumeratorOffset::None => partitions
                 .iter()
@@ -622,5 +637,45 @@ impl KafkaSplitEnumerator {
             .iter()
             .map(|partition| partition.id())
             .collect())
+    }
+}
+
+/// Drops cached start offsets of partitions that are no longer present and returns the
+/// partitions whose start offset still has to be resolved.
+fn sync_resolved_partitions(
+    resolved: &mut HashMap<i32, Option<i64>>,
+    partitions: &[i32],
+) -> Vec<i32> {
+    let current: HashSet<i32> = partitions.iter().copied().collect();
+    resolved.retain(|partition, _| current.contains(partition));
+    partitions
+        .iter()
+        .copied()
+        .filter(|partition| !resolved.contains_key(partition))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sync_resolved_partitions() {
+        let mut resolved = HashMap::new();
+
+        // First tick: every partition needs resolving.
+        assert_eq!(sync_resolved_partitions(&mut resolved, &[0, 1]), vec![0, 1]);
+        resolved.extend([(0, Some(10)), (1, Some(20))]);
+
+        // Stable partition set: nothing to resolve, cache untouched.
+        assert!(sync_resolved_partitions(&mut resolved, &[0, 1]).is_empty());
+        assert_eq!(resolved, HashMap::from([(0, Some(10)), (1, Some(20))]));
+
+        // New partition: only the new one needs resolving.
+        assert_eq!(sync_resolved_partitions(&mut resolved, &[0, 1, 2]), vec![2]);
+
+        // Removed partition: its cached entry is dropped; nothing else to resolve.
+        assert!(sync_resolved_partitions(&mut resolved, &[1]).is_empty());
+        assert_eq!(resolved, HashMap::from([(1, Some(20))]));
     }
 }

--- a/src/connector/src/source/kafka/enumerator.rs
+++ b/src/connector/src/source/kafka/enumerator.rs
@@ -646,6 +646,15 @@ fn sync_resolved_partitions(
     resolved: &mut HashMap<i32, Option<i64>>,
     partitions: &[i32],
 ) -> Vec<i32> {
+    // `partitions` holds distinct ids, so equal length plus full containment means the set is
+    // unchanged, which is the case on almost every tick.
+    let unchanged = resolved.len() == partitions.len()
+        && partitions
+            .iter()
+            .all(|partition| resolved.contains_key(partition));
+    if unchanged {
+        return Vec::new();
+    }
     let current: HashSet<i32> = partitions.iter().copied().collect();
     resolved.retain(|partition, _| current.contains(partition));
     partitions


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

The meta-side `KafkaSplitEnumerator` re-issued `offsets_for_times` for every partition on every 30s discovery tick, using the fixed `scan.startup.timestamp.millis`. When that timestamp is older than local log retention the broker answers from tiered storage, so dozens of long-lived sources become a sustained load driver on the Kafka cluster.

This PR caches the resolved start offset per partition on the enumerator:

- Only partitions first seen on this tick are sent to `offsets_for_times`; a stable partition set issues no such RPC at all, and skips the cache bookkeeping entirely.
- Partitions that disappear are evicted from the cache.
- `refresh` / `UpdateProps` recreate the enumerator, which drops the cache, so a property change re-resolves.
- Watermark fetching, `stop_offset`, `on_tick`, and `list_splits_batch` are unchanged.

The cache maintenance is a pure helper (`sync_resolved_partitions`) covered by a unit test for the first tick, a stable set, an added partition, and a removed partition. The madsim Kafka broker does not count requests, so there is no end-to-end assertion on RPC counts.

Behaviour note: the discovered start offsets of already-assigned partitions were discarded by `reassign_splits` anyway; running actors keep their own offsets. The only path that reads them for all partitions is `discover_splits` for a job created later on the same source. Such a job now gets the offset resolved at first discovery instead of a fresh re-resolution. That only differs when the timestamp was beyond the newest message at first resolution (today: "latest at this tick", now: "latest at first discovery").

- Closes #26934

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] <!-- OPTIONAL --> I have added necessary unit tests and integration tests.
- [x] <!-- OPTIONAL --> I have added test labels as necessary. (`ci/run-e2e-kafka-source-tests` is auto-applied for this path and the step runs by default.)
- [ ] <!-- OPTIONAL --> I have added fuzzing tests or opened an issue to track them.
- [ ] <!-- OPTIONAL --> My PR contains breaking changes.
- [ ] <!-- OPTIONAL --> My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] <!-- OPTIONAL --> I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] <!-- OPTIONAL --> My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Kafka sources created with `scan.startup.timestamp.millis` no longer re-resolve the startup offset from the broker on every 30-second partition-discovery tick. The offset is resolved once per partition, which removes a steady-state `offsets_for_times` load on Kafka clusters, most noticeably when the timestamp falls into tiered storage.

</details>

https://claude.ai/code/session_011kGz2rVb6AbChRxPhY7DSb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Kafka-based data ingestion now reuses resolved partition start offsets when starting from a timestamp, reducing repeated offset lookups.
  - Start offsets remain synchronized as partitions change, ensuring newly available partitions are resolved correctly while stale partition information is discarded.
  - This improves startup efficiency and maintains accurate processing when Kafka partition assignments change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
