### PR TITLE
fix(stream): invalidate materialize cache for rows deleted by refresh merge

### DIFF
--- a/ci/scripts/e2e-source-test.sh
+++ b/ci/scripts/e2e-source-test.sh
@@ -42,6 +42,7 @@ risedev slt './e2e_test/source_inline/fs/parquet_nested_declared_schema.slt'
 risedev slt './e2e_test/source_inline/fs/parquet_duplicate_field_names.slt'
 risedev slt './e2e_test/source_inline/fs/parquet_nested_smallint.slt'
 risedev slt './e2e_test/source_inline/refresh/refresh_table.slt'
+risedev slt './e2e_test/source_inline/refresh/refresh_table_delete_readd.slt'
 risedev slt './e2e_test/source_inline/vault/vault_secret_ddl.slt'
 
 echo "--- Run webhook source tests"

--- a/e2e_test/source_inline/refresh/refresh_table_delete_readd.slt
+++ b/e2e_test/source_inline/refresh/refresh_table_delete_readd.slt
@@ -1,0 +1,142 @@
+# Rows deleted by the refresh merge phase must be dropped from the materialize cache,
+# otherwise a row that comes back in a later refresh is handled as an update and lost.
+
+control substitution on
+
+system ok
+rm -rf ./e2e_test/source_inline/refresh/refresh_delete_readd_tmp && mkdir -p ./e2e_test/source_inline/refresh/refresh_delete_readd_tmp
+
+system ok
+echo "1,100,alpha" > ./e2e_test/source_inline/refresh/refresh_delete_readd_tmp/a.csv
+
+system ok
+printf "2,200,beta\n3,200,gamma\n" > ./e2e_test/source_inline/refresh/refresh_delete_readd_tmp/b.csv
+
+system ok
+echo "4,300,delta" > ./e2e_test/source_inline/refresh/refresh_delete_readd_tmp/c.csv
+
+statement ok
+CREATE TABLE refresh_delete_readd_t (rule_id int, company_id int, rule_name varchar, PRIMARY KEY (rule_id, company_id)) WITH (
+    connector = '__for_testing_only_batch_posix_fs',
+    batch_posix_fs.root = './e2e_test/source_inline/refresh/refresh_delete_readd_tmp',
+    refresh_mode = 'FULL_RELOAD',
+    match_pattern = '*.csv'
+) FORMAT PLAIN ENCODE CSV (without_header = 'true', delimiter = ',');
+
+statement ok retry 3 backoff 5s
+REFRESH TABLE refresh_delete_readd_t;
+
+query IIT retry 3 backoff 5s
+SELECT * FROM refresh_delete_readd_t ORDER BY rule_id;
+----
+1 100 alpha
+2 200 beta
+3 200 gamma
+4 300 delta
+
+
+# A downstream MV turns on the conflict check, which goes through the materialize cache.
+statement ok
+CREATE MATERIALIZED VIEW refresh_delete_readd_mv AS SELECT DISTINCT company_id FROM refresh_delete_readd_t;
+
+# A refresh without upstream changes routes every row through the cache.
+statement ok retry 3 backoff 5s
+REFRESH TABLE refresh_delete_readd_t;
+
+query T retry 12 backoff 5s
+SELECT s.current_status
+FROM rw_catalog.rw_refresh_table_state s
+JOIN rw_catalog.rw_tables t ON s.table_id = t.id
+WHERE t.name = 'refresh_delete_readd_t';
+----
+IDLE
+
+
+system ok
+rm ./e2e_test/source_inline/refresh/refresh_delete_readd_tmp/a.csv
+
+statement ok retry 3 backoff 5s
+REFRESH TABLE refresh_delete_readd_t;
+
+query II retry 3 backoff 5s
+SELECT rule_id, company_id FROM refresh_delete_readd_t ORDER BY rule_id;
+----
+2 200
+3 200
+4 300
+
+
+query I retry 3 backoff 5s
+SELECT company_id FROM refresh_delete_readd_mv ORDER BY company_id;
+----
+200
+300
+
+
+# Add rule 1 back with the identical content.
+system ok
+echo "1,100,alpha" > ./e2e_test/source_inline/refresh/refresh_delete_readd_tmp/a.csv
+
+statement ok retry 3 backoff 5s
+REFRESH TABLE refresh_delete_readd_t;
+
+query IIT retry 3 backoff 5s
+SELECT * FROM refresh_delete_readd_t ORDER BY rule_id;
+----
+1 100 alpha
+2 200 beta
+3 200 gamma
+4 300 delta
+
+
+query I retry 3 backoff 5s
+SELECT company_id FROM refresh_delete_readd_mv ORDER BY company_id;
+----
+100
+200
+300
+
+
+system ok
+rm ./e2e_test/source_inline/refresh/refresh_delete_readd_tmp/a.csv
+
+statement ok retry 3 backoff 5s
+REFRESH TABLE refresh_delete_readd_t;
+
+query II retry 3 backoff 5s
+SELECT rule_id, company_id FROM refresh_delete_readd_t ORDER BY rule_id;
+----
+2 200
+3 200
+4 300
+
+
+# Add rule 1 back with a different value.
+system ok
+echo "1,100,alpha_v2" > ./e2e_test/source_inline/refresh/refresh_delete_readd_tmp/a.csv
+
+statement ok retry 3 backoff 5s
+REFRESH TABLE refresh_delete_readd_t;
+
+query IIT retry 3 backoff 5s
+SELECT * FROM refresh_delete_readd_t ORDER BY rule_id;
+----
+1 100 alpha_v2
+2 200 beta
+3 200 gamma
+4 300 delta
+
+
+query I retry 3 backoff 5s
+SELECT company_id FROM refresh_delete_readd_mv ORDER BY company_id;
+----
+100
+200
+300
+
+
+statement ok
+DROP TABLE refresh_delete_readd_t CASCADE;
+
+system ok
+rm -rf ./e2e_test/source_inline/refresh/refresh_delete_readd_tmp

--- a/src/stream/src/executor/mview/cache.rs
+++ b/src/stream/src/executor/mview/cache.rs
@@ -20,7 +20,7 @@ use futures::{StreamExt as _, stream};
 use itertools::Itertools as _;
 use risingwave_common::array::{Op, StreamChunk};
 use risingwave_common::catalog::{ConflictBehavior, checked_conflict_behaviors};
-use risingwave_common::row::{CompactedRow, OwnedRow, Row as _};
+use risingwave_common::row::{CompactedRow, OwnedRow, Row, RowExt as _};
 use risingwave_common::types::ScalarImpl;
 use risingwave_common::util::iter_util::ZipEqFast as _;
 use risingwave_common::util::sort_util::{OrderType, cmp_datum};
@@ -387,6 +387,21 @@ impl MaterializeCache {
         }
 
         Ok(())
+    }
+
+    /// Drop the entries of rows deleted from `table` without going through [`Self::handle_new`].
+    /// Entries are removed instead of set to `None` so mass deletes leave no tombstones behind.
+    pub fn invalidate_rows<S: StateStore, SD: ValueRowSerde>(
+        &mut self,
+        rows: impl IntoIterator<Item = impl Row>,
+        table: &StateTableInner<S, SD>,
+    ) {
+        for row in rows {
+            let key = row
+                .project(table.pk_indices())
+                .memcmp_serialize(table.pk_serde());
+            self.lru_cache.remove(&key);
+        }
     }
 
     /// Evict the LRU cache entries that are lower than the watermark.

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -698,6 +698,9 @@ impl<S: StateStore, SD: ValueRowSerde> MaterializeExecutor<S, SD> {
                     for row in &rows_to_delete {
                         self.state_table.delete(row);
                     }
+                    if let Some(cache) = &mut self.materialize_cache {
+                        cache.invalidate_rows(&rows_to_delete, &self.state_table);
+                    }
                     if !rows_to_delete.is_empty() {
                         let to_delete_chunk = StreamChunk::from_rows(
                             &rows_to_delete


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).



## What's changed and what's your intention?

The merge phase of a `FULL_RELOAD` refresh deletes rows directly from the state table and never touches `MaterializeCache`. When the same key shows up in a later refresh, the stale cache entry makes the executor handle the insert as an update of a row that no longer exists:

- identical row: filtered as a no-op update, so the row is silently missing from the table until the actor restarts;
- changed row: written as `Update` for an absent key. Debug builds fail the mem-table sanity check; release builds emit `U-`/`U+` instead of `Insert`, so a downstream `DISTINCT` MV never gets its group back.

Fix: drop the deleted keys from the cache in the merge phase, so the next appearance of the key takes the insert path.

Test: an SLT that deletes a row upstream, refreshes, adds the row back (identical and changed) and checks the table and a `DISTINCT` MV. It fails on `main` at the identical re-add step.

- Closes #27038

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.


## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed stale materialized-view results after rows are deleted during table refreshes.
  - Ensured deleted rows are removed from the materialized-view cache during refresh and replacement operations.
  - Added end-to-end coverage for deleting, re-adding, and updating rows while validating both tables and materialized views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->