### PR TITLE
fix(iceberg): merge COW overwrite manifests on release-3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6851,7 +6851,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=515177b5317886f01cbbe54f235519430e72e219#515177b5317886f01cbbe54f235519430e72e219"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0#fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0"
 dependencies = [
  "anyhow",
  "apache-avro 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6910,7 +6910,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-glue"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=515177b5317886f01cbbe54f235519430e72e219#515177b5317886f01cbbe54f235519430e72e219"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0#fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6925,7 +6925,7 @@ dependencies = [
 [[package]]
 name = "iceberg-catalog-rest"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=515177b5317886f01cbbe54f235519430e72e219#515177b5317886f01cbbe54f235519430e72e219"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0#fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6947,7 +6947,7 @@ dependencies = [
 [[package]]
 name = "iceberg-compaction-core"
 version = "0.1.0"
-source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=96e73081d485e08e2869e92e938bc90f11cefae8#96e73081d485e08e2869e92e938bc90f11cefae8"
+source = "git+https://github.com/nimtable/iceberg-compaction.git?rev=8649135046d0b0f9360db90569a2c7ed22a3d855#8649135046d0b0f9360db90569a2c7ed22a3d855"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6976,7 +6976,7 @@ dependencies = [
 [[package]]
 name = "iceberg-datafusion"
 version = "0.8.0"
-source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=515177b5317886f01cbbe54f235519430e72e219#515177b5317886f01cbbe54f235519430e72e219"
+source = "git+https://github.com/risingwavelabs/iceberg-rust.git?rev=fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0#fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,14 +176,14 @@ hashbrown0_16 = { package = "hashbrown", version = "0.16.1", features = [
 ] }
 hytra = "0.1"
 # branch dev_rebase_main_20260303
-iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "515177b5317886f01cbbe54f235519430e72e219", features = [
+iceberg = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0", features = [
     "storage-s3",
     "storage-gcs",
     "storage-azblob",
     "storage-azdls",
 ] }
-iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "515177b5317886f01cbbe54f235519430e72e219" }
-iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "515177b5317886f01cbbe54f235519430e72e219" }
+iceberg-catalog-glue = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0" }
+iceberg-catalog-rest = { git = "https://github.com/risingwavelabs/iceberg-rust.git", rev = "fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0" }
 indexmap = { version = "2.12.0", features = ["serde"] }
 itertools = "0.14.0"
 jni = { version = "0.21.1", features = ["invocation"] }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -34,7 +34,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { workspace = true }
 hex = "0.4"
 iceberg = { workspace = true }
-iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "96e73081d485e08e2869e92e938bc90f11cefae8" }
+iceberg-compaction-core = { git = "https://github.com/nimtable/iceberg-compaction.git", rev = "8649135046d0b0f9360db90569a2c7ed22a3d855" }
 itertools = { workspace = true }
 libc = "0.2"
 lz4 = "1.28.0"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

COW publication to Iceberg `main` retains obsolete deletion-only manifests, allowing metadata to grow while the live file set stays small. Bring the overwrite manifest fix from #26990 to `release-3.1`: prune obsolete manifests, enable manifest merging within overwrite commits, and preserve the partition spec of each merge bin.

`release-3.1` uses the same Iceberg baseline (`515177b5`), so this reuses [iceberg-rust#233](https://github.com/risingwavelabs/iceberg-rust/pull/233) at `fc973389f93cb4a0c6be8962ca3ebc7bc9bae8a0`. The implementation remains 15 additions / 6 deletions with no new tests or V3-specific handling. Existing snapshot-property overrides and merge thresholds remain supported.

The release's compaction baseline differs from release-3.0. [This pin-only alignment](https://github.com/nimtable/iceberg-compaction/compare/96e73081d485e08e2869e92e938bc90f11cefae8...8649135046d0b0f9360db90569a2c7ed22a3d855) is based on the existing `96e73081` revision and uses the same Iceberg commit. RW pins it at `8649135046d0b0f9360db90569a2c7ed22a3d855`. Normalizing these two revisions restores all three changed dependency files exactly to the release baseline.

## Validation

- `RUSTUP_TOOLCHAIN=nightly-2025-10-10 make check` passed in the aligned compaction checkout (workspace/all-target Clippy with warnings denied, formatting, TOML).
- `cargo +nightly-2025-10-10 test -p iceberg-compaction-core --lib --locked`: **133 passed**.
- `CXXFLAGS='-include cerrno' cargo +nightly-2026-06-11 check -p risingwave_storage --lib --locked` passed on the release-3.1 pinned toolchain. The local C++ flag supplies a missing FAISS header; no source workaround is included.
- RW formatting, `cargo metadata --locked`, and normalized lockfile verification passed. The resolved graph contains one shared Iceberg revision.
- The reused Iceberg commit is unchanged from #26990, where all **74 existing transaction tests**, Clippy, and formatting passed. Its existing test modules remain unchanged.
- Iceberg end-to-end tests are requested through `ci/run-e2e-iceberg-tests`; CI results are pending.

## Checklist

- [x] I have written necessary rustdoc comments. (Dependency-only port; comments are in the linked implementation.)
- [ ] I have added necessary unit tests and integration tests. (No new test code; existing tests were used.)
- [x] I have added test labels as necessary. (`ci/run-e2e-iceberg-tests` alongside default PR coverage.)
- [ ] My PR contains breaking changes.
- [x] I have checked which release branches need this change. (This PR targets the requested `release-3.1`; #26990 covers `release-3.0`.)

## Documentation

No product documentation changes: this is internal manifest maintenance with no new supported interface or operator workflow.

## Attribution

Collaborated with Jarvis (OpenAI Codex).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated underlying storage and compaction components to newer revisions.
  - Existing storage features and public interfaces remain unchanged.
  - No user-facing behavior changes are expected from this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->