### PR TITLE
fix(storage): bound SST scans and point gets by table ID

### DIFF
--- a/src/storage/benches/bench_compactor.rs
+++ b/src/storage/benches/bench_compactor.rs
@@ -354,6 +354,7 @@ fn bench_merge_iterator_compactor(c: &mut Criterion) {
     let level2 = vec![info1, info2];
     let read_options = Arc::new(SstableIteratorReadOptions {
         cache_policy: CachePolicy::Fill(Hint::Normal),
+        read_table_id: None,
         scan_end_user_key: None,
         prefetch: false,
         max_preload_retry_times: 0,

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -138,11 +138,14 @@ pub async fn get_from_sstable_info(
         return Ok(None);
     }
 
+    let mut iterator_read_options = SstableIteratorReadOptions::from_read_options(read_options);
+    iterator_read_options.read_table_id = Some(full_key.user_key.table_id);
+
     let mut iter = IteratorStatsGuard::new(
         SstableIterator::create(
             sstable,
             sstable_store_ref.clone(),
-            Arc::new(SstableIteratorReadOptions::from_read_options(read_options)),
+            Arc::new(iterator_read_options),
             sstable_info,
         ),
         local_stats,
@@ -193,9 +196,19 @@ pub fn get_from_batch<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::get_from_sstable_info;
+    use bytes::Bytes;
+    use risingwave_common::catalog::TableId;
+    use risingwave_common::hash::VirtualNode;
+    use risingwave_common::util::epoch::test_epoch;
+    use risingwave_hummock_sdk::EpochWithGap;
+    use risingwave_hummock_sdk::key::{FullKey, TableKey, UserKey};
+
+    use super::{CachePolicy, get_from_sstable_info};
     use crate::hummock::iterator::test_utils::{iterator_test_key_of, mock_sstable_store};
-    use crate::hummock::test_utils::{default_builder_opt_for_test, gen_test_sstable_info};
+    use crate::hummock::test_utils::{
+        default_builder_opt_for_test, gen_test_sstable_info, gen_test_sstable_with_table_ids,
+        test_value_of,
+    };
     use crate::hummock::value::HummockValue;
     use crate::monitor::StoreLocalStatistic;
     use crate::store::ReadOptions;
@@ -233,5 +246,70 @@ mod tests {
         assert!(result.is_none());
         drop(result);
         assert_eq!(stats.cache_data_block_total, 1);
+    }
+
+    #[tokio::test]
+    async fn test_point_get_reads_only_requested_table_blocks() {
+        let sstable_store = mock_sstable_store().await;
+        let mut builder_options = default_builder_opt_for_test();
+        builder_options.block_capacity = 128;
+
+        let test_user_key = |table_id, key: &str| {
+            UserKey::new(
+                TableId::new(table_id),
+                TableKey(Bytes::from(
+                    [VirtualNode::ZERO.to_be_bytes().as_slice(), key.as_bytes()].concat(),
+                )),
+            )
+        };
+        let test_key = |table_id, key: &str| FullKey {
+            user_key: test_user_key(table_id, key),
+            epoch_with_gap: EpochWithGap::new_from_epoch(test_epoch(1)),
+        };
+        let kv_pairs = (1..=2).flat_map(|table_id| {
+            (0..8).map(move |idx| {
+                (
+                    test_key(table_id, &format!("key_{idx:05}")),
+                    HummockValue::put(Bytes::from(test_value_of(idx))),
+                )
+            })
+        });
+        let (sstable, sstable_info) = gen_test_sstable_with_table_ids(
+            builder_options,
+            10,
+            kv_pairs,
+            sstable_store.clone(),
+            vec![1, 2],
+        )
+        .await;
+        let table_2_block_start = sstable
+            .meta
+            .block_metas
+            .partition_point(|block_meta| block_meta.table_id() < TableId::new(2));
+        assert!(table_2_block_start > 0);
+
+        // The queried table-2 key sorts before the first table-2 block. Without a point-get table
+        // id filter, the SST iterator seeks to the previous table-1 block first.
+        let full_key = test_key(2, "key");
+        let mut local_stats = StoreLocalStatistic::default();
+        let read_options = ReadOptions {
+            cache_policy: CachePolicy::Disable,
+            ..Default::default()
+        };
+
+        {
+            let result = get_from_sstable_info(
+                sstable_store,
+                &sstable_info,
+                full_key.to_ref(),
+                &read_options,
+                None,
+                &mut local_stats,
+            )
+            .await
+            .unwrap();
+            assert!(result.is_none());
+        }
+        assert_eq!(local_stats.cache_data_block_total, 1);
     }
 }

--- a/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
@@ -77,17 +77,12 @@ impl SstableIterator {
             sstable_info_ref.sst_id,
             sstable_info_ref.object_id,
         );
-        let read_table_id_range = if let Some(read_table_id) = options.read_table_id {
-            assert!(
-                sstable_info_ref
-                    .table_ids
-                    .binary_search(&read_table_id)
-                    .is_ok(),
-                "read table id {} not found in SST {} table_ids {:?}",
-                read_table_id,
-                sstable_info_ref.sst_id,
-                sstable_info_ref.table_ids
-            );
+        let read_table_id_range = if let Some(read_table_id) = options.read_table_id
+            && sstable_info_ref
+                .table_ids
+                .binary_search(&read_table_id)
+                .is_ok()
+        {
             (read_table_id, read_table_id)
         } else {
             (
@@ -775,6 +770,28 @@ mod tests {
         while sstable_iter.is_valid() {
             assert_eq!(sstable_iter.key().user_key.table_id, TableId::new(2));
             sstable_iter.next().await.unwrap();
+        }
+
+        for missing_table_id in [0, 4] {
+            let options = Arc::new(SstableIteratorReadOptions {
+                read_table_id: Some(TableId::new(missing_table_id)),
+                ..Default::default()
+            });
+            let mut sstable_iter = SstableIterator::create(
+                sstable.clone(),
+                sstable_store.clone(),
+                options,
+                &sstable_info,
+            );
+            sstable_iter.rewind().await.unwrap();
+            for table_id in 1..=3 {
+                for idx in 0..8 {
+                    assert!(sstable_iter.is_valid());
+                    assert_eq!(sstable_iter.key(), test_key(table_id, idx).to_ref());
+                    sstable_iter.next().await.unwrap();
+                }
+            }
+            assert!(!sstable_iter.is_valid());
         }
 
         let mut table_2_sstable_info = sstable_info.get_inner();

--- a/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
@@ -77,10 +77,24 @@ impl SstableIterator {
             sstable_info_ref.sst_id,
             sstable_info_ref.object_id,
         );
-        let read_table_id_range = (
-            *sstable_info_ref.table_ids.first().unwrap(),
-            *sstable_info_ref.table_ids.last().unwrap(),
-        );
+        let read_table_id_range = if let Some(read_table_id) = options.read_table_id {
+            assert!(
+                sstable_info_ref
+                    .table_ids
+                    .binary_search(&read_table_id)
+                    .is_ok(),
+                "read table id {} not found in SST {} table_ids {:?}",
+                read_table_id,
+                sstable_info_ref.sst_id,
+                sstable_info_ref.table_ids
+            );
+            (read_table_id, read_table_id)
+        } else {
+            (
+                *sstable_info_ref.table_ids.first().unwrap(),
+                *sstable_info_ref.table_ids.last().unwrap(),
+            )
+        };
         assert!(
             read_table_id_range.0 <= read_table_id_range.1,
             "invalid table id range {} - {}",
@@ -592,6 +606,7 @@ mod tests {
         );
         let options = Arc::new(SstableIteratorReadOptions {
             cache_policy: CachePolicy::Fill(Hint::Normal),
+            read_table_id: None,
             scan_end_user_key: Some(Bound::Included(uk.clone())),
             prefetch: true,
             max_preload_retry_times: 0,
@@ -692,6 +707,7 @@ mod tests {
         for (case, prefetch) in [("prefetch off", false), ("prefetch on", true)] {
             let options = Arc::new(SstableIteratorReadOptions {
                 cache_policy: CachePolicy::Disable,
+                read_table_id: None,
                 scan_end_user_key: Some(Bound::Excluded(table_3_start.clone())),
                 prefetch,
                 max_preload_retry_times: 0,
@@ -739,6 +755,28 @@ mod tests {
             }
         }
 
+        let options = Arc::new(SstableIteratorReadOptions {
+            cache_policy: CachePolicy::Disable,
+            read_table_id: Some(TableId::new(2)),
+            scan_end_user_key: None,
+            prefetch: false,
+            max_preload_retry_times: 0,
+        });
+        let mut sstable_iter = SstableIterator::create(
+            sstable.clone(),
+            sstable_store.clone(),
+            options,
+            &sstable_info,
+        );
+        assert_eq!(sstable_iter.block_start_idx_inclusive, table_2_block_start);
+        assert_eq!(sstable_iter.block_end_idx_exclusive, table_3_block_start);
+        sstable_iter.rewind().await.unwrap();
+        assert!(sstable_iter.is_valid());
+        while sstable_iter.is_valid() {
+            assert_eq!(sstable_iter.key().user_key.table_id, TableId::new(2));
+            sstable_iter.next().await.unwrap();
+        }
+
         let mut table_2_sstable_info = sstable_info.get_inner();
         table_2_sstable_info.table_ids = vec![TableId::new(2)];
         let table_2_sstable_info = SstableInfo::from(table_2_sstable_info);
@@ -748,6 +786,7 @@ mod tests {
                 .copy_into();
         let options = Arc::new(SstableIteratorReadOptions {
             cache_policy: CachePolicy::Disable,
+            read_table_id: None,
             scan_end_user_key: Some(Bound::Excluded(table_2_start)),
             prefetch: false,
             max_preload_retry_times: 0,

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -512,8 +512,9 @@ impl SstableMeta {
 #[derive(Default)]
 pub struct SstableIteratorReadOptions {
     pub cache_policy: CachePolicy,
-    /// The table being read by the state-store request. When present, SST iterators can avoid
-    /// blocks for other tables that are colocated in the same physical SST.
+    /// The table being read by the state-store request. When present in the SST's table IDs,
+    /// SST iterators can avoid blocks for other tables colocated in the same physical SST.
+    /// Otherwise, they use the SST's full table ID range.
     pub read_table_id: Option<TableId>,
     /// The only hard upper bound of this scan. It limits the iterator's block window.
     pub scan_end_user_key: Option<Bound<UserKey<KeyPayloadType>>>,

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -512,6 +512,9 @@ impl SstableMeta {
 #[derive(Default)]
 pub struct SstableIteratorReadOptions {
     pub cache_policy: CachePolicy,
+    /// The table being read by the state-store request. When present, SST iterators can avoid
+    /// blocks for other tables that are colocated in the same physical SST.
+    pub read_table_id: Option<TableId>,
     /// The only hard upper bound of this scan. It limits the iterator's block window.
     pub scan_end_user_key: Option<Bound<UserKey<KeyPayloadType>>>,
     /// Whether to prefetch blocks within the already-bounded scan window.
@@ -525,6 +528,7 @@ impl SstableIteratorReadOptions {
     pub fn from_read_options(read_options: &ReadOptions) -> Self {
         Self {
             cache_policy: read_options.cache_policy,
+            read_table_id: None,
             scan_end_user_key: None,
             prefetch: false,
             max_preload_retry_times: 0,

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -1042,6 +1042,7 @@ impl HummockVersionReader {
             .as_ref()
             .map(|hint| Sstable::hash_for_filter(hint, table_id.as_raw_id()));
         let mut sst_read_options = SstableIteratorReadOptions::from_read_options(&read_options);
+        sst_read_options.read_table_id = Some(table_id);
         sst_read_options.scan_end_user_key = Some(user_key_range.1.map(|key| key.cloned()));
         sst_read_options.prefetch = read_options.prefetch_options.prefetch;
         if sst_read_options.prefetch {
@@ -1212,6 +1213,7 @@ impl HummockVersionReader {
         }
         let read_options = Arc::new(SstableIteratorReadOptions {
             cache_policy: Default::default(),
+            read_table_id: Some(options.table_id),
             scan_end_user_key: None,
             prefetch: false,
             max_preload_retry_times: 0,

--- a/src/storage/src/hummock/validator.rs
+++ b/src/storage/src/hummock/validator.rs
@@ -65,6 +65,7 @@ pub async fn validate_ssts(task: ValidationTask, sstable_store: SstableStoreRef)
             sstable_store.clone(),
             Arc::new(SstableIteratorReadOptions {
                 cache_policy: CachePolicy::NotFill,
+                read_table_id: None,
                 scan_end_user_key: None,
                 prefetch: false,
                 max_preload_retry_times: 0,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

When an SST contains multiple tables, a scan or point get can read blocks belonging to another table. Bound SST iterators to the requested table ID so these reads avoid unrelated blocks. For example, a point get before the first key in table 2 now reads only the table-2 block instead of first visiting the preceding table-1 block.

If the requested table ID is absent from the SST's table IDs, iteration falls back to the SST's full table ID range. Regression coverage checks that absent IDs below and above that range still allow iterating every key.

Cherry-picks these merged PRs from `patch/v2.8.5-refill` onto `main`, in order:

1. #26496 — bound SST iterators by read table ID (`1cca41699a4905bb7de511716bd62d9a39ece5c4`).
2. #26501 — apply the same bound to point gets (`ae3bd84b9d8eef6755975d7ab5d32c4328ed95ea`).

### Conflict resolutions

- `src/storage/src/hummock/event_handler/refiller.rs`: retained main's `HummockVersion::from(PbHummockVersion::default())` conversion; the source patch used the older `from_rpc_protobuf` call.
- `src/storage/benches/bench_block_iter.rs`: retained main's equivalent `BlockBuilder::add` implementation. The source patch used a different local variable name (`encoded_key` instead of `key`).
- `src/storage/src/hummock/mod.rs`: set `read_table_id` while preserving main's `IteratorStatsGuard`, merged test imports, and retained both the existing statistics regression test and the incoming point-get table-bound regression test.
- Additional compatibility adjustment: preserved `#[expect(clippy::too_many_arguments)]` on `GlobalBarrierManager::start`. The original patch removed it, but main's function has 12 arguments and still exceeds the configured threshold of 10.

## Validation

After adding the absent-table-ID fallback:

- Forward SST iterator tests — 5 passed, including fallback coverage.
- Point-get regression tests (`hummock::tests::`) — 2 passed.
- Formatting and diff checks — passed.

Earlier validation of the initial cherry-picks:

- `cargo fmt --all -- --check` — passed.
- `git diff --check origin/main...HEAD` — passed.
- `cargo test --offline -p risingwave_storage --lib hummock:: --no-default-features -- --skip hummock::event_handler::hummock_event_handler::tests::test_clear_one_table_preserves_other_table_uploads --quiet` — 193 passed, 0 failed.
- The initial unfiltered Hummock run was interrupted after `test_clear_one_table_preserves_other_table_uploads` remained running for over 60 seconds. That test was excluded only from the subsequent local invocation; no test was disabled in the code. Its cause has not been investigated.
- The passing tests include the scan table-bound regression, the new point-get table-bound regression, and main's existing iterator statistics regression.

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added necessary unit tests and integration tests.
- [x] I have added test labels as necessary.

## CI and labels

Request `ci/run-e2e-refill-tests` for neighboring SST cache/refill coverage. Preserve the default PR pipeline, including integration, e2e, and recovery deterministic simulation tests.

Apply `type/fix` and `A-storage`. Do not add `user-facing-changes` or `breaking-change`: this changes internal read efficiency without changing supported interfaces or workflows. Do not add test-infrastructure labels for regression tests, or `cherry-pick`, whose live description targets older release branches. No selected-only or run-all CI labels are needed.

## Documentation

No product documentation changes are needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Point lookups now read only blocks belonging to the requested table in shared storage files.
  - Table-specific scans avoid accessing unrelated table data, improving read efficiency.
  - Table-scoped iteration now limits reads to the selected table’s data.
  - Reads without a specified table continue to scan the full applicable range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->