### PR TITLE
fix(stream): preserve CDC events during recovery startup

### DIFF
--- a/proto/plan_common.proto
+++ b/proto/plan_common.proto
@@ -140,15 +140,15 @@ message CdcKeyOrdering {
 message ExternalTableDesc {
   uint32 table_id = 1;
   repeated ColumnDesc columns = 2;
-  // Kept so old workers and persisted stream graphs can read the primary-key columns.
-  repeated common.ColumnOrder legacy_pk = 3 [deprecated = true];
+  // TODO: may refactor primary key representations
+  repeated common.ColumnOrder pk = 3;
   string table_name = 4;
   repeated uint32 stream_key = 5;
   map<string, string> connect_properties = 6;
   // upstream cdc source job id
   uint32 source_id = 7;
   map<string, secret.SecretRef> secret_refs = 8;
-  CdcKeyOrdering pk = 9;
+  CdcKeyOrdering pk_ordering = 9;
 }
 
 enum JoinType {

--- a/proto/plan_common.proto
+++ b/proto/plan_common.proto
@@ -121,18 +121,34 @@ message VectorIndexReaderDesc {
   uint32 hnsw_ef_search = 7;
 }
 
+message CdcKeyOrdering {
+  enum Comparison {
+    COMPARISON_UNSPECIFIED = 0;
+    COMPARISON_NATIVE = 1;
+    COMPARISON_UNSIGNED_INT64 = 2;
+  }
+
+  message Column {
+    uint32 pk_col_idx = 1;
+    Comparison comparison = 2;
+  }
+
+  repeated Column columns = 1;
+}
+
 // Represents a table in external database for CDC scenario
 message ExternalTableDesc {
   uint32 table_id = 1;
   repeated ColumnDesc columns = 2;
-  // TODO: may refactor primary key representations
-  repeated common.ColumnOrder pk = 3;
+  // Kept so old workers and persisted stream graphs can read the primary-key columns.
+  repeated common.ColumnOrder legacy_pk = 3 [deprecated = true];
   string table_name = 4;
   repeated uint32 stream_key = 5;
   map<string, string> connect_properties = 6;
   // upstream cdc source job id
   uint32 source_id = 7;
   map<string, secret.SecretRef> secret_refs = 8;
+  CdcKeyOrdering pk = 9;
 }
 
 enum JoinType {

--- a/src/common/src/catalog/external_table.rs
+++ b/src/common/src/catalog/external_table.rs
@@ -77,15 +77,14 @@ pub struct CdcTableDesc {
 }
 
 impl CdcTableDesc {
-    #[allow(deprecated)]
     pub fn to_protobuf(&self) -> ExternalTableDesc {
         assert_eq!(self.pk.len(), self.pk_comparisons.len());
         ExternalTableDesc {
             table_id: self.table_id,
             source_id: self.source_id,
             columns: self.columns.iter().map(Into::into).collect(),
-            legacy_pk: self.pk.iter().map(|column| column.to_protobuf()).collect(),
-            pk: Some(PbCdcKeyOrdering {
+            pk: self.pk.iter().map(|column| column.to_protobuf()).collect(),
+            pk_ordering: Some(PbCdcKeyOrdering {
                 columns: self
                     .pk
                     .iter()
@@ -117,7 +116,6 @@ mod tests {
     use crate::util::sort_util::OrderType;
 
     #[test]
-    #[allow(deprecated)]
     fn test_cdc_key_comparisons_are_persisted_with_pk_indices() {
         let table_desc = CdcTableDesc {
             table_id: TableId::new(1),
@@ -135,11 +133,11 @@ mod tests {
         };
 
         let protobuf = table_desc.to_protobuf();
-        assert_eq!(protobuf.legacy_pk.len(), 2);
-        assert_eq!(protobuf.legacy_pk[0].column_index, 3);
-        assert_eq!(protobuf.legacy_pk[1].column_index, 1);
+        assert_eq!(protobuf.pk.len(), 2);
+        assert_eq!(protobuf.pk[0].column_index, 3);
+        assert_eq!(protobuf.pk[1].column_index, 1);
 
-        let pk_columns = protobuf.pk.unwrap().columns;
+        let pk_columns = protobuf.pk_ordering.unwrap().columns;
         assert_eq!(pk_columns.len(), 2);
         assert_eq!(pk_columns[0].pk_col_idx, 3);
         assert_eq!(

--- a/src/common/src/catalog/external_table.rs
+++ b/src/common/src/catalog/external_table.rs
@@ -14,12 +14,38 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use risingwave_pb::plan_common::ExternalTableDesc;
+use risingwave_pb::plan_common::cdc_key_ordering::{Column as PbCdcKeyColumn, Comparison};
+use risingwave_pb::plan_common::{CdcKeyOrdering as PbCdcKeyOrdering, ExternalTableDesc};
 use risingwave_pb::secret::PbSecretRef;
 
 use super::{ColumnDesc, ColumnId, TableId};
 use crate::id::SourceId;
+use crate::util::iter_util::ZipEqFast;
 use crate::util::sort_util::ColumnOrder;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum CdcKeyComparison {
+    #[default]
+    Native,
+    UnsignedInt64,
+}
+
+impl CdcKeyComparison {
+    pub fn from_protobuf(comparison: Comparison) -> Self {
+        match comparison {
+            Comparison::Unspecified => Self::Native,
+            Comparison::Native => Self::Native,
+            Comparison::UnsignedInt64 => Self::UnsignedInt64,
+        }
+    }
+
+    fn to_protobuf(self) -> Comparison {
+        match self {
+            Self::Native => Comparison::Native,
+            Self::UnsignedInt64 => Comparison::UnsignedInt64,
+        }
+    }
+}
 
 /// Necessary information for compute node to access data in the external database.
 /// Compute node will use this information to connect to the external database and scan the table.
@@ -36,6 +62,8 @@ pub struct CdcTableDesc {
     pub external_table_name: String,
     /// The key used to sort in storage.
     pub pk: Vec<ColumnOrder>,
+    /// Comparison semantics for each primary-key column.
+    pub pk_comparisons: Vec<CdcKeyComparison>,
     /// All columns in the table, noticed it is NOT sorted by columnId in the vec.
     pub columns: Vec<ColumnDesc>,
 
@@ -49,12 +77,25 @@ pub struct CdcTableDesc {
 }
 
 impl CdcTableDesc {
+    #[allow(deprecated)]
     pub fn to_protobuf(&self) -> ExternalTableDesc {
+        assert_eq!(self.pk.len(), self.pk_comparisons.len());
         ExternalTableDesc {
             table_id: self.table_id,
             source_id: self.source_id,
             columns: self.columns.iter().map(Into::into).collect(),
-            pk: self.pk.iter().map(|v| v.to_protobuf()).collect(),
+            legacy_pk: self.pk.iter().map(|column| column.to_protobuf()).collect(),
+            pk: Some(PbCdcKeyOrdering {
+                columns: self
+                    .pk
+                    .iter()
+                    .zip_eq_fast(&self.pk_comparisons)
+                    .map(|(column_order, comparison)| PbCdcKeyColumn {
+                        pk_col_idx: column_order.column_index as _,
+                        comparison: comparison.to_protobuf() as _,
+                    })
+                    .collect(),
+            }),
             table_name: self.external_table_name.clone(),
             stream_key: self.stream_key.iter().map(|k| *k as _).collect(),
             connect_properties: self.connect_properties.clone(),
@@ -65,5 +106,47 @@ impl CdcTableDesc {
     /// Helper function to create a mapping from `column id` to `column index`
     pub fn get_id_to_op_idx_mapping(&self) -> HashMap<ColumnId, usize> {
         ColumnDesc::get_id_to_op_idx_mapping(self.columns.as_slice(), None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_pb::plan_common::cdc_key_ordering::Comparison;
+
+    use super::*;
+    use crate::util::sort_util::OrderType;
+
+    #[test]
+    #[allow(deprecated)]
+    fn test_cdc_key_comparisons_are_persisted_with_pk_indices() {
+        let table_desc = CdcTableDesc {
+            table_id: TableId::new(1),
+            source_id: SourceId::new(2),
+            external_table_name: "orders".to_owned(),
+            pk: vec![
+                ColumnOrder::new(3, OrderType::ascending()),
+                ColumnOrder::new(1, OrderType::ascending()),
+            ],
+            pk_comparisons: vec![CdcKeyComparison::UnsignedInt64, CdcKeyComparison::Native],
+            columns: vec![],
+            stream_key: vec![3, 1],
+            connect_properties: BTreeMap::new(),
+            secret_refs: BTreeMap::new(),
+        };
+
+        let protobuf = table_desc.to_protobuf();
+        assert_eq!(protobuf.legacy_pk.len(), 2);
+        assert_eq!(protobuf.legacy_pk[0].column_index, 3);
+        assert_eq!(protobuf.legacy_pk[1].column_index, 1);
+
+        let pk_columns = protobuf.pk.unwrap().columns;
+        assert_eq!(pk_columns.len(), 2);
+        assert_eq!(pk_columns[0].pk_col_idx, 3);
+        assert_eq!(
+            pk_columns[0].get_comparison().unwrap(),
+            Comparison::UnsignedInt64
+        );
+        assert_eq!(pk_columns[1].pk_col_idx, 1);
+        assert_eq!(pk_columns[1].get_comparison().unwrap(), Comparison::Native);
     }
 }

--- a/src/compute/tests/cdc_tests.rs
+++ b/src/compute/tests/cdc_tests.rs
@@ -27,7 +27,9 @@ use risingwave_batch_executors::{Executor as BatchExecutor, RowSeqScanExecutor, 
 use risingwave_common::array::{
     Array, ArrayBuilder, DataChunk, DataChunkTestExt, Op, StreamChunk, Utf8ArrayBuilder,
 };
-use risingwave_common::catalog::{ColumnDesc, ColumnId, ConflictBehavior, Field, Schema, TableId};
+use risingwave_common::catalog::{
+    CdcKeyComparison, ColumnDesc, ColumnId, ConflictBehavior, Field, Schema, TableId,
+};
 use risingwave_common::row::{OwnedRow, Row};
 use risingwave_common::types::{DataType, Datum, JsonbVal, ScalarImpl};
 use risingwave_common::util::epoch::{EpochExt, test_epoch};
@@ -185,6 +187,7 @@ async fn test_cdc_backfill() -> StreamResult<()> {
         ExternalCdcTableType::Mock,
         table_schema.clone(),
         table_pk_order_types,
+        vec![CdcKeyComparison::Native],
         table_pk_indices.clone(),
     );
 
@@ -493,6 +496,7 @@ async fn setup_parallelized_cdc_backfill_test_context() -> ParallelizedCdcBackfi
         ExternalCdcTableType::Mock,
         table_schema.clone(),
         table_pk_order_types,
+        vec![CdcKeyComparison::Native],
         table_pk_indices.clone(),
     );
     let actor_id = 0x1a.into();

--- a/src/connector/src/source/cdc/external/mod.rs
+++ b/src/connector/src/source/cdc/external/mod.rs
@@ -81,6 +81,16 @@ impl ExternalCdcTableType {
         matches!(self, Self::MySql | Self::Postgres)
     }
 
+    pub fn get_cdc_offset_parser(&self) -> ConnectorResult<CdcOffsetParseFunc> {
+        match self {
+            Self::MySql => Ok(MySqlExternalTableReader::get_cdc_offset_parser()),
+            Self::Postgres => Ok(PostgresExternalTableReader::get_cdc_offset_parser()),
+            Self::SqlServer => Ok(SqlServerExternalTableReader::get_cdc_offset_parser()),
+            Self::Mock => Ok(MockExternalTableReader::get_cdc_offset_parser()),
+            _ => bail!("invalid external table type: {:?}", *self),
+        }
+    }
+
     pub async fn create_table_reader(
         &self,
         config: ExternalTableConfig,

--- a/src/connector/src/source/cdc/external/mod.rs
+++ b/src/connector/src/source/cdc/external/mod.rs
@@ -25,7 +25,7 @@ use futures::pin_mut;
 use futures::stream::BoxStream;
 use futures_async_stream::try_stream;
 use risingwave_common::bail;
-use risingwave_common::catalog::{ColumnDesc, Field, Schema};
+use risingwave_common::catalog::{CdcKeyComparison, ColumnDesc, Field, Schema};
 use risingwave_common::row::OwnedRow;
 use risingwave_common::secret::LocalSecretManager;
 use risingwave_pb::catalog::table::CdcTableType as PbCdcTableType;
@@ -389,21 +389,6 @@ impl ExternalTableReader for ExternalTableReaderImpl {
 }
 
 impl ExternalTableReaderImpl {
-    /// For each given primary key column (by name), returns whether comparing the RisingWave
-    /// `i64` value needs upstream unsigned `BIGINT` semantics. Only MySQL `BIGINT UNSIGNED` can
-    /// overflow into a negative `i64`; other connectors are always false.
-    pub fn pk_column_unsigned_i64_compare_flags(
-        &self,
-        pk_names: &[String],
-    ) -> ConnectorResult<Vec<bool>> {
-        match self {
-            ExternalTableReaderImpl::MySql(mysql) => {
-                mysql.pk_column_unsigned_i64_compare_flags(pk_names)
-            }
-            _ => Ok(vec![false; pk_names.len()]),
-        }
-    }
-
     pub fn get_cdc_offset_parser(&self) -> CdcOffsetParseFunc {
         match self {
             ExternalTableReaderImpl::MySql(_) => MySqlExternalTableReader::get_cdc_offset_parser(),
@@ -542,6 +527,30 @@ impl ExternalTableImpl {
             ExternalTableImpl::MySql(mysql) => mysql.pk_names(),
             ExternalTableImpl::Postgres(postgres) => postgres.pk_names(),
             ExternalTableImpl::SqlServer(sql_server) => sql_server.pk_names(),
+        }
+    }
+
+    pub fn pk_column_comparisons(
+        &self,
+        pk_names: &[String],
+    ) -> ConnectorResult<Vec<CdcKeyComparison>> {
+        match self {
+            ExternalTableImpl::MySql(mysql) => mysql.pk_column_comparisons(pk_names),
+            ExternalTableImpl::Postgres(_) | ExternalTableImpl::SqlServer(_) => {
+                Ok(vec![CdcKeyComparison::Native; pk_names.len()])
+            }
+        }
+    }
+
+    pub async fn discover_pk_column_comparisons(
+        config: &ExternalTableConfig,
+        pk_names: &[String],
+    ) -> ConnectorResult<Vec<CdcKeyComparison>> {
+        match CdcSourceType::from(config.connector.as_str()) {
+            CdcSourceType::Mysql => {
+                MySqlExternalTable::discover_pk_column_comparisons(config, pk_names).await
+            }
+            _ => Ok(vec![CdcKeyComparison::Native; pk_names.len()]),
         }
     }
 }

--- a/src/connector/src/source/cdc/external/mysql.rs
+++ b/src/connector/src/source/cdc/external/mysql.rs
@@ -24,7 +24,9 @@ use mysql_async::prelude::*;
 use mysql_common::params::Params;
 use mysql_common::value::Value;
 use risingwave_common::bail;
-use risingwave_common::catalog::{CDC_OFFSET_COLUMN_NAME, ColumnDesc, ColumnId, Field, Schema};
+use risingwave_common::catalog::{
+    CDC_OFFSET_COLUMN_NAME, CdcKeyComparison, ColumnDesc, ColumnId, Field, Schema,
+};
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, Datum, Decimal, F32, ScalarImpl};
 use risingwave_common::util::iter_util::ZipEqFast;
@@ -126,6 +128,7 @@ impl MySqlOffset {
 pub struct MySqlExternalTable {
     column_descs: Vec<ColumnDesc>,
     pk_names: Vec<String>,
+    pk_comparisons: Vec<CdcKeyComparison>,
 }
 
 impl MySqlExternalTable {
@@ -158,6 +161,24 @@ impl MySqlExternalTable {
             .discover_columns(schema.clone(), table.clone(), &system_info)
             .await?;
         let indexes = schema_discovery.discover_indexes(schema, table).await?;
+        let pk_names = primary_key_names(&indexes)
+            .ok_or_else(|| anyhow!("MySQL table doesn't define the primary key"))?;
+        let pk_comparisons = pk_names
+            .iter()
+            .map(|pk_name| {
+                let column = columns
+                    .iter()
+                    .find(|column| column.name.eq_ignore_ascii_case(pk_name))
+                    .ok_or_else(|| {
+                        anyhow!("primary key column `{pk_name}` not found in upstream MySQL schema")
+                    })?;
+                Ok(if mysql_type_is_unsigned_bigint(&column.col_type) {
+                    CdcKeyComparison::UnsignedInt64
+                } else {
+                    CdcKeyComparison::Native
+                })
+            })
+            .collect::<ConnectorResult<Vec<_>>>()?;
         let mut column_descs = vec![];
         for col in columns {
             let data_type = mysql_type_to_rw_type(&col.col_type)?;
@@ -189,11 +210,10 @@ impl MySqlExternalTable {
             column_descs.push(column_desc);
         }
 
-        let pk_names = primary_key_names(&indexes)
-            .ok_or_else(|| anyhow!("MySQL table doesn't define the primary key"))?;
         Ok(Self {
             column_descs,
             pk_names,
+            pk_comparisons,
         })
     }
 
@@ -203,6 +223,66 @@ impl MySqlExternalTable {
 
     pub fn pk_names(&self) -> &Vec<String> {
         &self.pk_names
+    }
+
+    pub fn pk_column_comparisons(
+        &self,
+        pk_names: &[String],
+    ) -> ConnectorResult<Vec<CdcKeyComparison>> {
+        pk_names
+            .iter()
+            .map(|pk_name| {
+                self.pk_names
+                    .iter()
+                    .position(|name| name.eq_ignore_ascii_case(pk_name))
+                    .map(|idx| self.pk_comparisons[idx])
+                    .ok_or_else(|| {
+                        anyhow!("primary key column `{pk_name}` not found in upstream MySQL schema")
+                            .into()
+                    })
+            })
+            .collect()
+    }
+
+    pub async fn discover_pk_column_comparisons(
+        config: &ExternalTableConfig,
+        pk_names: &[String],
+    ) -> ConnectorResult<Vec<CdcKeyComparison>> {
+        let pool = build_mysql_connection_pool(
+            &config.host,
+            config.port.parse::<u16>().unwrap(),
+            &config.username,
+            &config.password,
+            &config.database,
+            config.ssl_mode.clone(),
+        );
+        let pk_infos = MySqlExternalTableReader::query_upstream_pk_infos(
+            &pool,
+            &config.database,
+            &config.table,
+        )
+        .await?;
+        pool.disconnect().await?;
+
+        pk_names
+            .iter()
+            .map(|pk_name| {
+                pk_infos
+                    .iter()
+                    .find(|(name, _)| name.eq_ignore_ascii_case(pk_name))
+                    .map(|(_, col_type)| {
+                        if mysql_type_is_unsigned_bigint(col_type) {
+                            CdcKeyComparison::UnsignedInt64
+                        } else {
+                            CdcKeyComparison::Native
+                        }
+                    })
+                    .ok_or_else(|| {
+                        anyhow!("primary key column `{pk_name}` not found in upstream MySQL schema")
+                            .into()
+                    })
+            })
+            .collect()
     }
 }
 
@@ -665,17 +745,6 @@ impl MySqlExternalTableReader {
             })
     }
 
-    /// For each given primary key column (by name), whether it needs unsigned `i64` comparison.
-    pub(crate) fn pk_column_unsigned_i64_compare_flags(
-        &self,
-        pk_names: &[String],
-    ) -> ConnectorResult<Vec<bool>> {
-        pk_names
-            .iter()
-            .map(|name| self.needs_unsigned_i64_compare(name))
-            .collect()
-    }
-
     /// Convert negative i64 to unsigned u64 based on column type
     fn convert_negative_to_unsigned(&self, negative_val: i64) -> u64 {
         negative_val as u64
@@ -857,7 +926,7 @@ mod tests {
     use futures::pin_mut;
     use futures_async_stream::for_await;
     use maplit::{convert_args, hashmap};
-    use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema};
+    use risingwave_common::catalog::{CdcKeyComparison, ColumnDesc, ColumnId, Field, Schema};
     use risingwave_common::types::DataType;
     use sea_schema::mysql::def::{ColumnType, IndexInfo, IndexOrder, IndexPart, IndexType};
 
@@ -901,6 +970,22 @@ mod tests {
                 "typeid".to_owned(),
                 "clientid".to_owned(),
             ])
+        );
+    }
+
+    #[test]
+    fn test_pk_column_comparisons_follow_requested_order() {
+        let table = MySqlExternalTable {
+            column_descs: vec![],
+            pk_names: vec!["signed_id".to_owned(), "unsigned_id".to_owned()],
+            pk_comparisons: vec![CdcKeyComparison::Native, CdcKeyComparison::UnsignedInt64],
+        };
+
+        assert_eq!(
+            table
+                .pk_column_comparisons(&["UNSIGNED_ID".to_owned(), "SIGNED_ID".to_owned(),])
+                .unwrap(),
+            vec![CdcKeyComparison::UnsignedInt64, CdcKeyComparison::Native,]
         );
     }
 

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -28,9 +28,9 @@ use pgwire::pg_response::{PgResponse, StatementType};
 use prost::Message as _;
 use risingwave_common::acl::AclMode;
 use risingwave_common::catalog::{
-    CdcTableDesc, ColumnCatalog, ColumnDesc, ConflictBehavior, DEFAULT_SCHEMA_NAME, Engine,
-    ICEBERG_SINK_PREFIX, ICEBERG_SOURCE_PREFIX, RISINGWAVE_ICEBERG_ROW_ID, ROW_ID_COLUMN_NAME,
-    TableId,
+    CdcKeyComparison, CdcTableDesc, ColumnCatalog, ColumnDesc, ConflictBehavior,
+    DEFAULT_SCHEMA_NAME, Engine, ICEBERG_SINK_PREFIX, ICEBERG_SOURCE_PREFIX,
+    RISINGWAVE_ICEBERG_ROW_ID, ROW_ID_COLUMN_NAME, TableId,
 };
 use risingwave_common::config::MetaBackend;
 use risingwave_common::global_jvm::Jvm;
@@ -836,6 +836,7 @@ pub(crate) fn gen_create_table_plan_for_cdc_table(
     source_watermarks: Vec<SourceWatermark>,
     mut columns: Vec<ColumnCatalog>,
     pk_names: Vec<String>,
+    pk_comparisons: Vec<CdcKeyComparison>,
     cdc_with_options: WithOptionsSecResolved,
     mut col_id_gen: ColumnIdGenerator,
     on_conflict: Option<OnConflict>,
@@ -914,6 +915,7 @@ pub(crate) fn gen_create_table_plan_for_cdc_table(
         source_id: source.id, // id of cdc source streaming job
         external_table_name: external_table_name.clone(),
         pk: table_pk,
+        pk_comparisons,
         columns: non_generated_column_descs,
         stream_key: pk_column_indices,
         connect_properties: options,
@@ -1430,7 +1432,7 @@ pub(super) async fn handle_create_table_plan(
                     cdc_table.external_table_name.clone(),
                 )?;
 
-            let (columns, pk_names) = match wildcard_idx {
+            let (columns, pk_names, pk_comparisons) = match wildcard_idx {
                 Some(_) => bind_cdc_table_schema_externally(cdc_with_options.clone()).await?,
                 None => {
                     for column_def in &column_defs {
@@ -1449,12 +1451,13 @@ pub(super) async fn handle_create_table_plan(
 
                     let (columns, pk_names) =
                         bind_cdc_table_schema(&column_defs, &constraints, false)?;
-                    // read default value definition from external db
-                    let (options, secret_refs) = cdc_with_options.clone().into_parts();
-                    let _config = ExternalTableConfig::try_from_btreemap(options, secret_refs)
-                        .context("failed to extract external table config")?;
+                    let pk_comparisons = Box::pin(bind_cdc_pk_comparisons_externally(
+                        cdc_with_options.clone(),
+                        &pk_names,
+                    ))
+                    .await?;
 
-                    (columns, pk_names)
+                    (columns, pk_names, pk_comparisons)
                 }
             };
 
@@ -1475,6 +1478,7 @@ pub(super) async fn handle_create_table_plan(
                 source_watermarks,
                 columns,
                 pk_names,
+                pk_comparisons,
                 cdc_with_options,
                 col_id_gen,
                 on_conflict,
@@ -1621,7 +1625,7 @@ fn sanity_check_for_table_on_cdc_source(
 /// Derive schema for cdc table when create a new Table or alter an existing Table
 async fn bind_cdc_table_schema_externally(
     cdc_with_options: WithOptionsSecResolved,
-) -> Result<(Vec<ColumnCatalog>, Vec<String>)> {
+) -> Result<(Vec<ColumnCatalog>, Vec<String>, Vec<CdcKeyComparison>)> {
     // read cdc table schema from external db or parsing the schema from SQL definitions
     let (options, secret_refs) = cdc_with_options.into_parts();
     let config = ExternalTableConfig::try_from_btreemap(options, secret_refs)
@@ -1631,6 +1635,8 @@ async fn bind_cdc_table_schema_externally(
         .await
         .context("failed to auto derive table schema")?;
 
+    let pk_names = table.pk_names().clone();
+    let pk_comparisons = table.pk_column_comparisons(&pk_names)?;
     Ok((
         table
             .column_descs()
@@ -1641,8 +1647,21 @@ async fn bind_cdc_table_schema_externally(
                 is_hidden: false,
             })
             .collect(),
-        table.pk_names().clone(),
+        pk_names,
+        pk_comparisons,
     ))
+}
+
+async fn bind_cdc_pk_comparisons_externally(
+    cdc_with_options: WithOptionsSecResolved,
+    pk_names: &[String],
+) -> Result<Vec<CdcKeyComparison>> {
+    // Replacement plans also use this path, so a successful schema change persists the current
+    // upstream comparison semantics in the new stream graph.
+    let (options, secret_refs) = cdc_with_options.into_parts();
+    let config = ExternalTableConfig::try_from_btreemap(options, secret_refs)
+        .context("failed to extract external table config")?;
+    Ok(ExternalTableImpl::discover_pk_column_comparisons(&config, pk_names).await?)
 }
 
 /// Derive schema for cdc table when create a new Table or alter an existing Table
@@ -1699,7 +1718,7 @@ pub async fn handle_create_table(
     }
 
     let (graph, source, hummock_table, job_type, shared_source_id) = {
-        let (plan, source, table, job_type, shared_source_id) = handle_create_table_plan(
+        let (plan, source, table, job_type, shared_source_id) = Box::pin(handle_create_table_plan(
             handler_args.clone(),
             ExplainOptions::default(),
             format_encode,
@@ -1715,7 +1734,7 @@ pub async fn handle_create_table(
             include_column_options,
             webhook_info,
             engine,
-        )
+        ))
         .await?;
         tracing::trace!("table_plan: {:?}", plan.explain_to_string());
 
@@ -2386,6 +2405,11 @@ pub async fn generate_stream_graph_for_replace_table(
                 )?;
 
             let (column_catalogs, pk_names) = bind_cdc_table_schema(&columns, &constraints, true)?;
+            let pk_comparisons = Box::pin(bind_cdc_pk_comparisons_externally(
+                cdc_with_options.clone(),
+                &pk_names,
+            ))
+            .await?;
 
             // CDC-table branch only: see the comment at the symmetric call site in
             // `handle_create_table_plan`. Plain (non-CDC) tables don't hit this check.
@@ -2401,6 +2425,7 @@ pub async fn generate_stream_graph_for_replace_table(
                 source_watermarks,
                 column_catalogs,
                 pk_names,
+                pk_comparisons,
                 cdc_with_options,
                 col_id_gen,
                 on_conflict,

--- a/src/frontend/src/handler/explain.rs
+++ b/src/frontend/src/handler/explain.rs
@@ -96,7 +96,7 @@ pub async fn do_handle_explain(
             } => {
                 let format_encode = format_encode.map(|s| s.into_v2_with_warning());
 
-                let (plan, _source, table, _job_type, _) = handle_create_table_plan(
+                let (plan, _source, table, _job_type, _) = Box::pin(handle_create_table_plan(
                     handler_args,
                     explain_options,
                     format_encode,
@@ -115,7 +115,7 @@ pub async fn do_handle_explain(
                     include_column_options,
                     webhook_info,
                     risingwave_common::catalog::Engine::Hummock,
-                )
+                ))
                 .await?;
                 let context = plan.ctx();
                 (

--- a/src/meta/src/stream/cdc.rs
+++ b/src/meta/src/stream/cdc.rs
@@ -77,15 +77,14 @@ pub(crate) async fn try_init_parallel_cdc_table_snapshot_splits(
         })
         .map(Into::into)
         .collect();
-    let table_pk_indices = if let Some(pk) = &table_desc.pk {
+    let table_pk_indices = if let Some(pk) = &table_desc.pk_ordering {
         pk.columns
             .iter()
             .map(|column| column.pk_col_idx as usize)
             .collect_vec()
     } else {
-        #[allow(deprecated)]
         table_desc
-            .legacy_pk
+            .pk
             .iter()
             .map(|column| column.column_index as usize)
             .collect_vec()

--- a/src/meta/src/stream/cdc.rs
+++ b/src/meta/src/stream/cdc.rs
@@ -77,11 +77,19 @@ pub(crate) async fn try_init_parallel_cdc_table_snapshot_splits(
         })
         .map(Into::into)
         .collect();
-    let table_pk_indices = table_desc
-        .pk
-        .iter()
-        .map(|k| k.column_index as usize)
-        .collect_vec();
+    let table_pk_indices = if let Some(pk) = &table_desc.pk {
+        pk.columns
+            .iter()
+            .map(|column| column.pk_col_idx as usize)
+            .collect_vec()
+    } else {
+        #[allow(deprecated)]
+        table_desc
+            .legacy_pk
+            .iter()
+            .map(|column| column.column_index as usize)
+            .collect_vec()
+    };
     let table_config = ExternalTableConfig::try_from_btreemap(
         table_desc.connect_properties.clone(),
         table_desc.secret_refs.clone(),

--- a/src/prost/build.rs
+++ b/src/prost/build.rs
@@ -1257,6 +1257,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .type_attribute("expr.FunctionCall", "#[derive(Eq, Hash)]")
         .type_attribute("expr.UserDefinedFunction", "#[derive(Eq, Hash)]")
         .type_attribute("plan_common.ColumnDesc", "#[derive(Eq, Hash)]")
+        .type_attribute("plan_common.CdcKeyOrdering", "#[derive(Eq, Hash)]")
         .type_attribute("plan_common.ExternalTableDesc", "#[derive(Eq, Hash)]")
         .type_attribute(
             "plan_common.ColumnDesc.generated_or_default_column",

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -23,7 +23,7 @@ use itertools::Itertools;
 use risingwave_common::array::{DataChunk, Op};
 use risingwave_common::bail;
 use risingwave_common::bitmap::BitmapBuilder;
-use risingwave_common::catalog::ColumnDesc;
+use risingwave_common::catalog::{CdcKeyComparison, ColumnDesc};
 use risingwave_common::row::RowExt;
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_connector::parser::{
@@ -293,6 +293,12 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
         // The indices to primary key columns
         let pk_indices = self.external_table.pk_indices().to_vec();
         let pk_order = self.external_table.pk_order_types().to_vec();
+        let pk_needs_unsigned_i64_compare = self
+            .external_table
+            .pk_comparisons()
+            .iter()
+            .map(|comparison| *comparison == CdcKeyComparison::UnsignedInt64)
+            .collect_vec();
 
         let table_id = self.external_table.table_id();
         let upstream_table_name = self.external_table.qualified_table_name();
@@ -445,20 +451,6 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
 
             let offset_parse_func = upstream_table_reader.reader.get_cdc_offset_parser();
             let mut consumed_binlog_offset: Option<CdcOffset> = None;
-
-            // Whether each pk column needs unsigned `i64` comparison. Frontend up-casts narrower
-            // unsigned integers, while unsigned float/double/decimal keep their native comparison
-            // semantics; only `BIGINT UNSIGNED` can overflow into a negative `i64` in RisingWave.
-            let pk_needs_unsigned_i64_compare = {
-                let schema = self.external_table.schema();
-                let pk_names: Vec<String> = pk_indices
-                    .iter()
-                    .map(|&i| schema.fields[i].name.clone())
-                    .collect();
-                upstream_table_reader
-                    .reader
-                    .pk_column_unsigned_i64_compare_flags(&pk_names)?
-            };
 
             tracing::info!(
                 %table_id,
@@ -1134,7 +1126,9 @@ mod tests {
 
     use futures::{StreamExt, pin_mut};
     use risingwave_common::array::{Array, DataChunk, Op, StreamChunk};
-    use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema, TableId};
+    use risingwave_common::catalog::{
+        CdcKeyComparison, ColumnDesc, ColumnId, Field, Schema, TableId,
+    };
     use risingwave_common::row::{OwnedRow, Row};
     use risingwave_common::types::{DataType, Datum, JsonbVal, ScalarImpl};
     use risingwave_common::util::epoch::test_epoch;
@@ -1341,6 +1335,7 @@ mod tests {
             ExternalCdcTableType::Undefined,
             Schema::new(vec![Field::with_name(DataType::Int64, "id")]),
             vec![OrderType::ascending()],
+            vec![CdcKeyComparison::Native],
             vec![0],
         );
         let schema = Schema::new(vec![
@@ -1541,6 +1536,7 @@ mod tests {
                 Field::with_name(DataType::Float64, "price"),
             ]),
             vec![OrderType::ascending()],
+            vec![CdcKeyComparison::Native],
             vec![0],
         );
         let output_columns = vec![
@@ -2207,6 +2203,7 @@ mod tests {
                 Field::with_name(DataType::Float64, "price"),
             ]),
             vec![OrderType::ascending()],
+            vec![CdcKeyComparison::Native],
             vec![0],
         );
         let output_columns = vec![

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -194,14 +194,6 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
             .inc_by(upstream_processed_row_count);
     }
 
-    fn map_startup_chunk(
-        chunk: StreamChunk,
-        is_recovery: bool,
-        output_indices: &[usize],
-    ) -> Option<StreamChunk> {
-        is_recovery.then(|| mapping_chunk(chunk, output_indices))
-    }
-
     fn consume_upstream_chunk_buffer(
         offset_parse_func: &risingwave_connector::source::cdc::external::CdcOffsetParseFunc,
         upstream_chunk_buffer: &mut Vec<StreamChunk>,
@@ -387,8 +379,8 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
             // we now try to create the table reader with retry.
             //
             // A fresh backfill can ignore CDC events here because its snapshot starts from the
-            // beginning. During recovery, emit all CDC events and let the downstream materialize
-            // executor reconcile PK conflicts with the resumed snapshot and subsequent CDC events.
+            // beginning. Recovery must preserve events for the already-scanned prefix, using
+            // the reader's offset parser and unsigned PK comparison metadata to filter them.
             let is_recovery = current_pk_pos.is_some();
             let mut table_reader: Option<ExternalTableReaderImpl> = None;
             let external_table = self.external_table.clone();
@@ -409,6 +401,12 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                 .await
                 .expect("Retry create cdc table reader until success.")
             });
+            if is_recovery {
+                // Leave upstream chunks and barriers pending until we can filter them safely.
+                // Emitting an unscanned key here is unsafe: normal backfill can discard a later
+                // delete before the snapshot reaches that key, leaving a stale row downstream.
+                table_reader = Some(future.as_mut().await);
+            }
             loop {
                 if let Some(msg) =
                     build_reader_and_poll_upstream(&mut upstream, &mut table_reader, &mut future)
@@ -416,17 +414,11 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                 {
                     match msg {
                         Message::Barrier(barrier) => {
-                            // Commit after all preceding recovery chunks have been emitted.
                             state_impl.commit_state(barrier.epoch).await?;
                             yield Message::Barrier(barrier);
                         }
-                        Message::Chunk(chunk) => {
-                            if let Some(chunk) =
-                                Self::map_startup_chunk(chunk, is_recovery, &self.output_indices)
-                            {
-                                Self::report_metrics(&self.metrics, 0, chunk.cardinality() as u64);
-                                yield Message::Chunk(chunk);
-                            }
+                        Message::Chunk(_) => {
+                            // Only fresh backfills consume upstream before the reader is ready.
                         }
                         Message::Watermark(_) => {
                             // ignore watermark
@@ -525,12 +517,31 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                         break;
                     }
                     Message::Chunk(chunk) => {
-                        last_binlog_offset = get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
-                        if let Some(chunk) =
-                            Self::map_startup_chunk(chunk, is_recovery, &self.output_indices)
-                        {
+                        let chunk_offset = get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
+                        if let Some(current_pos) = current_pk_pos.as_ref() {
+                            let chunk = mapping_chunk(
+                                mark_cdc_chunk(
+                                    &offset_parse_func,
+                                    chunk,
+                                    current_pos,
+                                    &pk_indices,
+                                    &pk_order,
+                                    &pk_needs_unsigned_i64_compare,
+                                    last_binlog_offset.clone(),
+                                )?,
+                                &self.output_indices,
+                            );
                             Self::report_metrics(&self.metrics, 0, chunk.cardinality() as u64);
-                            yield Message::Chunk(chunk);
+                            if chunk.cardinality() > 0 {
+                                yield Message::Chunk(chunk);
+                            }
+                        }
+                        if let Some(chunk_offset) = chunk_offset
+                            && last_binlog_offset
+                                .as_ref()
+                                .is_none_or(|last| *last < chunk_offset)
+                        {
+                            last_binlog_offset = Some(chunk_offset);
                         }
                     }
                     Message::Watermark(_) => {
@@ -1127,7 +1138,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::str::FromStr;
 
-    use futures::{StreamExt, pin_mut, stream};
+    use futures::{StreamExt, pin_mut};
     use risingwave_common::array::{Array, DataChunk, Op, StreamChunk};
     use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema, TableId};
     use risingwave_common::row::{OwnedRow, Row};
@@ -1139,12 +1150,11 @@ mod tests {
     use risingwave_connector::source::cdc::external::mock_external_table::MockExternalTableReader;
     use risingwave_connector::source::cdc::external::mysql::MySqlOffset;
     use risingwave_connector::source::cdc::external::{
-        CdcOffset, ExternalCdcTableType, ExternalTableConfig, ExternalTableReaderImpl,
-        SchemaTableName,
+        CdcOffset, ExternalCdcTableType, ExternalTableConfig, SchemaTableName,
     };
     use risingwave_storage::memory::MemoryStateStore;
 
-    use super::{PkCompareInfo, build_reader_and_poll_upstream};
+    use super::PkCompareInfo;
     use crate::common::table::test_utils::gen_pbtable;
     use crate::executor::backfill::cdc::cdc_backfill::transform_upstream;
     use crate::executor::backfill::cdc::state::CdcBackfillState;
@@ -1583,65 +1593,35 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_recovery_yields_all_chunks_while_creating_reader() {
-        let chunk = StreamChunk::from_rows(
-            &[
-                (
-                    Op::Insert,
-                    OwnedRow::new(vec![
-                        Some(ScalarImpl::Int64(4)),
-                        Some(ScalarImpl::Float64(44.04.into())),
-                        Some(ScalarImpl::Utf8("offset-1".into())),
-                    ]),
-                ),
-                (
-                    Op::Delete,
-                    OwnedRow::new(vec![
-                        Some(ScalarImpl::Int64(5)),
-                        Some(ScalarImpl::Float64(55.05.into())),
-                        Some(ScalarImpl::Utf8("offset-3".into())),
-                    ]),
-                ),
-            ],
-            &[DataType::Int64, DataType::Float64, DataType::Varchar],
-        );
-        let fresh_chunk = chunk.clone();
-        let mut upstream = stream::iter([Ok(Message::Chunk(chunk))]);
-        let mut table_reader: Option<ExternalTableReaderImpl> = None;
-        let mut reader_future = Box::pin(std::future::pending::<ExternalTableReaderImpl>());
+    #[tokio::test(start_paused = true)]
+    async fn test_recovery_waits_for_reader_before_consuming_upstream() {
+        let (mut tx, mut executor, _) = create_recovering_cdc_backfill().await;
+        // Reader creation will keep retrying, while recovery has a saved PK position.
+        executor.external_table = ExternalStorageTable::for_test_undefined();
+        let executor = executor.execute_inner();
+        pin_mut!(executor);
 
-        let Message::Chunk(chunk) =
-            build_reader_and_poll_upstream(&mut upstream, &mut table_reader, &mut reader_future)
+        tx.send_barrier(Barrier::new_test_barrier(test_epoch(3)));
+        assert!(matches!(
+            executor.next().await.unwrap().unwrap(),
+            Message::Barrier(_)
+        ));
+        tx.push_chunk(create_raw_cdc_chunk(&[(
+            r#"{ "payload": { "before": null, "after": { "id": 4, "price": 44.04 }, "op": "c" } }"#,
+            r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":3},"isHeartbeat":false}"#,
+        )]));
+        tx.send_barrier(Barrier::new_test_barrier(test_epoch(4)));
+
+        // Neither the chunk nor its checkpoint may pass before filtering metadata is ready.
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), executor.next())
                 .await
-                .unwrap()
-                .unwrap()
-        else {
-            panic!("expected the upstream chunk while the reader is pending");
-        };
-        assert!(table_reader.is_none());
-        let chunk =
-            CdcBackfillExecutor::<MemoryStateStore>::map_startup_chunk(chunk, true, &[0, 1])
-                .unwrap();
-        let rows = chunk
-            .rows()
-            .map(|(op, row)| (op, row.to_owned_row()))
-            .collect::<Vec<_>>();
-        assert_eq!(rows.len(), 2);
-        assert_eq!(rows[0].0, Op::Insert);
-        assert_eq!(rows[0].1[0], Some(ScalarImpl::Int64(4)));
-        assert_eq!(rows[1].0, Op::Delete);
-        assert_eq!(rows[1].1[0], Some(ScalarImpl::Int64(5)));
-        assert!(CdcBackfillExecutor::<MemoryStateStore>::map_startup_chunk(
-            fresh_chunk,
-            false,
-            &[0, 1],
-        )
-        .is_none());
+                .is_err()
+        );
     }
 
     #[tokio::test]
-    async fn test_recovery_yields_all_updates_before_backfill_barrier() {
+    async fn test_recovery_filters_updates_before_backfill_barrier() {
         let (mut tx, executor, memory_state_store) = create_recovering_cdc_backfill().await;
         let executor = executor.execute_inner();
         pin_mut!(executor);
@@ -1671,16 +1651,130 @@ mod tests {
             .rows()
             .map(|(op, row)| (op, row.to_owned_row()))
             .collect::<Vec<_>>();
-        assert_eq!(rows.len(), 2);
+        assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].0, Op::Insert);
         assert_eq!(rows[0].1[0], Some(ScalarImpl::Int64(1)));
-        assert_eq!(rows[1].0, Op::Insert);
-        assert_eq!(rows[1].1[0], Some(ScalarImpl::Int64(6)));
         assert!(matches!(
             executor.next().await.unwrap().unwrap(),
             Message::Barrier(_)
         ));
         assert_recovery_offset(memory_state_store, 2, test_epoch(4)).await;
+    }
+
+    #[tokio::test]
+    async fn test_recovery_preserves_scanned_inserts_and_deletes() {
+        let (mut tx, executor, _) = create_recovering_cdc_backfill().await;
+        let executor = executor.execute_inner();
+        pin_mut!(executor);
+
+        tx.send_barrier(Barrier::new_test_barrier(test_epoch(3)));
+        assert!(matches!(
+            executor.next().await.unwrap().unwrap(),
+            Message::Barrier(_)
+        ));
+        // This replayed event predates the saved offset and must not lower the offset filter.
+        tx.push_chunk(create_raw_cdc_chunk(&[(
+            r#"{ "payload": { "before": null, "after": { "id": 3, "price": 30.01 }, "op": "c" } }"#,
+            r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":1},"isHeartbeat":false}"#,
+        )]));
+        tx.push_chunk(create_raw_cdc_chunk(&[
+            (
+                r#"{ "payload": { "before": null, "after": { "id": 3, "price": 31.01 }, "op": "c" } }"#,
+                r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":1},"isHeartbeat":false}"#,
+            ),
+            (
+                r#"{ "payload": { "before": null, "after": { "id": 4, "price": 44.04 }, "op": "c" } }"#,
+                r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":2},"isHeartbeat":false}"#,
+            ),
+            (
+                r#"{ "payload": { "before": { "id": 5, "price": 55.05 }, "after": null, "op": "d" } }"#,
+                r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":3},"isHeartbeat":false}"#,
+            ),
+        ]));
+        tx.send_barrier(Barrier::new_test_barrier(test_epoch(4)));
+
+        let Message::Chunk(chunk) = executor.next().await.unwrap().unwrap() else {
+            panic!("expected the scanned-prefix changes before the barrier");
+        };
+        let rows = chunk
+            .rows()
+            .map(|(op, row)| (op, row.to_owned_row()))
+            .collect::<Vec<_>>();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].0, Op::Insert);
+        assert_eq!(rows[0].1[0], Some(ScalarImpl::Int64(4)));
+        assert_eq!(rows[1].0, Op::Delete);
+        assert_eq!(rows[1].1[0], Some(ScalarImpl::Int64(5)));
+        assert!(matches!(
+            executor.next().await.unwrap().unwrap(),
+            Message::Barrier(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_recovery_does_not_leave_deleted_unscanned_row() {
+        let (mut tx, mut executor, memory_state_store) = create_recovering_cdc_backfill().await;
+        executor.options.snapshot_barrier_interval = 1;
+        let executor = executor.execute_inner();
+        pin_mut!(executor);
+
+        tx.send_barrier(Barrier::new_test_barrier(test_epoch(3)));
+        assert!(matches!(
+            executor.next().await.unwrap().unwrap(),
+            Message::Barrier(_)
+        ));
+
+        // Recover at PK 5, then receive an insert for an unscanned key during startup.
+        tx.push_chunk(create_raw_cdc_chunk(&[(
+            r#"{ "payload": { "before": null, "after": { "id": 100, "price": 100.01 }, "op": "c" } }"#,
+            r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":3},"isHeartbeat":false}"#,
+        )]));
+        tx.send_barrier(Barrier::new_test_barrier(test_epoch(4)));
+
+        // Normal backfill receives its delete before the snapshot reaches PK 100.
+        // The snapshot refresh at barrier 5 scans up to PK 8 and filters out the delete.
+        tx.push_chunk(create_raw_cdc_chunk(&[(
+            r#"{ "payload": { "before": { "id": 100, "price": 100.01 }, "after": null, "op": "d" } }"#,
+            r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":4},"isHeartbeat":false}"#,
+        )]));
+        tx.send_barrier(Barrier::new_test_barrier(test_epoch(5)));
+        // The next snapshot is empty, so backfill completes at barrier 6.
+        tx.send_barrier(Barrier::new_test_barrier(test_epoch(6)));
+
+        let mut materialized = BTreeMap::new();
+        loop {
+            match executor.next().await.unwrap().unwrap() {
+                Message::Chunk(chunk) => {
+                    for (op, row) in chunk.rows() {
+                        let pk = row.datum_at(0).unwrap().into_int64();
+                        match op {
+                            Op::Insert => {
+                                materialized.insert(pk, row.to_owned_row());
+                            }
+                            Op::Delete => {
+                                materialized.remove(&pk);
+                            }
+                            _ => unreachable!("CDC updates are converted to inserts"),
+                        }
+                    }
+                }
+                Message::Barrier(barrier) if barrier.epoch.curr == test_epoch(6) => break,
+                Message::Barrier(_) => {}
+                Message::Watermark(_) => panic!("unexpected watermark during backfill"),
+            }
+        }
+
+        assert!(!materialized.contains_key(&100));
+        let mut restored_state = CdcBackfillState::new(
+            TableId::new(1234),
+            create_cdc_state_table(memory_state_store).await,
+            5,
+        );
+        restored_state
+            .init_epoch(Barrier::new_test_barrier(test_epoch(6)).epoch)
+            .await
+            .unwrap();
+        assert!(restored_state.restore_state().await.unwrap().is_finished);
     }
 
     #[test]

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -194,6 +194,14 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
             .inc_by(upstream_processed_row_count);
     }
 
+    fn map_startup_chunk(
+        chunk: StreamChunk,
+        is_recovery: bool,
+        output_indices: &[usize],
+    ) -> Option<StreamChunk> {
+        is_recovery.then(|| mapping_chunk(chunk, output_indices))
+    }
+
     fn consume_upstream_chunk_buffer(
         offset_parse_func: &risingwave_connector::source::cdc::external::CdcOffsetParseFunc,
         upstream_chunk_buffer: &mut Vec<StreamChunk>,
@@ -377,7 +385,11 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
         if need_backfill {
             // After init the state table and forward the initial barrier to downstream,
             // we now try to create the table reader with retry.
-            // If backfill hasn't finished, we can ignore upstream cdc events before we create the table reader.
+            //
+            // A fresh backfill can ignore CDC events here because its snapshot starts from the
+            // beginning. During recovery, emit all CDC events and let the downstream materialize
+            // executor reconcile PK conflicts with the resumed snapshot and subsequent CDC events.
+            let is_recovery = current_pk_pos.is_some();
             let mut table_reader: Option<ExternalTableReaderImpl> = None;
             let external_table = self.external_table.clone();
             let actor_id = self.actor_ctx.id;
@@ -402,19 +414,22 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                     build_reader_and_poll_upstream(&mut upstream, &mut table_reader, &mut future)
                         .await?
                 {
-                    if let Some(msg) = mapping_message(msg, &self.output_indices) {
-                        match msg {
-                            Message::Barrier(barrier) => {
-                                // commit state to bump the epoch of state table
-                                state_impl.commit_state(barrier.epoch).await?;
-                                yield Message::Barrier(barrier);
+                    match msg {
+                        Message::Barrier(barrier) => {
+                            // Commit after all preceding recovery chunks have been emitted.
+                            state_impl.commit_state(barrier.epoch).await?;
+                            yield Message::Barrier(barrier);
+                        }
+                        Message::Chunk(chunk) => {
+                            if let Some(chunk) =
+                                Self::map_startup_chunk(chunk, is_recovery, &self.output_indices)
+                            {
+                                Self::report_metrics(&self.metrics, 0, chunk.cardinality() as u64);
+                                yield Message::Chunk(chunk);
                             }
-                            Message::Chunk(_) => {
-                                // ignore chunk if we need backfill, since we can read the data from the snapshot
-                            }
-                            Message::Watermark(_) => {
-                                // ignore watermark
-                            }
+                        }
+                        Message::Watermark(_) => {
+                            // ignore watermark
                         }
                     }
                 } else {
@@ -504,13 +519,19 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                                 // ignore other mutations
                             }
                         }
-                        // commit state just to bump the epoch of state table
+                        // Commit after all preceding recovery chunks have been emitted.
                         state_impl.commit_state(barrier.epoch).await?;
                         yield Message::Barrier(barrier);
                         break;
                     }
-                    Message::Chunk(ref chunk) => {
-                        last_binlog_offset = get_cdc_chunk_last_offset(&offset_parse_func, chunk)?;
+                    Message::Chunk(chunk) => {
+                        last_binlog_offset = get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
+                        if let Some(chunk) =
+                            Self::map_startup_chunk(chunk, is_recovery, &self.output_indices)
+                        {
+                            Self::report_metrics(&self.metrics, 0, chunk.cardinality() as u64);
+                            yield Message::Chunk(chunk);
+                        }
                     }
                     Message::Watermark(_) => {
                         // Ignore watermark
@@ -1106,7 +1127,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::str::FromStr;
 
-    use futures::{StreamExt, pin_mut};
+    use futures::{StreamExt, pin_mut, stream};
     use risingwave_common::array::{Array, DataChunk, Op, StreamChunk};
     use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema, TableId};
     use risingwave_common::row::{OwnedRow, Row};
@@ -1118,18 +1139,19 @@ mod tests {
     use risingwave_connector::source::cdc::external::mock_external_table::MockExternalTableReader;
     use risingwave_connector::source::cdc::external::mysql::MySqlOffset;
     use risingwave_connector::source::cdc::external::{
-        CdcOffset, ExternalCdcTableType, ExternalTableConfig, SchemaTableName,
+        CdcOffset, ExternalCdcTableType, ExternalTableConfig, ExternalTableReaderImpl,
+        SchemaTableName,
     };
     use risingwave_storage::memory::MemoryStateStore;
 
-    use super::PkCompareInfo;
+    use super::{PkCompareInfo, build_reader_and_poll_upstream};
     use crate::common::table::test_utils::gen_pbtable;
     use crate::executor::backfill::cdc::cdc_backfill::transform_upstream;
     use crate::executor::backfill::cdc::state::CdcBackfillState;
     use crate::executor::monitor::StreamingMetrics;
     use crate::executor::prelude::StateTable;
     use crate::executor::source::default_source_internal_table;
-    use crate::executor::test_utils::MockSource;
+    use crate::executor::test_utils::{MessageSender, MockSource};
     use crate::executor::{
         ActorContext, Barrier, CdcBackfillExecutor, ExternalStorageTable, Message,
     };
@@ -1462,6 +1484,203 @@ mod tests {
             None,
         )
         .await
+    }
+
+    async fn create_recovering_cdc_backfill() -> (
+        MessageSender,
+        CdcBackfillExecutor<MemoryStateStore>,
+        MemoryStateStore,
+    ) {
+        let memory_state_store = MemoryStateStore::new();
+        let mut state_writer = CdcBackfillState::new(
+            TableId::new(1234),
+            create_cdc_state_table(memory_state_store.clone()).await,
+            5,
+        );
+        state_writer
+            .init_epoch(Barrier::new_test_barrier(test_epoch(1)).epoch)
+            .await
+            .unwrap();
+        state_writer
+            .mutate_state(
+                Some(OwnedRow::new(vec![Some(ScalarImpl::Int64(5))])),
+                Some(CdcOffset::MySql(MySqlOffset::new("1.binlog".to_owned(), 2))),
+                5,
+                false,
+            )
+            .await
+            .unwrap();
+        state_writer
+            .commit_state(Barrier::new_test_barrier(test_epoch(2)).epoch)
+            .await
+            .unwrap();
+
+        let (tx, source) = MockSource::channel();
+        let source = source.into_executor(
+            Schema::new(vec![
+                Field::unnamed(DataType::Jsonb),
+                Field::unnamed(DataType::Varchar),
+            ]),
+            vec![0],
+        );
+        let external_table = ExternalStorageTable::new(
+            TableId::new(1234),
+            SchemaTableName {
+                schema_name: "public".to_owned(),
+                table_name: "mock_table".to_owned(),
+            },
+            "mydb".to_owned(),
+            ExternalTableConfig::default(),
+            ExternalCdcTableType::Mock,
+            Schema::new(vec![
+                Field::with_name(DataType::Int64, "id"),
+                Field::with_name(DataType::Float64, "price"),
+            ]),
+            vec![OrderType::ascending()],
+            vec![0],
+        );
+        let output_columns = vec![
+            ColumnDesc::named("id", ColumnId::new(1), DataType::Int64),
+            ColumnDesc::named("price", ColumnId::new(2), DataType::Float64),
+        ];
+        let executor = CdcBackfillExecutor::new(
+            ActorContext::for_test(0x1a),
+            external_table,
+            source,
+            vec![0, 1],
+            output_columns,
+            None,
+            StreamingMetrics::unused().into(),
+            create_cdc_state_table(memory_state_store.clone()).await,
+            None,
+            CdcScanOptions::default(),
+            BTreeMap::default(),
+        );
+        (tx, executor, memory_state_store)
+    }
+
+    async fn assert_recovery_offset(
+        memory_state_store: MemoryStateStore,
+        expected_position: u64,
+        epoch: u64,
+    ) {
+        let mut restored_state = CdcBackfillState::new(
+            TableId::new(1234),
+            create_cdc_state_table(memory_state_store).await,
+            5,
+        );
+        restored_state
+            .init_epoch(Barrier::new_test_barrier(epoch).epoch)
+            .await
+            .unwrap();
+        let state = restored_state.restore_state().await.unwrap();
+        assert_eq!(
+            state.last_cdc_offset,
+            Some(CdcOffset::MySql(MySqlOffset::new(
+                "1.binlog".to_owned(),
+                expected_position,
+            )))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recovery_yields_all_chunks_while_creating_reader() {
+        let chunk = StreamChunk::from_rows(
+            &[
+                (
+                    Op::Insert,
+                    OwnedRow::new(vec![
+                        Some(ScalarImpl::Int64(4)),
+                        Some(ScalarImpl::Float64(44.04.into())),
+                        Some(ScalarImpl::Utf8("offset-1".into())),
+                    ]),
+                ),
+                (
+                    Op::Delete,
+                    OwnedRow::new(vec![
+                        Some(ScalarImpl::Int64(5)),
+                        Some(ScalarImpl::Float64(55.05.into())),
+                        Some(ScalarImpl::Utf8("offset-3".into())),
+                    ]),
+                ),
+            ],
+            &[DataType::Int64, DataType::Float64, DataType::Varchar],
+        );
+        let fresh_chunk = chunk.clone();
+        let mut upstream = stream::iter([Ok(Message::Chunk(chunk))]);
+        let mut table_reader: Option<ExternalTableReaderImpl> = None;
+        let mut reader_future = Box::pin(std::future::pending::<ExternalTableReaderImpl>());
+
+        let Message::Chunk(chunk) =
+            build_reader_and_poll_upstream(&mut upstream, &mut table_reader, &mut reader_future)
+                .await
+                .unwrap()
+                .unwrap()
+        else {
+            panic!("expected the upstream chunk while the reader is pending");
+        };
+        assert!(table_reader.is_none());
+        let chunk =
+            CdcBackfillExecutor::<MemoryStateStore>::map_startup_chunk(chunk, true, &[0, 1])
+                .unwrap();
+        let rows = chunk
+            .rows()
+            .map(|(op, row)| (op, row.to_owned_row()))
+            .collect::<Vec<_>>();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].0, Op::Insert);
+        assert_eq!(rows[0].1[0], Some(ScalarImpl::Int64(4)));
+        assert_eq!(rows[1].0, Op::Delete);
+        assert_eq!(rows[1].1[0], Some(ScalarImpl::Int64(5)));
+        assert!(CdcBackfillExecutor::<MemoryStateStore>::map_startup_chunk(
+            fresh_chunk,
+            false,
+            &[0, 1],
+        )
+        .is_none());
+    }
+
+    #[tokio::test]
+    async fn test_recovery_yields_all_updates_before_backfill_barrier() {
+        let (mut tx, executor, memory_state_store) = create_recovering_cdc_backfill().await;
+        let executor = executor.execute_inner();
+        pin_mut!(executor);
+
+        tx.send_barrier(Barrier::new_test_barrier(test_epoch(3)));
+        assert!(matches!(
+            executor.next().await.unwrap().unwrap(),
+            Message::Barrier(_)
+        ));
+
+        tx.push_chunk(create_raw_cdc_chunk(&[
+            (
+                r#"{ "payload": { "before": { "id": 1, "price": 11.01 }, "after": { "id": 1, "price": 12.01 }, "source": { "version": "1.9.7.Final", "connector": "mysql", "name": "RW_CDC_1002" }, "op": "u", "ts_ms": 1695277757017, "transaction": null } }"#,
+                r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":3},"isHeartbeat":false}"#,
+            ),
+            (
+                r#"{ "payload": { "before": { "id": 6, "price": 66.06 }, "after": { "id": 6, "price": 67.06 }, "source": { "version": "1.9.7.Final", "connector": "mysql", "name": "RW_CDC_1002" }, "op": "u", "ts_ms": 1695277757017, "transaction": null } }"#,
+                r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":4},"isHeartbeat":false}"#,
+            ),
+        ]));
+        tx.send_barrier(Barrier::new_test_barrier(test_epoch(4)));
+
+        let Message::Chunk(chunk) = executor.next().await.unwrap().unwrap() else {
+            panic!("expected the recovered update before the barrier");
+        };
+        let rows = chunk
+            .rows()
+            .map(|(op, row)| (op, row.to_owned_row()))
+            .collect::<Vec<_>>();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].0, Op::Insert);
+        assert_eq!(rows[0].1[0], Some(ScalarImpl::Int64(1)));
+        assert_eq!(rows[1].0, Op::Insert);
+        assert_eq!(rows[1].1[0], Some(ScalarImpl::Int64(6)));
+        assert!(matches!(
+            executor.next().await.unwrap().unwrap(),
+            Message::Barrier(_)
+        ));
+        assert_recovery_offset(memory_state_store, 2, test_epoch(4)).await;
     }
 
     #[test]

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -381,8 +381,6 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
             // A fresh backfill can ignore CDC events here because its snapshot starts from the
             // beginning. Recovery must preserve events for the already-scanned prefix, using
             // the reader's offset parser and unsigned PK comparison metadata to filter them.
-            let is_recovery = current_pk_pos.is_some();
-            let mut table_reader: Option<ExternalTableReaderImpl> = None;
             let external_table = self.external_table.clone();
             let actor_id = self.actor_ctx.id;
             let fragment_id = self.actor_ctx.fragment_id;
@@ -401,14 +399,14 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                 .await
                 .expect("Retry create cdc table reader until success.")
             });
-            if is_recovery {
+            let table_reader = if current_pk_pos.is_some() {
                 // Leave upstream chunks and barriers pending until we can filter them safely.
                 // Emitting an unscanned key here is unsafe: normal backfill can discard a later
                 // delete before the snapshot reaches that key, leaving a stale row downstream.
-                table_reader = Some(future.as_mut().await);
-            }
-            loop {
-                if let Some(msg) =
+                future.as_mut().await
+            } else {
+                let mut table_reader = None;
+                while let Some(msg) =
                     build_reader_and_poll_upstream(&mut upstream, &mut table_reader, &mut future)
                         .await?
                 {
@@ -418,27 +416,23 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                             yield Message::Barrier(barrier);
                         }
                         Message::Chunk(_) => {
-                            // Only fresh backfills consume upstream before the reader is ready.
+                            // The snapshot starts from the beginning and covers these changes.
                         }
                         Message::Watermark(_) => {
                             // ignore watermark
                         }
                     }
-                } else {
-                    assert!(table_reader.is_some(), "table reader must created");
-                    tracing::info!(
-                        %table_id,
-                        upstream_table_name,
-                        "table reader created successfully"
-                    );
-                    break;
                 }
-            }
-
-            let upstream_table_reader = UpstreamTableReader::new(
-                self.external_table.clone(),
-                table_reader.expect("table reader must created"),
+                table_reader.expect("table reader must be created")
+            };
+            tracing::info!(
+                %table_id,
+                upstream_table_name,
+                "table reader created successfully"
             );
+
+            let upstream_table_reader =
+                UpstreamTableReader::new(self.external_table.clone(), table_reader);
 
             if last_binlog_offset.is_none() {
                 // Limit concurrent CDC connections globally to 10 using a semaphore.

--- a/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc/cdc_backfill.rs
@@ -288,6 +288,36 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
         ))
     }
 
+    fn filter_recovery_chunk(
+        offset_parse_func: &risingwave_connector::source::cdc::external::CdcOffsetParseFunc,
+        chunk: StreamChunk,
+        current_pos: &OwnedRow,
+        pk_compare: PkCompareInfo<'_>,
+        last_binlog_offset: &Option<CdcOffset>,
+        output_indices: &[usize],
+    ) -> StreamExecutorResult<(Option<StreamChunk>, Option<CdcOffset>)> {
+        let chunk_offset = get_cdc_chunk_last_offset(offset_parse_func, &chunk)?;
+        let chunk = mapping_chunk(
+            mark_cdc_chunk(
+                offset_parse_func,
+                chunk,
+                current_pos,
+                pk_compare.indices,
+                pk_compare.order,
+                pk_compare.needs_unsigned_i64_compare,
+                last_binlog_offset.clone(),
+            )?,
+            output_indices,
+        );
+        let chunk = (chunk.cardinality() > 0).then_some(chunk);
+        let consumed_offset = chunk_offset.filter(|chunk_offset| {
+            last_binlog_offset
+                .as_ref()
+                .is_none_or(|last| *last < *chunk_offset)
+        });
+        Ok((chunk, consumed_offset))
+    }
+
     #[try_stream(ok = Message, error = StreamExecutorError)]
     async fn execute_inner(mut self) {
         // The indices to primary key columns
@@ -385,8 +415,11 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
             // we now try to create the table reader with retry.
             //
             // A fresh backfill can ignore CDC events here because its snapshot starts from the
-            // beginning. Recovery must preserve events for the already-scanned prefix, using
-            // the reader's offset parser and unsigned PK comparison metadata to filter them.
+            // beginning. Recovery preserves events for the already-scanned prefix while reader
+            // creation is retried. Both offset parsing and PK comparison metadata are available
+            // without a live reader.
+            let offset_parse_func = self.external_table.table_type().get_cdc_offset_parser()?;
+            let mut table_reader = None;
             let external_table = self.external_table.clone();
             let actor_id = self.actor_ctx.id;
             let fragment_id = self.actor_ctx.fragment_id;
@@ -405,32 +438,46 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                 .await
                 .expect("Retry create cdc table reader until success.")
             });
-            let table_reader = if current_pk_pos.is_some() {
-                // Leave upstream chunks and barriers pending until we can filter them safely.
-                // Emitting an unscanned key here is unsafe: normal backfill can discard a later
-                // delete before the snapshot reaches that key, leaving a stale row downstream.
-                future.as_mut().await
-            } else {
-                let mut table_reader = None;
-                while let Some(msg) =
-                    build_reader_and_poll_upstream(&mut upstream, &mut table_reader, &mut future)
-                        .await?
-                {
-                    match msg {
-                        Message::Barrier(barrier) => {
-                            state_impl.commit_state(barrier.epoch).await?;
-                            yield Message::Barrier(barrier);
-                        }
-                        Message::Chunk(_) => {
+            while let Some(msg) =
+                build_reader_and_poll_upstream(&mut upstream, &mut table_reader, &mut future)
+                    .await?
+            {
+                match msg {
+                    Message::Barrier(barrier) => {
+                        state_impl.commit_state(barrier.epoch).await?;
+                        yield Message::Barrier(barrier);
+                    }
+                    Message::Chunk(chunk) => {
+                        if let Some(current_pos) = current_pk_pos.as_ref() {
+                            let (chunk, consumed_offset) = Self::filter_recovery_chunk(
+                                &offset_parse_func,
+                                chunk,
+                                current_pos,
+                                PkCompareInfo {
+                                    indices: &pk_indices,
+                                    order: &pk_order,
+                                    needs_unsigned_i64_compare: &pk_needs_unsigned_i64_compare,
+                                },
+                                &last_binlog_offset,
+                                &self.output_indices,
+                            )?;
+                            if let Some(chunk) = chunk {
+                                Self::report_metrics(&self.metrics, 0, chunk.cardinality() as u64);
+                                yield Message::Chunk(chunk);
+                            }
+                            if let Some(consumed_offset) = consumed_offset {
+                                last_binlog_offset = Some(consumed_offset);
+                            }
+                        } else {
                             // The snapshot starts from the beginning and covers these changes.
                         }
-                        Message::Watermark(_) => {
-                            // ignore watermark
-                        }
+                    }
+                    Message::Watermark(_) => {
+                        // ignore watermark
                     }
                 }
-                table_reader.expect("table reader must be created")
-            };
+            }
+            let table_reader = table_reader.expect("table reader must be created");
             tracing::info!(
                 %table_id,
                 upstream_table_name,
@@ -449,7 +496,6 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                 last_binlog_offset = upstream_table_reader.current_cdc_offset().await?;
             }
 
-            let offset_parse_func = upstream_table_reader.reader.get_cdc_offset_parser();
             let mut consumed_binlog_offset: Option<CdcOffset> = None;
 
             tracing::info!(
@@ -503,26 +549,28 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                         break;
                     }
                     Message::Chunk(chunk) => {
-                        let chunk_offset = get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?;
                         if let Some(current_pos) = current_pk_pos.as_ref() {
-                            let chunk = mapping_chunk(
-                                mark_cdc_chunk(
-                                    &offset_parse_func,
-                                    chunk,
-                                    current_pos,
-                                    &pk_indices,
-                                    &pk_order,
-                                    &pk_needs_unsigned_i64_compare,
-                                    last_binlog_offset.clone(),
-                                )?,
+                            let (chunk, consumed_offset) = Self::filter_recovery_chunk(
+                                &offset_parse_func,
+                                chunk,
+                                current_pos,
+                                PkCompareInfo {
+                                    indices: &pk_indices,
+                                    order: &pk_order,
+                                    needs_unsigned_i64_compare: &pk_needs_unsigned_i64_compare,
+                                },
+                                &last_binlog_offset,
                                 &self.output_indices,
-                            );
-                            Self::report_metrics(&self.metrics, 0, chunk.cardinality() as u64);
-                            if chunk.cardinality() > 0 {
+                            )?;
+                            if let Some(chunk) = chunk {
+                                Self::report_metrics(&self.metrics, 0, chunk.cardinality() as u64);
                                 yield Message::Chunk(chunk);
                             }
-                        }
-                        if let Some(chunk_offset) = chunk_offset
+                            if let Some(consumed_offset) = consumed_offset {
+                                last_binlog_offset = Some(consumed_offset);
+                            }
+                        } else if let Some(chunk_offset) =
+                            get_cdc_chunk_last_offset(&offset_parse_func, &chunk)?
                             && last_binlog_offset
                                 .as_ref()
                                 .is_none_or(|last| *last < chunk_offset)
@@ -1124,7 +1172,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::str::FromStr;
 
-    use futures::{StreamExt, pin_mut};
+    use futures::{StreamExt, pin_mut, stream};
     use risingwave_common::array::{Array, DataChunk, Op, StreamChunk};
     use risingwave_common::catalog::{
         CdcKeyComparison, ColumnDesc, ColumnId, Field, Schema, TableId,
@@ -1138,11 +1186,12 @@ mod tests {
     use risingwave_connector::source::cdc::external::mock_external_table::MockExternalTableReader;
     use risingwave_connector::source::cdc::external::mysql::MySqlOffset;
     use risingwave_connector::source::cdc::external::{
-        CdcOffset, ExternalCdcTableType, ExternalTableConfig, SchemaTableName,
+        CdcOffset, ExternalCdcTableType, ExternalTableConfig, ExternalTableReaderImpl,
+        SchemaTableName,
     };
     use risingwave_storage::memory::MemoryStateStore;
 
-    use super::PkCompareInfo;
+    use super::{PkCompareInfo, build_reader_and_poll_upstream};
     use crate::common::table::test_utils::gen_pbtable;
     use crate::executor::backfill::cdc::cdc_backfill::transform_upstream;
     use crate::executor::backfill::cdc::state::CdcBackfillState;
@@ -1583,31 +1632,83 @@ mod tests {
         );
     }
 
-    #[tokio::test(start_paused = true)]
-    async fn test_recovery_waits_for_reader_before_consuming_upstream() {
-        let (mut tx, mut executor, _) = create_recovering_cdc_backfill().await;
-        // Reader creation will keep retrying, while recovery has a saved PK position.
-        executor.external_table = ExternalStorageTable::for_test_undefined();
-        let executor = executor.execute_inner();
-        pin_mut!(executor);
-
-        tx.send_barrier(Barrier::new_test_barrier(test_epoch(3)));
-        assert!(matches!(
-            executor.next().await.unwrap().unwrap(),
-            Message::Barrier(_)
-        ));
-        tx.push_chunk(create_raw_cdc_chunk(&[(
-            r#"{ "payload": { "before": null, "after": { "id": 4, "price": 44.04 }, "op": "c" } }"#,
-            r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":3},"isHeartbeat":false}"#,
-        )]));
-        tx.send_barrier(Barrier::new_test_barrier(test_epoch(4)));
-
-        // Neither the chunk nor its checkpoint may pass before filtering metadata is ready.
-        assert!(
-            tokio::time::timeout(std::time::Duration::from_secs(1), executor.next())
-                .await
-                .is_err()
+    #[tokio::test]
+    async fn test_recovery_filters_upstream_while_reader_is_pending() {
+        let chunk = StreamChunk::from_rows(
+            &[
+                (
+                    Op::Insert,
+                    OwnedRow::new(vec![
+                        Some(ScalarImpl::Int64(4)),
+                        Some(ScalarImpl::Float64(44.04.into())),
+                        Some(ScalarImpl::Utf8(
+                            r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":3},"isHeartbeat":false}"#
+                                .into(),
+                        )),
+                    ]),
+                ),
+                (
+                    Op::Insert,
+                    OwnedRow::new(vec![
+                        Some(ScalarImpl::Int64(6)),
+                        Some(ScalarImpl::Float64(66.06.into())),
+                        Some(ScalarImpl::Utf8(
+                            r#"{"sourcePartition":{},"sourceOffset":{"file":"1.binlog","pos":4},"isHeartbeat":false}"#
+                                .into(),
+                        )),
+                    ]),
+                ),
+            ],
+            &[DataType::Int64, DataType::Float64, DataType::Varchar],
         );
+        let mut upstream = stream::iter([
+            Ok(Message::Chunk(chunk)),
+            Ok(Message::Barrier(Barrier::new_test_barrier(test_epoch(4)))),
+        ]);
+        let mut table_reader = None;
+        let mut reader_future = Box::pin(std::future::pending::<ExternalTableReaderImpl>());
+
+        let Message::Chunk(chunk) =
+            build_reader_and_poll_upstream(&mut upstream, &mut table_reader, &mut reader_future)
+                .await
+                .unwrap()
+                .unwrap()
+        else {
+            panic!("expected an upstream chunk while the reader is pending");
+        };
+        assert!(table_reader.is_none());
+
+        let parser = ExternalCdcTableType::Mock.get_cdc_offset_parser().unwrap();
+        let (chunk, consumed_offset) =
+            CdcBackfillExecutor::<MemoryStateStore>::filter_recovery_chunk(
+                &parser,
+                chunk,
+                &OwnedRow::new(vec![Some(ScalarImpl::Int64(5))]),
+                PkCompareInfo {
+                    indices: &[0],
+                    order: &[OrderType::ascending()],
+                    needs_unsigned_i64_compare: &[false],
+                },
+                &Some(CdcOffset::MySql(MySqlOffset::new("1.binlog".to_owned(), 2))),
+                &[0, 1],
+            )
+            .unwrap();
+        let chunk = chunk.expect("the scanned row should be emitted");
+        assert_eq!(chunk.cardinality(), 1);
+        assert_eq!(
+            chunk.row_at(0).1.to_owned_row()[0],
+            Some(ScalarImpl::Int64(4))
+        );
+        assert_eq!(
+            consumed_offset,
+            Some(CdcOffset::MySql(MySqlOffset::new("1.binlog".to_owned(), 4)))
+        );
+        assert!(matches!(
+            build_reader_and_poll_upstream(&mut upstream, &mut table_reader, &mut reader_future)
+                .await
+                .unwrap(),
+            Some(Message::Barrier(_))
+        ));
     }
 
     #[tokio::test]

--- a/src/stream/src/executor/backfill/cdc/upstream_table/external.rs
+++ b/src/stream/src/executor/backfill/cdc/upstream_table/external.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::catalog::{Schema, TableId};
+use risingwave_common::catalog::{CdcKeyComparison, Schema, TableId};
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_connector::error::ConnectorResult;
 use risingwave_connector::source::cdc::external::{
@@ -44,6 +44,8 @@ pub struct ExternalStorageTable {
 
     pk_order_types: Vec<OrderType>,
 
+    pk_comparisons: Vec<CdcKeyComparison>,
+
     /// Indices of primary key.
     /// Note that the index is based on the all columns of the table.
     pk_indices: Vec<usize>,
@@ -62,8 +64,11 @@ impl ExternalStorageTable {
         table_type: ExternalCdcTableType,
         schema: Schema,
         pk_order_types: Vec<OrderType>,
+        pk_comparisons: Vec<CdcKeyComparison>,
         pk_indices: Vec<usize>,
     ) -> Self {
+        assert_eq!(pk_order_types.len(), pk_comparisons.len());
+        assert_eq!(pk_order_types.len(), pk_indices.len());
         Self {
             table_id,
             table_name,
@@ -73,6 +78,7 @@ impl ExternalStorageTable {
             table_type,
             schema,
             pk_order_types,
+            pk_comparisons,
             pk_indices,
         }
     }
@@ -88,6 +94,7 @@ impl ExternalStorageTable {
             table_type: ExternalCdcTableType::Undefined,
             schema: Schema::empty().to_owned(),
             pk_order_types: vec![],
+            pk_comparisons: vec![],
             pk_indices: vec![],
         }
     }
@@ -98,6 +105,10 @@ impl ExternalStorageTable {
 
     pub fn pk_order_types(&self) -> &[OrderType] {
         &self.pk_order_types
+    }
+
+    pub fn pk_comparisons(&self) -> &[CdcKeyComparison] {
+        &self.pk_comparisons
     }
 
     pub fn schema(&self) -> &Schema {

--- a/src/stream/src/from_proto/stream_cdc_scan.rs
+++ b/src/stream/src/from_proto/stream_cdc_scan.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use anyhow::Context;
-use risingwave_common::catalog::Schema;
+use risingwave_common::catalog::{CdcKeyComparison, Schema};
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_connector::source::cdc::CdcScanOptions;
 use risingwave_connector::source::cdc::external::{
@@ -56,16 +56,38 @@ impl ExecutorBuilder for StreamCdcScanExecutorBuilder {
         assert_eq!(output_schema.data_types(), params.info.schema.data_types());
 
         let properties = table_desc.connect_properties.clone();
-        let table_pk_order_types = table_desc
-            .pk
-            .iter()
-            .map(|desc| OrderType::from_protobuf(desc.get_order_type().unwrap()))
-            .collect_vec();
-        let table_pk_indices = table_desc
-            .pk
-            .iter()
-            .map(|k| k.column_index as usize)
-            .collect_vec();
+        let (table_pk_order_types, table_pk_comparisons, table_pk_indices) =
+            if let Some(table_pk) = &table_desc.pk {
+                let order_types = table_pk
+                    .columns
+                    .iter()
+                    .map(|_| OrderType::ascending())
+                    .collect_vec();
+                let comparisons = table_pk
+                    .columns
+                    .iter()
+                    .map(|column| column.get_comparison().map(CdcKeyComparison::from_protobuf))
+                    .try_collect()?;
+                let indices = table_pk
+                    .columns
+                    .iter()
+                    .map(|column| column.pk_col_idx as usize)
+                    .collect_vec();
+                (order_types, comparisons, indices)
+            } else {
+                #[allow(deprecated)]
+                let legacy_pk = &table_desc.legacy_pk;
+                let order_types = legacy_pk
+                    .iter()
+                    .map(|column| OrderType::from_protobuf(column.get_order_type().unwrap()))
+                    .collect_vec();
+                let comparisons = vec![CdcKeyComparison::Native; legacy_pk.len()];
+                let indices = legacy_pk
+                    .iter()
+                    .map(|column| column.column_index as usize)
+                    .collect_vec();
+                (order_types, comparisons, indices)
+            };
 
         let scan_options = node
             .options
@@ -105,6 +127,7 @@ impl ExecutorBuilder for StreamCdcScanExecutorBuilder {
             table_type,
             table_schema,
             table_pk_order_types,
+            table_pk_comparisons,
             table_pk_indices,
         );
 

--- a/src/stream/src/from_proto/stream_cdc_scan.rs
+++ b/src/stream/src/from_proto/stream_cdc_scan.rs
@@ -57,7 +57,7 @@ impl ExecutorBuilder for StreamCdcScanExecutorBuilder {
 
         let properties = table_desc.connect_properties.clone();
         let (table_pk_order_types, table_pk_comparisons, table_pk_indices) =
-            if let Some(table_pk) = &table_desc.pk {
+            if let Some(table_pk) = &table_desc.pk_ordering {
                 let order_types = table_pk
                     .columns
                     .iter()
@@ -75,14 +75,14 @@ impl ExecutorBuilder for StreamCdcScanExecutorBuilder {
                     .collect_vec();
                 (order_types, comparisons, indices)
             } else {
-                #[allow(deprecated)]
-                let legacy_pk = &table_desc.legacy_pk;
-                let order_types = legacy_pk
+                let order_types = table_desc
+                    .pk
                     .iter()
                     .map(|column| OrderType::from_protobuf(column.get_order_type().unwrap()))
                     .collect_vec();
-                let comparisons = vec![CdcKeyComparison::Native; legacy_pk.len()];
-                let indices = legacy_pk
+                let comparisons = vec![CdcKeyComparison::Native; table_desc.pk.len()];
+                let indices = table_desc
+                    .pk
                     .iter()
                     .map(|column| column.column_index as usize)
                     .collect_vec();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Closes #27026.

Preserve CDC changes for the already-scanned prefix when recovering an unfinished `CdcBackfillExecutor`, including while external table reader creation is being retried.

Previously, startup discarded CDC chunks while creating the reader and waiting for the backfill-start barrier. On recovery, the snapshot resumes strictly after `current_pk_pos`, so discarded updates and deletes for already-scanned keys cannot be reconstructed. A subsequent source checkpoint can make that loss permanent.

### Recovery startup

- Obtain the connector-specific offset parser from the external table type and PK comparison semantics from the persisted table descriptor when available.
- While reader creation retries, new plans and legacy PostgreSQL or SQL Server plans continue polling upstream. For recovered backfills, use `mark_cdc_chunk` to emit only changes with `pk <= current_pk_pos` and offsets at or above the current lower bound, then project to the output schema. Apply the same filter while waiting for the backfill-start barrier.
- Fresh legacy MySQL backfills can continue polling because their snapshot starts from the beginning. After the reader connects, recover PK comparison metadata before snapshot filtering begins.
- Recovered legacy MySQL backfills wait for reader creation without polling upstream because their comparison metadata is unknown. After recovering signed and unsigned PK comparisons from the reader, process queued chunks with unsigned-aware filtering before forwarding their barrier. Log this compatibility wait once so operators can identify paused checkpoint progress.
- Emit qualifying changes before committing and forwarding the following barrier. Filter each chunk before advancing the in-memory offset lower bound; older replayed events and empty chunks cannot lower or clear it.

Filtering out unscanned keys prevents stale rows: if recovery at PK 5 emitted an insert for PK 100, a later delete could be filtered out before the snapshot reaches that key, leaving the premature insert downstream after backfill completes.

### Persisted key comparison semantics

Add `CdcKeyOrdering` to `ExternalTableDesc`, pairing each PK column index with native or unsigned-64-bit comparison semantics. Discover MySQL `BIGINT UNSIGNED` metadata during table creation and replacement planning, including explicit-schema tables, and carry it through to the executor. PostgreSQL and SQL Server use native comparison semantics.

Continue writing the original `pk` field at protobuf tag 3 for older workers and add `pk_ordering` at tag 9. New readers prefer `pk_ordering` and fall back to `pk` when it is absent. Legacy PostgreSQL and SQL Server graphs use native comparison semantics. Legacy MySQL graphs recover comparison metadata dynamically from the live reader instead of defaulting to signed ordering. Successful replacement planning persists the current upstream comparison metadata.

### Regression coverage

- Filter scanned and unscanned keys and poll the following barrier while the reader future remains pending.
- Preserve scanned-key updates, inserts, and deletes before the backfill-start barrier, while rejecting older offsets and retaining events at the offset boundary.
- Run the unscanned PK 100 insert/delete sequence through snapshot refresh and backfill completion; verify no stale row remains and the finished state is persisted.
- Verify legacy MySQL descriptors decode to unknown comparison metadata while legacy PostgreSQL, SQL Server, and mock descriptors use native comparisons.
- Verify new descriptors preserve `UnsignedInt64` and PK column order.
- Verify recovered legacy MySQL startup waits for the reader while fresh legacy MySQL and recovered plans with known comparisons continue polling.
- Verify live MySQL reader metadata resolves mixed signed and unsigned composite keys with case-insensitive names in the requested PK order.

## Checklist

- [ ] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the Release Timeline and Currently Supported Versions to determine which release branches I need to cherry-pick this PR into.

Verification:

- `cargo test -p risingwave_connector source::cdc::external::mysql::tests::`
- `cargo test -p risingwave_stream --lib from_proto::stream_cdc_scan::tests`
- `cargo test -p risingwave_stream --lib executor::backfill::cdc::cdc_backfill::tests`
- `cargo check -p risingwave_stream -p risingwave_connector`
- `cargo fmt --all -- --check`
- `git diff --check`
- CI coverage requested via labels: CDC source e2e, single-node e2e, deterministic recovery, and backwards compatibility.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Fix CDC backfill recovery losing changes to already-scanned rows during startup. Legacy MySQL backfills recover primary-key comparison semantics from the live reader before filtering queued recovery events.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CDC tables now preserve primary-key comparison semantics, including unsigned 64-bit key handling for MySQL sources.
  * CDC backfills support consistent primary-key ordering across recovery and parallel snapshot processing.

* **Bug Fixes**
  * Recovery backfills now preserve and deliver CDC changes received while the table reader is being created.
  * CDC changes are correctly filtered and ordered during recovery, preventing missed changes and stale rows.
  * Recovery now avoids materializing records that were deleted before they could be scanned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
