### PR TITLE
feat(stream): forward watermarks through general over window

### DIFF
--- a/e2e_test/streaming/over_window/watermark_forwarding.slt
+++ b/e2e_test/streaming/over_window/watermark_forwarding.slt
@@ -1,0 +1,139 @@
+# Watermark forwarding of the general `OverWindow` executor: watermarks on partition key columns
+# are always forwarded, and watermarks on the first `ORDER BY` column are forwarded when no window
+# frame extends to following rows. Here the forwarded watermark drives the state cleaning of a
+# downstream hash join on the watermark column, which requires watermarks from both join sides.
+# The cleaning is observed through the committed watermarks of the join state tables in
+# `rw_catalog.rw_hummock_table_watermark`, since rows below them are only reclaimed by compaction.
+
+# `let` and `${...}` references below require substitution to be enabled.
+control substitution on
+
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+# With parallel upstream actors, idle actors can delay the merged watermark.
+statement ok
+SET streaming_parallelism = 1;
+
+statement ok
+CREATE TABLE t1 (k INT, ts INT, v INT, WATERMARK FOR ts AS ts - 5) APPEND ONLY;
+
+statement ok
+CREATE TABLE t2 (ts INT, x INT, WATERMARK FOR ts AS ts - 5) APPEND ONLY;
+
+# The `lag` frame has no following rows, so the watermark on `ts` is forwarded through the over
+# window to the join.
+statement ok
+CREATE MATERIALIZED VIEW mv AS
+SELECT w.k, w.ts, w.v, w.lag_v, t2.x
+FROM (
+    SELECT k, ts, v, lag(v) OVER (PARTITION BY k ORDER BY ts) AS lag_v FROM t1
+) w
+JOIN t2 ON w.ts = t2.ts;
+
+let left_state_table_id
+SELECT id FROM rw_catalog.rw_internal_table_info WHERE job_name = 'mv' AND name LIKE '%hashjoinleft%';
+
+let right_state_table_id
+SELECT id FROM rw_catalog.rw_internal_table_info WHERE job_name = 'mv' AND name LIKE '%hashjoinright%';
+
+# The join has not received any watermark yet.
+query I
+SELECT count(*) FROM rw_catalog.rw_hummock_table_watermark
+WHERE table_id IN (${left_state_table_id}, ${right_state_table_id});
+----
+0
+
+statement ok
+INSERT INTO t1 VALUES (1, 10, 1), (1, 12, 2), (2, 12, 3);
+
+statement ok
+INSERT INTO t2 VALUES (10, 100), (12, 200);
+
+query IIIII
+SELECT * FROM mv ORDER BY k, ts;
+----
+1 10 1 NULL 100
+1 12 2 1 200
+2 12 3 NULL 200
+
+# Both sides have delivered watermark 7 to the join, so both join state tables have a committed
+# watermark on the join key `ts` now.
+query I retry 30 backoff 1s
+SELECT count(DISTINCT table_id) FROM rw_catalog.rw_hummock_table_watermark
+WHERE table_id IN (${left_state_table_id}, ${right_state_table_id});
+----
+2
+
+let left_wm_before
+SELECT max(encode(watermark::bytea, 'hex')) FROM rw_catalog.rw_hummock_table_watermark
+WHERE table_id = ${left_state_table_id};
+
+let right_wm_before
+SELECT max(encode(watermark::bytea, 'hex')) FROM rw_catalog.rw_hummock_table_watermark
+WHERE table_id = ${right_state_table_id};
+
+# Advance the watermark of the over window side only. The join key watermark is the minimum of both
+# sides, so the committed watermarks stay unchanged.
+statement ok
+INSERT INTO t1 VALUES (1, 30, 4);
+
+query I
+SELECT count(*) FROM rw_catalog.rw_hummock_table_watermark
+WHERE table_id IN (${left_state_table_id}, ${right_state_table_id})
+  AND encode(watermark::bytea, 'hex') NOT IN ('${left_wm_before}', '${right_wm_before}');
+----
+0
+
+# Advance the watermark of `t2` as well, so that both sides deliver watermark 25 to the join and the
+# committed watermarks of both join state tables advance.
+statement ok
+INSERT INTO t2 VALUES (30, 300);
+
+query IIIII
+SELECT * FROM mv ORDER BY k, ts;
+----
+1 10 1 NULL 100
+1 12 2 1 200
+1 30 4 2 300
+2 12 3 NULL 200
+
+query I retry 30 backoff 1s
+SELECT CASE WHEN count(*) > 0 THEN 1 ELSE 0 END FROM rw_catalog.rw_hummock_table_watermark
+WHERE table_id = ${left_state_table_id} AND encode(watermark::bytea, 'hex') > '${left_wm_before}';
+----
+1
+
+query I retry 30 backoff 1s
+SELECT CASE WHEN count(*) > 0 THEN 1 ELSE 0 END FROM rw_catalog.rw_hummock_table_watermark
+WHERE table_id = ${right_state_table_id} AND encode(watermark::bytea, 'hex') > '${right_wm_before}';
+----
+1
+
+# Rows arriving afterwards are still computed and joined correctly.
+statement ok
+INSERT INTO t1 VALUES (1, 31, 5);
+
+statement ok
+INSERT INTO t2 VALUES (31, 310);
+
+query IIIII
+SELECT * FROM mv ORDER BY k, ts;
+----
+1 10 1 NULL 100
+1 12 2 1 200
+1 30 4 2 300
+1 31 5 4 310
+2 12 3 NULL 200
+
+statement ok
+DROP MATERIALIZED VIEW mv;
+
+statement ok
+DROP TABLE t1;
+
+statement ok
+DROP TABLE t2;
+
+statement ok
+SET streaming_parallelism = DEFAULT;

--- a/src/expr/core/src/window_function/call.rs
+++ b/src/expr/core/src/window_function/call.rs
@@ -18,6 +18,7 @@ use FrameBound::{CurrentRow, Following, Preceding, UnboundedFollowing, Unbounded
 use enum_as_inner::EnumAsInner;
 use parse_display::Display;
 use risingwave_common::types::DataType;
+use risingwave_common::util::sort_util::OrderType;
 use risingwave_common::{bail, must_match};
 use risingwave_pb::expr::window_frame::{PbBounds, PbExclusion};
 use risingwave_pb::expr::{PbWindowFrame, PbWindowFunction};
@@ -184,6 +185,62 @@ impl FrameBounds {
     pub fn is_unbounded(&self) -> bool {
         self.start_is_unbounded() || self.end_is_unbounded()
     }
+
+    /// Whether the frame may include rows *preceding* the current row in the frame ordering.
+    pub fn may_include_preceding_rows(&self) -> bool {
+        match self {
+            Self::Rows(RowsFrameBounds { start, .. }) => {
+                start.is_unbounded_preceding() || start.is_preceding()
+            }
+            Self::Range(RangeFrameBounds { start, .. }) => {
+                start.is_unbounded_preceding() || start.is_preceding()
+            }
+            Self::Session(_) => true,
+        }
+    }
+
+    /// Whether the frame may include rows *following* the current row in the frame ordering.
+    pub fn may_include_following_rows(&self) -> bool {
+        match self {
+            Self::Rows(RowsFrameBounds { end, .. }) => {
+                end.is_unbounded_following() || end.is_following()
+            }
+            Self::Range(RangeFrameBounds { end, .. }) => {
+                end.is_unbounded_following() || end.is_following()
+            }
+            Self::Session(_) => true,
+        }
+    }
+}
+
+/// Whether a watermark on the first `ORDER BY` column can be forwarded through a general (i.e.
+/// non-EOWC) streaming over window operator evaluating the given `frames`, which all share the
+/// same `PARTITION BY` and `ORDER BY` clauses.
+///
+/// A watermark `wm` on a column promises that no row with the column value `< wm` will ever arrive
+/// again. To forward it, the operator must guarantee that the outputs of rows with the column value
+/// `< wm` will never change again, which holds when a row can only affect (i.e. be included in the
+/// frames of) rows that are not "smaller" than itself in the column:
+///
+/// - the column is ordered `ASC` and no frame extends to following rows, or
+/// - the column is ordered `DESC` and no frame extends to preceding rows.
+///
+/// Additionally, NULLs must be ordered as the largest values (`ASC NULLS LAST` or `DESC NULLS
+/// FIRST`). Rows with NULL in the column are not covered by the watermark guarantee, so they must
+/// also land on the "larger" side to never affect rows below the watermark.
+pub fn can_forward_watermark_on_order_key<'a>(
+    frames: impl IntoIterator<Item = &'a Frame>,
+    first_order_type: OrderType,
+) -> bool {
+    if !first_order_type.nulls_are_largest() {
+        return false;
+    }
+    let mut frames = frames.into_iter();
+    if first_order_type.is_ascending() {
+        frames.all(|frame| !frame.bounds.may_include_following_rows())
+    } else {
+        frames.all(|frame| !frame.bounds.may_include_preceding_rows())
+    }
 }
 
 pub trait FrameBoundsImpl {
@@ -289,5 +346,126 @@ impl FrameExclusion {
             Self::CurrentRow => PbExclusion::CurrentRow,
             Self::NoOthers => PbExclusion::NoOthers,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::types::ScalarImpl;
+
+    use super::*;
+    use crate::window_function::{RangeFrameBound, RangeFrameOffset, SessionFrameGap};
+
+    fn rows_frame(start: RowsFrameBound, end: RowsFrameBound) -> Frame {
+        Frame::rows(start, end)
+    }
+
+    fn range_frame(start: FrameBound<i64>, end: FrameBound<i64>, order_type: OrderType) -> Frame {
+        // The offsets don't need to be prepared for evaluation here.
+        let bound = |bound: FrameBound<i64>| -> RangeFrameBound {
+            bound.map(|offset| RangeFrameOffset::new(ScalarImpl::Int64(offset)))
+        };
+        Frame {
+            bounds: FrameBounds::Range(RangeFrameBounds {
+                order_data_type: DataType::Int64,
+                order_type,
+                offset_data_type: DataType::Int64,
+                start: bound(start),
+                end: bound(end),
+            }),
+            exclusion: FrameExclusion::default(),
+        }
+    }
+
+    fn session_frame(order_type: OrderType) -> Frame {
+        Frame {
+            bounds: FrameBounds::Session(SessionFrameBounds {
+                order_data_type: DataType::Int64,
+                order_type,
+                gap_data_type: DataType::Int64,
+                gap: SessionFrameGap::new(ScalarImpl::Int64(10)),
+            }),
+            exclusion: FrameExclusion::default(),
+        }
+    }
+
+    #[test]
+    fn test_can_forward_watermark_on_order_key() {
+        let asc = OrderType::ascending(); // ASC NULLS LAST
+        let desc = OrderType::descending(); // DESC NULLS FIRST
+        let can_forward =
+            |frames: &[Frame], order_type| can_forward_watermark_on_order_key(frames, order_type);
+
+        let preceding_only = [
+            rows_frame(UnboundedPreceding, CurrentRow), // rank functions
+            rows_frame(Preceding(1), Preceding(1)),     // `lag`
+            rows_frame(Preceding(2), CurrentRow),
+        ];
+        let following_only = [
+            rows_frame(CurrentRow, UnboundedFollowing),
+            rows_frame(Following(1), Following(1)), // `lead`
+            rows_frame(CurrentRow, Following(2)),
+        ];
+        let current_row_only = [rows_frame(CurrentRow, CurrentRow)];
+        let both_sides = [
+            rows_frame(Preceding(1), Following(1)),
+            rows_frame(UnboundedPreceding, UnboundedFollowing),
+        ];
+
+        assert!(can_forward(&preceding_only, asc));
+        assert!(!can_forward(&preceding_only, desc));
+        assert!(!can_forward(&following_only, asc));
+        assert!(can_forward(&following_only, desc));
+        assert!(can_forward(&current_row_only, asc));
+        assert!(can_forward(&current_row_only, desc));
+        assert!(!can_forward(&both_sides, asc));
+        assert!(!can_forward(&both_sides, desc));
+
+        // Any frame extending to the "smaller" side of the current row disables forwarding.
+        let mixed = [
+            rows_frame(Preceding(1), Preceding(1)),
+            rows_frame(Following(1), Following(1)),
+        ];
+        assert!(!can_forward(&mixed, asc));
+        assert!(!can_forward(&mixed, desc));
+
+        // `RANGE` frames follow the same rule.
+        for order_type in [asc, desc] {
+            let preceding_only = [range_frame(Preceding(10), CurrentRow, order_type)];
+            let following_only = [range_frame(CurrentRow, Following(10), order_type)];
+            let both_sides = [range_frame(Preceding(10), Following(10), order_type)];
+            assert_eq!(
+                can_forward(&preceding_only, order_type),
+                order_type.is_ascending()
+            );
+            assert_eq!(
+                can_forward(&following_only, order_type),
+                order_type.is_descending()
+            );
+            assert!(!can_forward(&both_sides, order_type));
+        }
+
+        // `SESSION` frames extend to both sides.
+        for order_type in [asc, desc] {
+            assert!(!can_forward(&[session_frame(order_type)], order_type));
+        }
+
+        // NULLs must be ordered as the largest values.
+        assert!(!can_forward(
+            &preceding_only,
+            OrderType::ascending_nulls_first()
+        ));
+        assert!(!can_forward(
+            &following_only,
+            OrderType::descending_nulls_last()
+        ));
+        assert!(can_forward(
+            &preceding_only,
+            OrderType::ascending_nulls_last()
+        ));
+        assert!(can_forward(
+            &following_only,
+            OrderType::descending_nulls_first()
+        ));
     }
 }

--- a/src/frontend/planner_test/tests/testdata/input/over_window_function.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/over_window_function.yaml
@@ -825,3 +825,80 @@
     from t;
   expected_outputs:
     - binder_error
+
+# Watermark forwarding of the general streaming over window
+- name: forward watermark on the first order key column for frames without following rows
+  sql: |
+    create table t (a int, b int, ts timestamp, watermark for ts as ts - interval '1 minute') append only;
+    select
+      *,
+      lag(b) over (partition by a order by ts),
+      row_number() over (partition by a order by ts),
+      sum(b) over (partition by a order by ts range between interval '1 hour' preceding and current row)
+    from t;
+  expected_outputs:
+    - stream_plan
+- name: do not forward watermark on the order key column if any frame has following rows
+  sql: |
+    create table t (a int, b int, ts timestamp, watermark for ts as ts - interval '1 minute') append only;
+    select
+      *,
+      lag(b) over (partition by a order by ts),
+      lead(b) over (partition by a order by ts)
+    from t;
+  expected_outputs:
+    - stream_plan
+- name: do not forward watermark on the order key column for descending order with preceding rows
+  sql: |
+    create table t (a int, b int, ts timestamp, watermark for ts as ts - interval '1 minute') append only;
+    select
+      *,
+      row_number() over (partition by a order by ts desc)
+    from t;
+  expected_outputs:
+    - stream_plan
+- name: forward watermark on the first order key column for descending order with only following rows
+  sql: |
+    create table t (a int, b int, ts timestamp, watermark for ts as ts - interval '1 minute') append only;
+    select
+      *,
+      lead(b) over (partition by a order by ts desc)
+    from t;
+  expected_outputs:
+    - stream_plan
+- name: do not forward watermark on the order key column if NULLs are not ordered as the largest
+  sql: |
+    create table t (a int, b int, ts timestamp, watermark for ts as ts - interval '1 minute') append only;
+    select
+      *,
+      lag(b) over (partition by a order by ts asc nulls first)
+    from t;
+  expected_outputs:
+    - stream_plan
+- name: do not forward watermark on non-first order key columns
+  sql: |
+    create table t (a int, b int, ts timestamp, watermark for ts as ts - interval '1 minute') append only;
+    select
+      *,
+      lag(b) over (partition by a order by b, ts)
+    from t;
+  expected_outputs:
+    - stream_plan
+- name: always forward watermark on partition key columns
+  sql: |
+    create table t (a int, b int, ts timestamp, watermark for ts as ts - interval '1 minute') append only;
+    select
+      *,
+      lead(b) over (partition by ts order by b)
+    from t;
+  expected_outputs:
+    - stream_plan
+- name: forwarded watermark enables state cleaning of a downstream join on the watermark column
+  sql: |
+    create table t1 (k int, ts int, v int, watermark for ts as ts - 5) append only;
+    create table t2 (ts int, x int, watermark for ts as ts - 5) append only;
+    select w.k, w.ts, w.v, w.lag_v, t2.x
+    from (select k, ts, v, lag(v) over (partition by k order by ts) as lag_v from t1) w
+    join t2 on w.ts = t2.ts;
+  expected_outputs:
+    - stream_plan

--- a/src/frontend/planner_test/tests/testdata/output/emit_on_window_close.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/emit_on_window_close.yaml
@@ -222,8 +222,8 @@
       ON s1.id = s2.id and s1.ts >= s2.ts   and s1.ts - INTERVAL '1' MINUTE <= s2.ts
     );
   stream_plan: |-
-    StreamMaterialize { columns: [id1, value1, id2, value2, ts1, ts2, s1._row_id(hidden), s2._row_id(hidden), count], stream_key: [s1._row_id, s2._row_id, id1, value2], pk_columns: [s1._row_id, s2._row_id, id1, value2], pk_conflict: NoCheck }
-    └─StreamOverWindow { window_functions: [count() OVER(PARTITION BY s2.value ORDER BY s2.ts ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
+    StreamMaterialize { columns: [id1, value1, id2, value2, ts1, ts2, s1._row_id(hidden), s2._row_id(hidden), count], stream_key: [s1._row_id, s2._row_id, id1, value2], pk_columns: [s1._row_id, s2._row_id, id1, value2], pk_conflict: NoCheck, watermark_columns: [ts2] }
+    └─StreamOverWindow { window_functions: [count() OVER(PARTITION BY s2.value ORDER BY s2.ts ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)], output_watermarks: [[s2.ts]] }
       └─StreamExchange { dist: HashShard(s2.value) }
         └─StreamHashJoin [interval, append_only] { type: Inner, predicate: s1.id = s2.id AND (s1.ts >= s2.ts) AND ($expr1 <= s2.ts), conditions_to_clean_left_state_table: (s1.ts >= s2.ts), conditions_to_clean_right_state_table: ($expr1 <= s2.ts), output_watermarks: [[s1.ts], [s2.ts]], output: [s1.id, s1.value, s2.id, s2.value, s1.ts, s2.ts, s1._row_id, s2._row_id] }
           ├─StreamExchange { dist: HashShard(s1.id) }

--- a/src/frontend/planner_test/tests/testdata/output/nexmark_watermark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark_watermark.yaml
@@ -2611,9 +2611,9 @@
                 └─BatchProject { exprs: [event_type, person, auction, bid, Case((event_type = 0:Int32), Field(person, 6:Int32), (event_type = 1:Int32), Field(auction, 5:Int32), Field(bid, 5:Int32)) as $expr1, _row_id] }
                   └─BatchSource { source: nexmark, columns: [event_type, person, auction, bid, _row_id] }
   stream_plan: |-
-    StreamMaterialize { columns: [auction, bidder, date_time, price, avg_price_10, max_price_10, _row_id(hidden)], stream_key: [_row_id, auction], pk_columns: [_row_id, auction], pk_conflict: NoCheck }
-    └─StreamProject { exprs: [$expr2, $expr3, $expr1, $expr4, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr5, max, _row_id] }
-      └─StreamOverWindow { window_functions: [sum($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), max($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
+    StreamMaterialize { columns: [auction, bidder, date_time, price, avg_price_10, max_price_10, _row_id(hidden)], stream_key: [_row_id, auction], pk_columns: [_row_id, auction], pk_conflict: NoCheck, watermark_columns: [date_time] }
+    └─StreamProject { exprs: [$expr2, $expr3, $expr1, $expr4, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr5, max, _row_id], output_watermarks: [[$expr1]] }
+      └─StreamOverWindow { window_functions: [sum($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), max($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)], output_watermarks: [[$expr1]] }
         └─StreamExchange { dist: HashShard($expr2) }
           └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, Field(bid, 1:Int32) as $expr3, Field(bid, 2:Int32) as $expr4, $expr1, _row_id], output_watermarks: [[$expr1]] }
             └─StreamFilter { predicate: ((Field(bid, 0:Int32) % 100:Int32) = 0:Int32) AND (event_type = 2:Int32) }
@@ -2623,9 +2623,9 @@
                     └─StreamSource { source: nexmark, columns: [event_type, person, auction, bid, _row_id] }
   stream_dist_plan: |+
     Fragment 0
-    StreamMaterialize { columns: [auction, bidder, date_time, price, avg_price_10, max_price_10, _row_id(hidden)], stream_key: [_row_id, auction], pk_columns: [_row_id, auction], pk_conflict: NoCheck }
-    └── StreamProject { exprs: [$expr2, $expr3, $expr1, $expr4, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr5, max, _row_id] }
-        └── StreamOverWindow { window_functions: [sum($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), max($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
+    StreamMaterialize { columns: [auction, bidder, date_time, price, avg_price_10, max_price_10, _row_id(hidden)], stream_key: [_row_id, auction], pk_columns: [_row_id, auction], pk_conflict: NoCheck, watermark_columns: [date_time] }
+    └── StreamProject { exprs: [$expr2, $expr3, $expr1, $expr4, Case((count = 0:Int32), null:Decimal, (sum / count::Decimal)) as $expr5, max, _row_id], output_watermarks: [[$expr1]] }
+        └── StreamOverWindow { window_functions: [sum($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), count($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW), max($expr4) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)], output_watermarks: [[$expr1]] }
             ├── tables: [ OverWindow: 0 ]
             └── StreamExchange Hash([0]) from 1
 

--- a/src/frontend/planner_test/tests/testdata/output/over_window_function.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/over_window_function.yaml
@@ -1724,3 +1724,108 @@
     Caused by:
       Feature is not yet implemented: `IGNORE NULLS` is not supported for `lead` yet
     No tracking issue yet. Feel free to submit a feature request at https://github.com/risingwavelabs/risingwave/issues/new?labels=type%2Ffeature&template=feature_request.yml
+- name: forward watermark on the first order key column for frames without following rows
+  sql: |
+    create table t (a int, b int, ts timestamp, watermark for ts as ts - interval '1 minute') append only;
+    select
+      *,
+      lag(b) over (partition by a order by ts),
+      row_number() over (partition by a order by ts),
+      sum(b) over (partition by a order by ts range between interval '1 hour' preceding and current row)
+    from t;
+  stream_plan: |-
+    StreamMaterialize { columns: [a, b, ts, lag, row_number, sum, t._row_id(hidden)], stream_key: [t._row_id, a], pk_columns: [t._row_id, a], pk_conflict: NoCheck, watermark_columns: [ts] }
+    └─StreamProject { exprs: [t.a, t.b, t.ts, first_value, row_number, sum, t._row_id], output_watermarks: [[t.ts]] }
+      └─StreamOverWindow { window_functions: [first_value(t.b) OVER(PARTITION BY t.a ORDER BY t.ts ASC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING), sum(t.b) OVER(PARTITION BY t.a ORDER BY t.ts ASC RANGE BETWEEN 01:00:00 PRECEDING AND CURRENT ROW), row_number() OVER(PARTITION BY t.a ORDER BY t.ts ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)], output_watermarks: [[t.ts]] }
+        └─StreamExchange { dist: HashShard(t.a) }
+          └─StreamTableScan { table: t, columns: [t.a, t.b, t.ts, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: do not forward watermark on the order key column if any frame has following rows
+  sql: |
+    create table t (a int, b int, ts timestamp, watermark for ts as ts - interval '1 minute') append only;
+    select
+      *,
+      lag(b) over (partition by a order by ts),
+      lead(b) over (partition by a order by ts)
+    from t;
+  stream_plan: |-
+    StreamMaterialize { columns: [a, b, ts, t._row_id(hidden), lag, lead], stream_key: [t._row_id, a], pk_columns: [t._row_id, a], pk_conflict: NoCheck }
+    └─StreamOverWindow { window_functions: [first_value(t.b) OVER(PARTITION BY t.a ORDER BY t.ts ASC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING), first_value(t.b) OVER(PARTITION BY t.a ORDER BY t.ts ASC ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)] }
+      └─StreamExchange { dist: HashShard(t.a) }
+        └─StreamTableScan { table: t, columns: [t.a, t.b, t.ts, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: do not forward watermark on the order key column for descending order with preceding rows
+  sql: |
+    create table t (a int, b int, ts timestamp, watermark for ts as ts - interval '1 minute') append only;
+    select
+      *,
+      row_number() over (partition by a order by ts desc)
+    from t;
+  stream_plan: |-
+    StreamMaterialize { columns: [a, b, ts, t._row_id(hidden), row_number], stream_key: [t._row_id, a], pk_columns: [t._row_id, a], pk_conflict: NoCheck }
+    └─StreamOverWindow { window_functions: [row_number() OVER(PARTITION BY t.a ORDER BY t.ts DESC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
+      └─StreamExchange { dist: HashShard(t.a) }
+        └─StreamTableScan { table: t, columns: [t.a, t.b, t.ts, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: forward watermark on the first order key column for descending order with only following rows
+  sql: |
+    create table t (a int, b int, ts timestamp, watermark for ts as ts - interval '1 minute') append only;
+    select
+      *,
+      lead(b) over (partition by a order by ts desc)
+    from t;
+  stream_plan: |-
+    StreamMaterialize { columns: [a, b, ts, t._row_id(hidden), lead], stream_key: [t._row_id, a], pk_columns: [t._row_id, a], pk_conflict: NoCheck, watermark_columns: [ts] }
+    └─StreamOverWindow { window_functions: [first_value(t.b) OVER(PARTITION BY t.a ORDER BY t.ts DESC ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)], output_watermarks: [[t.ts]] }
+      └─StreamExchange { dist: HashShard(t.a) }
+        └─StreamTableScan { table: t, columns: [t.a, t.b, t.ts, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: do not forward watermark on the order key column if NULLs are not ordered as the largest
+  sql: |
+    create table t (a int, b int, ts timestamp, watermark for ts as ts - interval '1 minute') append only;
+    select
+      *,
+      lag(b) over (partition by a order by ts asc nulls first)
+    from t;
+  stream_plan: |-
+    StreamMaterialize { columns: [a, b, ts, t._row_id(hidden), lag], stream_key: [t._row_id, a], pk_columns: [t._row_id, a], pk_conflict: NoCheck }
+    └─StreamOverWindow { window_functions: [first_value(t.b) OVER(PARTITION BY t.a ORDER BY t.ts ASC NULLS FIRST ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING)] }
+      └─StreamExchange { dist: HashShard(t.a) }
+        └─StreamTableScan { table: t, columns: [t.a, t.b, t.ts, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: do not forward watermark on non-first order key columns
+  sql: |
+    create table t (a int, b int, ts timestamp, watermark for ts as ts - interval '1 minute') append only;
+    select
+      *,
+      lag(b) over (partition by a order by b, ts)
+    from t;
+  stream_plan: |-
+    StreamMaterialize { columns: [a, b, ts, t._row_id(hidden), lag], stream_key: [t._row_id, a], pk_columns: [t._row_id, a], pk_conflict: NoCheck }
+    └─StreamOverWindow { window_functions: [first_value(t.b) OVER(PARTITION BY t.a ORDER BY t.b ASC, t.ts ASC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING)] }
+      └─StreamExchange { dist: HashShard(t.a) }
+        └─StreamTableScan { table: t, columns: [t.a, t.b, t.ts, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: always forward watermark on partition key columns
+  sql: |
+    create table t (a int, b int, ts timestamp, watermark for ts as ts - interval '1 minute') append only;
+    select
+      *,
+      lead(b) over (partition by ts order by b)
+    from t;
+  stream_plan: |-
+    StreamMaterialize { columns: [a, b, ts, t._row_id(hidden), lead], stream_key: [t._row_id, ts], pk_columns: [t._row_id, ts], pk_conflict: NoCheck, watermark_columns: [ts] }
+    └─StreamOverWindow { window_functions: [first_value(t.b) OVER(PARTITION BY t.ts ORDER BY t.b ASC ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)], output_watermarks: [[t.ts]] }
+      └─StreamExchange { dist: HashShard(t.ts) }
+        └─StreamTableScan { table: t, columns: [t.a, t.b, t.ts, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: forwarded watermark enables state cleaning of a downstream join on the watermark column
+  sql: |
+    create table t1 (k int, ts int, v int, watermark for ts as ts - 5) append only;
+    create table t2 (ts int, x int, watermark for ts as ts - 5) append only;
+    select w.k, w.ts, w.v, w.lag_v, t2.x
+    from (select k, ts, v, lag(v) over (partition by k order by ts) as lag_v from t1) w
+    join t2 on w.ts = t2.ts;
+  stream_plan: |-
+    StreamMaterialize { columns: [k, ts, v, lag_v, x, t1._row_id(hidden), t2._row_id(hidden)], stream_key: [t1._row_id, k, t2._row_id, ts], pk_columns: [t1._row_id, k, t2._row_id, ts], pk_conflict: NoCheck, watermark_columns: [ts] }
+    └─StreamExchange { dist: HashShard(t1.k, t1.ts, t1._row_id, t2._row_id) }
+      └─StreamHashJoin [window] { type: Inner, predicate: t1.ts = t2.ts, conditions_to_clean_state_in_join_key: [(t1.ts = t2.ts)], output_watermarks: [[t1.ts]], output: [t1.k, t1.ts, t1.v, first_value, t2.x, t1._row_id, t2._row_id] }
+        ├─StreamExchange { dist: HashShard(t1.ts) }
+        │ └─StreamOverWindow { window_functions: [first_value(t1.v) OVER(PARTITION BY t1.k ORDER BY t1.ts ASC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING)], output_watermarks: [[t1.ts]] }
+        │   └─StreamExchange { dist: HashShard(t1.k) }
+        │     └─StreamTableScan { table: t1, columns: [t1.k, t1.ts, t1.v, t1._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t1._row_id], pk: [_row_id], dist: UpstreamHashShard(t1._row_id) }
+        └─StreamExchange { dist: HashShard(t2.ts) }
+          └─StreamTableScan { table: t2, columns: [t2.ts, t2.x, t2._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t2._row_id], pk: [_row_id], dist: UpstreamHashShard(t2._row_id) }

--- a/src/frontend/src/optimizer/plan_node/stream_over_window.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_over_window.rs
@@ -14,19 +14,20 @@
 
 use std::collections::HashSet;
 
+use pretty_xmlish::XmlNode;
 use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
-use risingwave_expr::window_function::FrameBounds;
+use risingwave_expr::window_function::{FrameBounds, can_forward_watermark_on_order_key};
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
-use super::generic::{GenericPlanNode, PlanWindowFunction};
+use super::generic::{DistillUnit, GenericPlanNode, PlanWindowFunction};
 use super::stream::prelude::*;
-use super::utils::{TableCatalogBuilder, impl_distill_by_unit};
+use super::utils::{Distill, TableCatalogBuilder, watermark_pretty};
 use super::{
     ExprRewritable, PlanBase, PlanTreeNodeUnary, StreamNode, StreamPlanRef as PlanRef, generic,
 };
 use crate::TableCatalog;
 use crate::optimizer::plan_node::expr_visitable::ExprVisitable;
-use crate::optimizer::property::{MonotonicityMap, WatermarkColumns};
+use crate::optimizer::property::MonotonicityMap;
 use crate::stream_fragmenter::BuildFragmentGraphState;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -41,7 +42,22 @@ impl StreamOverWindow {
         reject_upsert_input!(core.input);
 
         let input = &core.input;
-        let watermark_columns = WatermarkColumns::new();
+        let watermark_columns = {
+            // Watermarks on partition key columns can always be forwarded, since a row can only
+            // affect rows in the same partition. Watermarks on the first order key column can be
+            // forwarded only if the window frames guarantee that a row can only affect rows not
+            // below itself in that column. All other watermarks are dropped by the executor.
+            let mut cols = core.partition_key_indices();
+            if let Some(first_order_key) = core.order_key().first()
+                && can_forward_watermark_on_order_key(
+                    core.window_functions().iter().map(|func| &func.frame),
+                    first_order_key.order_type,
+                )
+            {
+                cols.push(first_order_key.column_index);
+            }
+            input.watermark_columns().retain_clone(&cols)
+        };
 
         let base = PlanBase::new_stream_with_core(
             &core,
@@ -116,7 +132,15 @@ impl StreamOverWindow {
     }
 }
 
-impl_distill_by_unit!(StreamOverWindow, core, "StreamOverWindow");
+impl Distill for StreamOverWindow {
+    fn distill<'a>(&self) -> XmlNode<'a> {
+        let mut node = self.core.distill_with_name("StreamOverWindow");
+        if let Some(ow) = watermark_pretty(self.base.watermark_columns(), self.schema()) {
+            node.fields.push(("output_watermarks".into(), ow));
+        }
+        node
+    }
+}
 
 impl PlanTreeNodeUnary<Stream> for StreamOverWindow {
     fn input(&self) -> PlanRef {

--- a/src/stream/src/executor/over_window/general.rs
+++ b/src/stream/src/executor/over_window/general.rs
@@ -25,7 +25,7 @@ use risingwave_common::types::{DefaultOrd, DefaultOrdered, ScalarImpl};
 use risingwave_common::util::memcmp_encoding::{self, MemcmpEncoded};
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_expr::window_function::{
-    RangeFrameBounds, RowsFrameBounds, StateKey, WindowFuncCall,
+    RangeFrameBounds, RowsFrameBounds, StateKey, WindowFuncCall, can_forward_watermark_on_order_key,
 };
 
 use super::frame_finder::merge_rows_frames;
@@ -43,6 +43,10 @@ use crate::executor::prelude::*;
 ///
 /// - State table schema = output schema, state table pk = `partition key | order key | input pk`.
 /// - Output schema = input schema + window function results.
+/// - Watermarks on partition key columns are always forwarded, since a row can only affect rows in
+///   the same partition. Watermarks on the first order key column are forwarded only if the window
+///   frames guarantee that a row can only affect rows not below itself in that column (see
+///   [`can_forward_watermark_on_order_key`]). All other watermarks are dropped.
 /// - When [`StateCleaning`] is enabled, stale rows below the watermark of the first order key
 ///   column are deleted from recently touched partitions at barriers.
 pub struct OverWindowExecutor<S: StateStore> {
@@ -70,6 +74,9 @@ struct ExecutorInner<S: StateStore> {
     cache_policy: CachePolicy,
     /// Watermark-driven state cleaning strategy, `None` if disabled.
     state_cleaning: Option<StateCleaning>,
+    /// Indices of input columns on which watermarks are forwarded to downstream: the partition key
+    /// columns, and the first order key column if allowed by the window frames.
+    watermark_forward_cols: HashSet<usize>,
 }
 
 struct ExecutionVars<S: StateStore> {
@@ -275,7 +282,7 @@ impl<S: StateStore> OverWindowExecutor<S> {
             &input_info.stream_key,
         );
 
-        let deduped_part_key_indices = {
+        let deduped_part_key_indices: Vec<usize> = {
             let mut dedup = HashSet::new();
             args.partition_key_indices
                 .iter()
@@ -311,6 +318,19 @@ impl<S: StateStore> OverWindowExecutor<S> {
             None
         };
 
+        let watermark_forward_cols = {
+            let mut cols: HashSet<usize> = deduped_part_key_indices.iter().copied().collect();
+            if let Some(&first_order_key_idx) = args.order_key_indices.first()
+                && can_forward_watermark_on_order_key(
+                    calls.iter().map(|call| &call.frame),
+                    args.order_key_order_types[0],
+                )
+            {
+                cols.insert(first_order_key_idx);
+            }
+            cols
+        };
+
         Self {
             input: args.input,
             inner: ExecutorInner {
@@ -328,6 +348,7 @@ impl<S: StateStore> OverWindowExecutor<S> {
                 chunk_size: args.chunk_size,
                 cache_policy,
                 state_cleaning,
+                watermark_forward_cols,
             },
         }
     }
@@ -715,12 +736,14 @@ impl<S: StateStore> OverWindowExecutor<S> {
                             .is_none_or(|old| old.default_cmp(&watermark.val).is_lt())
                     {
                         // Only used for state cleaning at the next barrier.
-                        vars.cleaning_watermark = Some(watermark.val);
+                        vars.cleaning_watermark = Some(watermark.val.clone());
                     }
-                    // TODO(rc): We don't propagate watermarks to downstream for now, because rows
-                    // below the watermark may still be updated by later rows if there's any
-                    // following frame bound, e.g. `lead`. We need to think about it carefully.
-                    continue;
+                    if this.watermark_forward_cols.contains(&watermark.col_idx) {
+                        // All changes caused by the rows received so far have already been
+                        // emitted, and rows arriving in the future can only affect rows that are
+                        // not below the watermark in this column, so it's safe to forward it now.
+                        yield Message::Watermark(watermark);
+                    }
                 }
                 Message::Chunk(chunk) => {
                     #[for_await]

--- a/src/stream/tests/integration_tests/over_window.rs
+++ b/src/stream/tests/integration_tests/over_window.rs
@@ -18,6 +18,7 @@ use std::sync::atomic::Ordering;
 use futures::TryStreamExt;
 use risingwave_common::config::streaming::OverWindowCachePolicy;
 use risingwave_common::row::{OwnedRow, Row};
+use risingwave_common::types::ScalarImpl;
 use risingwave_common::util::epoch::{EpochPair, test_epoch};
 use risingwave_expr::aggregate::{AggArgs, PbAggKind};
 use risingwave_expr::window_function::{
@@ -1013,4 +1014,80 @@ async fn test_over_window_state_cleaning_inner(cache_policy: OverWindowCachePoli
         state_order_keys(store.clone(), &calls).await,
         vec![60, 70, 80]
     );
+}
+
+/// Watermarks on the partition key column are always forwarded. Watermarks on the order key
+/// column are forwarded only if no window frame extends to following rows. Other watermarks are
+/// dropped.
+#[tokio::test]
+async fn test_over_window_watermark_forwarding() {
+    let lag = WindowFuncCall {
+        kind: WindowFuncKind::Aggregate(PbAggKind::FirstValue.into()),
+        return_type: DataType::Int32,
+        args: AggArgs::from_iter([(DataType::Int32, 3)]),
+        ignore_nulls: false,
+        frame: Frame::rows(FrameBound::Preceding(1), FrameBound::Preceding(1)),
+    };
+    let lead = WindowFuncCall {
+        kind: WindowFuncKind::Aggregate(PbAggKind::FirstValue.into()),
+        return_type: DataType::Int32,
+        args: AggArgs::from_iter([(DataType::Int32, 3)]),
+        ignore_nulls: false,
+        frame: Frame::rows(FrameBound::Following(1), FrameBound::Following(1)),
+    };
+
+    // `lag` only: the frame has no following rows, so watermarks on both the order key column
+    // and the partition key column are forwarded.
+    {
+        let (mut tx, mut stream) =
+            create_executor(vec![lag.clone()], MemoryStateStore::new()).await;
+        tx.push_barrier(test_epoch(1), false);
+        stream.expect_barrier().await;
+
+        // Changes caused by chunks before the watermark are emitted before the watermark.
+        tx.push_chunk(StreamChunk::from_pretty(
+            " I  T  I   i
+            + 10 p1 100 10
+            + 20 p1 101 11",
+        ));
+        tx.push_int64_watermark(0, 15);
+        assert_eq!(
+            stream.expect_chunk().await,
+            StreamChunk::from_pretty(
+                " I  T  I   i  i
+                + 10 p1 100 10 .
+                + 20 p1 101 11 10",
+            )
+        );
+        let watermark = stream.expect_watermark().await;
+        assert_eq!(watermark.col_idx, 0);
+        assert_eq!(watermark.val, ScalarImpl::Int64(15));
+
+        tx.push_watermark(1, DataType::Varchar, "p1".into());
+        let watermark = stream.expect_watermark().await;
+        assert_eq!(watermark.col_idx, 1);
+        assert_eq!(watermark.val, ScalarImpl::from("p1"));
+
+        // Watermarks on other columns are dropped.
+        tx.push_watermark(3, DataType::Int32, 42i32.into());
+        tx.push_barrier(test_epoch(2), false);
+        stream.expect_barrier().await;
+    }
+
+    // `lag` + `lead`: the `lead` frame has following rows, so only watermarks on the partition
+    // key column are forwarded.
+    {
+        let (mut tx, mut stream) = create_executor(vec![lag, lead], MemoryStateStore::new()).await;
+        tx.push_barrier(test_epoch(1), false);
+        stream.expect_barrier().await;
+
+        tx.push_int64_watermark(0, 15);
+        tx.push_watermark(1, DataType::Varchar, "p1".into());
+        let watermark = stream.expect_watermark().await;
+        assert_eq!(watermark.col_idx, 1);
+        assert_eq!(watermark.val, ScalarImpl::from("p1"));
+
+        tx.push_barrier(test_epoch(2), false);
+        stream.expect_barrier().await;
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## Summary

The general (non-EOWC) `OverWindowExecutor` drops every watermark it receives (#11504). As a result, any watermark-driven mechanism downstream of a window function stops working: e.g. a hash join on the event time column after `lag(x) OVER (PARTITION BY k ORDER BY event_time)` can never clean its state, because the join needs watermarks from both sides.

This PR forwards watermarks through `StreamOverWindow` / `OverWindowExecutor` when it's safe to do so, without changing output semantics or adding latency. It's the follow-up of #26917 mentioned there.

## Design

A watermark `wm` on a column promises that no row with the column value `< wm` will arrive again. The over window operator can forward it only if the outputs of rows with the column value `< wm` can never change again, i.e. if a new (or deleted) row can only affect rows that are not "smaller" than itself in that column.

- **Partition key columns**: always forwarded. A row can only affect rows in the same partition, which share the same partition key values.
- **First `ORDER BY` column**: forwarded iff `can_forward_watermark_on_order_key` holds for all window frames (which share the same `PARTITION BY` / `ORDER BY`):
  - `ASC` (NULLs last) and no frame extends to following rows (no `lead`, no `... FOLLOWING` end bound, no `SESSION`), or
  - `DESC` (NULLs first) and no frame extends to preceding rows.

  NULLs must be ordered as the largest values because rows with NULL in the column are not covered by the watermark guarantee, so they must also land on the "larger" side. This is the same requirement as the state cleaning in #26917.
- **Other columns** (non-first order key columns, other input columns): dropped, since a new row can affect rows with arbitrary values in them.

The rule lives in `risingwave_expr::window_function::can_forward_watermark_on_order_key` and is shared by the optimizer (`StreamOverWindow::new` derives `watermark_columns` and now shows `output_watermarks` in plans) and the executor (`OverWindowExecutor` computes the forwardable column set at construction).

The executor processes each chunk fully before reading the next message, so when a watermark arrives, all changes caused by earlier rows have already been emitted; it's forwarded right away. Forwarding does not depend on the input being append-only: for retract inputs, the argument applies to deletes and updates the same way, as long as the input records themselves respect the watermark. `StreamEowcOverWindow` is unchanged.

## Tests

- Unit test of `can_forward_watermark_on_order_key` covering `ROWS` / `RANGE` / `SESSION` frames, both directions and NULL ordering.
- Executor integration test `test_over_window_watermark_forwarding`: chunk outputs are emitted before the watermark, order key watermarks are forwarded for `lag` and dropped once `lead` is present, partition key watermarks are always forwarded, others are dropped.
- Planner tests in `over_window_function.yaml` for each branch of the rule, plus a downstream join whose state cleaning on the watermark column becomes possible.
- e2e `over_window/watermark_forwarding.slt`: the forwarded watermark drives the state cleaning of a downstream hash join on the watermark column, which requires watermarks from both sides. The committed watermarks of both join state tables (`rw_catalog.rw_hummock_table_watermark`) appear and advance only when both sides have delivered, while results stay correct.

Related: #11504, #26917


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming over-window operations now forward eligible watermarks from partition and order columns.
  * Improved watermark propagation enables downstream state, including join state, to be cleaned up sooner while preserving correctness across different window frames and ordering options.
  * Stream plans now expose applicable watermark information for materialized results.

* **Tests**
  * Added coverage for watermark forwarding, state cleanup, window frame behavior, ordering, and downstream joins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->