### PR TITLE
feat(dynamodb): allow altering batch size and retry options

### DIFF
--- a/src/connector/src/allow_alter_on_fly_fields.rs
+++ b/src/connector/src/allow_alter_on_fly_fields.rs
@@ -244,6 +244,15 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
             "doris.stream_load.http.timeout.ms".to_owned(),
         ].into_iter().collect(),
     ).unwrap();
+    // DynamoDbConfig
+    map.try_insert(
+        std::any::type_name::<DynamoDbConfig>().to_owned(),
+        [
+            "dynamodb.max_batch_item_nums".to_owned(),
+            "dynamodb.batch_write_retry_times".to_owned(),
+            "dynamodb.batch_write_retry_backoff_ms".to_owned(),
+        ].into_iter().collect(),
+    ).unwrap();
     // ElasticSearchConfig
     map.try_insert(
         std::any::type_name::<ElasticSearchConfig>().to_owned(),

--- a/src/connector/src/sink/dynamodb.rs
+++ b/src/connector/src/sink/dynamodb.rs
@@ -60,6 +60,7 @@ pub struct DynamoDbConfig {
         default = "default_max_batch_item_nums"
     )]
     #[serde_as(as = "DisplayFromStr")]
+    #[with_option(allow_alter_on_fly)]
     pub max_batch_item_nums: usize,
 
     #[serde(
@@ -74,6 +75,7 @@ pub struct DynamoDbConfig {
         default = "default_batch_write_retry_times"
     )]
     #[serde_as(as = "DisplayFromStr")]
+    #[with_option(allow_alter_on_fly)]
     pub batch_write_retry_times: usize,
 
     #[serde(
@@ -81,6 +83,7 @@ pub struct DynamoDbConfig {
         default = "default_batch_write_retry_backoff_ms"
     )]
     #[serde_as(as = "DisplayFromStr")]
+    #[with_option(allow_alter_on_fly)]
     pub batch_write_retry_backoff_ms: u64,
 
     #[serde(flatten)]

--- a/src/connector/src/sink/dynamodb.rs
+++ b/src/connector/src/sink/dynamodb.rs
@@ -40,6 +40,7 @@ use crate::error::ConnectorResult;
 use crate::sink::log_store::DeliveryFutureManagerAddFuture;
 
 pub const DYNAMO_DB_SINK: &str = "dynamodb";
+const MAX_BATCH_WRITE_ITEM_NUMS: usize = 25;
 
 #[serde_as]
 #[derive(Deserialize, Debug, Clone, WithOptions)]
@@ -127,8 +128,21 @@ impl DynamoDbConfig {
     }
 
     fn from_btreemap(values: BTreeMap<String, String>) -> Result<Self> {
-        serde_json::from_value::<DynamoDbConfig>(serde_json::to_value(values).unwrap())
-            .map_err(|e| SinkError::Config(anyhow!(e)))
+        let config =
+            serde_json::from_value::<DynamoDbConfig>(serde_json::to_value(values).unwrap())
+                .map_err(|e| SinkError::Config(anyhow!(e)))?;
+        config.validate_batch_write_options()?;
+        Ok(config)
+    }
+
+    fn validate_batch_write_options(&self) -> Result<()> {
+        if !(1..=MAX_BATCH_WRITE_ITEM_NUMS).contains(&self.max_batch_item_nums) {
+            return Err(SinkError::Config(anyhow!(
+                "`dynamodb.max_batch_item_nums` must be between 1 and {MAX_BATCH_WRITE_ITEM_NUMS}, got {}",
+                self.max_batch_item_nums
+            )));
+        }
+        Ok(())
     }
 }
 
@@ -657,19 +671,26 @@ mod tests {
     }
 
     #[test]
-    fn dynamodb_alter_config_accepts_parseable_numbers() {
+    fn dynamodb_alter_config_validates_batch_write_options() {
         DynamoDbSink::validate_alter_config(&dynamodb_config_options([
-            ("dynamodb.max_batch_item_nums", "0"),
-            ("dynamodb.batch_write_retry_times", "0"),
-            ("dynamodb.batch_write_retry_backoff_ms", "0"),
+            ("dynamodb.max_batch_item_nums", "25"),
+            ("dynamodb.batch_write_retry_times", "5"),
+            ("dynamodb.batch_write_retry_backoff_ms", "200"),
         ]))
         .unwrap();
 
-        DynamoDbSink::validate_alter_config(&dynamodb_config_options([(
-            "dynamodb.max_batch_item_nums",
-            "26",
-        )]))
-        .unwrap();
+        for max_batch_item_nums in ["0", "26"] {
+            let err = DynamoDbSink::validate_alter_config(&dynamodb_config_options([(
+                "dynamodb.max_batch_item_nums",
+                max_batch_item_nums,
+            )]))
+            .unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("`dynamodb.max_batch_item_nums` must be between 1 and 25"),
+                "unexpected error: {err}"
+            );
+        }
     }
 
     #[test]

--- a/src/connector/src/sink/dynamodb.rs
+++ b/src/connector/src/sink/dynamodb.rs
@@ -191,6 +191,11 @@ impl Sink for DynamoDbSink {
         Ok(())
     }
 
+    fn validate_alter_config(config: &BTreeMap<String, String>) -> Result<()> {
+        DynamoDbConfig::from_btreemap(config.clone())?;
+        Ok(())
+    }
+
     async fn new_log_sinker(&self, _writer_param: SinkWriterParam) -> Result<Self::LogSinker> {
         Ok(
             DynamoDbSinkWriter::new(self.config.clone(), self.schema.clone())
@@ -640,6 +645,50 @@ mod tests {
     use aws_sdk_dynamodb::types::{DeleteRequest, KeyType, PutRequest};
 
     use super::*;
+
+    fn dynamodb_config_options(
+        options: impl IntoIterator<Item = (&'static str, &'static str)>,
+    ) -> BTreeMap<String, String> {
+        [("table", "Movies")]
+            .into_iter()
+            .chain(options)
+            .map(|(key, value)| (key.to_owned(), value.to_owned()))
+            .collect()
+    }
+
+    #[test]
+    fn dynamodb_alter_config_accepts_parseable_numbers() {
+        DynamoDbSink::validate_alter_config(&dynamodb_config_options([
+            ("dynamodb.max_batch_item_nums", "0"),
+            ("dynamodb.batch_write_retry_times", "0"),
+            ("dynamodb.batch_write_retry_backoff_ms", "0"),
+        ]))
+        .unwrap();
+
+        DynamoDbSink::validate_alter_config(&dynamodb_config_options([(
+            "dynamodb.max_batch_item_nums",
+            "26",
+        )]))
+        .unwrap();
+    }
+
+    #[test]
+    fn dynamodb_alter_config_rejects_malformed_numbers() {
+        for option in [
+            "dynamodb.max_batch_item_nums",
+            "dynamodb.batch_write_retry_times",
+            "dynamodb.batch_write_retry_backoff_ms",
+        ] {
+            let err = DynamoDbSink::validate_alter_config(&dynamodb_config_options([(
+                option, "invalid",
+            )]))
+            .unwrap_err();
+            assert!(
+                err.to_string().contains("invalid digit found in string"),
+                "unexpected error for {option}: {err}"
+            );
+        }
+    }
 
     fn dynamodb_put_request(
         items: impl IntoIterator<Item = (&'static str, &'static str)>,

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -309,6 +309,7 @@ DynamoDbConfig:
     field_type: usize
     required: false
     default: '25'
+    allow_alter_on_fly: true
   - name: dynamodb.max_future_send_nums
     field_type: usize
     required: false
@@ -317,10 +318,12 @@ DynamoDbConfig:
     field_type: usize
     required: false
     default: '3'
+    allow_alter_on_fly: true
   - name: dynamodb.batch_write_retry_backoff_ms
     field_type: u64
     required: false
     default: '100'
+    allow_alter_on_fly: true
 ElasticSearchConfig:
   fields:
   - name: url


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Allow existing DynamoDB sinks to update `dynamodb.max_batch_item_nums`, `dynamodb.batch_write_retry_times`, and `dynamodb.batch_write_retry_backoff_ms` through `ALTER SINK ... CONNECTOR WITH (...)`. These options were previously rejected by the runtime alteration allowlist.

Mark the three fields with `allow_alter_on_fly` and regenerate the WITH-options YAML and Rust allowlist.

## Validation

- `./risedev generate-with-options`: all three metadata generation tests passed.
- `rustfmt --check --edition 2024 src/connector/src/sink/dynamodb.rs src/connector/src/allow_alter_on_fly_fields.rs`: passed.
- `git diff --check`: passed.
- Request `ci/run-e2e-sink-tests` for the existing DynamoDB sink validation suite; e2e tests were not run locally.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added test labels as necessary.
- [ ] My PR contains breaking changes.

## Documentation

- [x] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

DynamoDB sinks now support changing the maximum batch item count, batch-write retry count, and retry backoff through `ALTER SINK ... CONNECTOR WITH (...)`.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DynamoDB sink batch-writing settings can now be updated while the sink is running:
    * Maximum items per batch
    * Retry count
    * Retry backoff delay

* **Bug Fixes**
  * Added validation to ensure batch sizes are between 1 and 25.
  * Invalid batch-writing configuration values now return clear errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->