### PR TITLE
feat(stream): forward watermarks through TopN executors

### DIFF
--- a/e2e_test/streaming/eowc/eowc_top_n_watermark_forwarding.slt
+++ b/e2e_test/streaming/eowc/eowc_top_n_watermark_forwarding.slt
@@ -1,0 +1,157 @@
+# Watermark forwarding of TopN executors: a watermark on the first `ORDER BY` column ordered
+# `ASC NULLS LAST` is forwarded by both plain and group TopN, and watermarks on any group key
+# column are forwarded by group TopN. The forwarded watermarks make the queries below eligible
+# for EMIT ON WINDOW CLOSE, where the `EowcSort` after the TopN only emits rows whose value in the
+# watermark column is below the watermark, i.e. rows that will never be evicted from the top N.
+
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+SET streaming_parallelism = 1;
+
+statement ok
+CREATE TABLE t (k INT, ts TIMESTAMP, v INT, WATERMARK FOR ts AS ts - INTERVAL '5 minutes') APPEND ONLY;
+
+statement ok
+SET streaming_parallelism = 0;
+
+# Plain TopN ordered by the watermark column `ts` forwards the watermark on `ts`.
+statement ok
+CREATE MATERIALIZED VIEW mv_top_n AS
+SELECT ts, v FROM (SELECT * FROM t ORDER BY ts LIMIT 3)
+EMIT ON WINDOW CLOSE;
+
+# Group TopN forwards the watermark on `window_start`, the second group key column.
+statement ok
+CREATE MATERIALIZED VIEW mv_group_top_n AS
+SELECT k, window_start, v FROM (
+    SELECT *, row_number() OVER (PARTITION BY k, window_start ORDER BY v) AS rn
+    FROM tumble(t, ts, INTERVAL '1 hour')
+)
+WHERE rn <= 1
+EMIT ON WINDOW CLOSE;
+
+# Group TopN ordered by the watermark column `ts` forwards the watermark on `ts`.
+statement ok
+CREATE MATERIALIZED VIEW mv_first_per_key AS
+SELECT k, ts, v FROM (
+    SELECT *, row_number() OVER (PARTITION BY k ORDER BY ts) AS rn
+    FROM t
+)
+WHERE rn <= 1
+EMIT ON WINDOW CLOSE;
+
+# The watermark on `ts` is not forwarded when it's not the first `ORDER BY` column, or when it's
+# ordered `DESC`.
+statement error cannot be executed in Emit-On-Window-Close mode
+CREATE MATERIALIZED VIEW mv_err AS
+SELECT ts, v FROM (SELECT * FROM t ORDER BY v, ts LIMIT 3)
+EMIT ON WINDOW CLOSE;
+
+statement error cannot be executed in Emit-On-Window-Close mode
+CREATE MATERIALIZED VIEW mv_err AS
+SELECT ts, v FROM (SELECT * FROM t ORDER BY ts DESC LIMIT 3)
+EMIT ON WINDOW CLOSE;
+
+# Watermark: 16:53, i.e. `window_start` watermark 16:00.
+statement ok
+INSERT INTO t VALUES (1, '2023-05-06 16:51:00', 5), (2, '2023-05-06 16:58:00', 9);
+
+query TI
+SELECT * FROM mv_top_n ORDER BY ts;
+----
+2023-05-06 16:51:00 5
+
+query ITI
+SELECT * FROM mv_group_top_n ORDER BY window_start, k;
+----
+
+query ITI
+SELECT * FROM mv_first_per_key ORDER BY k;
+----
+1 2023-05-06 16:51:00 5
+
+# Watermark: 17:25, i.e. `window_start` watermark 17:00. The row at 17:30 is now in the top 3 but
+# stays above the watermark, so it's held back by the `EowcSort`.
+statement ok
+INSERT INTO t VALUES (1, '2023-05-06 17:30:00', 4);
+
+query TI
+SELECT * FROM mv_top_n ORDER BY ts;
+----
+2023-05-06 16:51:00 5
+2023-05-06 16:58:00 9
+
+query ITI
+SELECT * FROM mv_group_top_n ORDER BY window_start, k;
+----
+1 2023-05-06 16:00:00 5
+2 2023-05-06 16:00:00 9
+
+query ITI
+SELECT * FROM mv_first_per_key ORDER BY k;
+----
+1 2023-05-06 16:51:00 5
+2 2023-05-06 16:58:00 9
+
+# Watermark: 17:35. The row at 17:26 evicts the held-back row at 17:30 from the top 3, so the
+# latter never shows up in the output. In window 17:00, `v = 2` evicts `v = 4` for `k = 1`.
+statement ok
+INSERT INTO t VALUES (2, '2023-05-06 17:26:00', 7), (1, '2023-05-06 17:40:00', 2);
+
+query TI
+SELECT * FROM mv_top_n ORDER BY ts;
+----
+2023-05-06 16:51:00 5
+2023-05-06 16:58:00 9
+2023-05-06 17:26:00 7
+
+query ITI
+SELECT * FROM mv_group_top_n ORDER BY window_start, k;
+----
+1 2023-05-06 16:00:00 5
+2 2023-05-06 16:00:00 9
+
+query ITI
+SELECT * FROM mv_first_per_key ORDER BY k;
+----
+1 2023-05-06 16:51:00 5
+2 2023-05-06 16:58:00 9
+
+# Watermark: 18:05, i.e. `window_start` watermark 18:00, which closes window 17:00.
+statement ok
+INSERT INTO t VALUES (1, '2023-05-06 18:10:00', 8);
+
+query TI
+SELECT * FROM mv_top_n ORDER BY ts;
+----
+2023-05-06 16:51:00 5
+2023-05-06 16:58:00 9
+2023-05-06 17:26:00 7
+
+query ITI
+SELECT * FROM mv_group_top_n ORDER BY window_start, k;
+----
+1 2023-05-06 16:00:00 5
+2 2023-05-06 16:00:00 9
+1 2023-05-06 17:00:00 2
+2 2023-05-06 17:00:00 7
+
+query ITI
+SELECT * FROM mv_first_per_key ORDER BY k;
+----
+1 2023-05-06 16:51:00 5
+2 2023-05-06 16:58:00 9
+
+statement ok
+DROP MATERIALIZED VIEW mv_first_per_key;
+
+statement ok
+DROP MATERIALIZED VIEW mv_group_top_n;
+
+statement ok
+DROP MATERIALIZED VIEW mv_top_n;
+
+statement ok
+DROP TABLE t;

--- a/src/common/src/util/sort_util.rs
+++ b/src/common/src/util/sort_util.rs
@@ -298,6 +298,26 @@ impl fmt::Debug for ColumnOrder {
     }
 }
 
+/// Returns the index of the first `ORDER BY` column of a streaming TopN operator if watermarks on
+/// that column can be forwarded by the operator, i.e. when the column is ordered `ASC NULLS LAST`.
+///
+/// A watermark `wm` on a column promises that no row with the column value `< wm` will ever arrive
+/// again. To forward it, the operator must guarantee that it will never emit any change (insertion,
+/// deletion or update) to rows with the column value `< wm` afterwards. A row arriving at a TopN
+/// operator can only change its own output and the output of rows ordered *after* it, by evicting
+/// them from or restoring them into the top N. When the first `ORDER BY` column is ordered
+/// `ASC NULLS LAST`, all such rows are not smaller than the arriving row in that column, which is
+/// `>= wm` (or NULL, treated as the largest) by the watermark guarantee. With `DESC` or
+/// `ASC NULLS FIRST` ordering, an arriving row may evict rows with values `< wm` instead, so
+/// watermarks on the column must be dropped.
+///
+/// The rule is shared by the optimizer and the executors so that they stay in sync.
+pub fn topn_watermark_forwardable_order_key(order_by: &[ColumnOrder]) -> Option<usize> {
+    let first = order_by.first()?;
+    (first.order_type.is_ascending() && first.order_type.nulls_are_largest())
+        .then_some(first.column_index)
+}
+
 pub struct ColumnOrderDisplay<'a> {
     pub column_order: &'a ColumnOrder,
     pub input_schema: &'a Schema,
@@ -859,5 +879,32 @@ mod tests {
                 &[OrderType::default()]
             )
         )
+    }
+
+    #[test]
+    fn test_topn_watermark_forwardable_order_key() {
+        assert_eq!(topn_watermark_forwardable_order_key(&[]), None);
+        for order_type in [OrderType::ascending(), OrderType::ascending_nulls_last()] {
+            assert_eq!(
+                topn_watermark_forwardable_order_key(&[
+                    ColumnOrder::new(2, order_type),
+                    ColumnOrder::new(0, OrderType::descending()),
+                ]),
+                Some(2)
+            );
+        }
+        for order_type in [
+            OrderType::descending(),
+            OrderType::descending_nulls_last(),
+            OrderType::ascending_nulls_first(),
+        ] {
+            assert_eq!(
+                topn_watermark_forwardable_order_key(&[
+                    ColumnOrder::new(2, order_type),
+                    ColumnOrder::new(0, OrderType::ascending()),
+                ]),
+                None
+            );
+        }
     }
 }

--- a/src/frontend/planner_test/tests/testdata/input/emit_on_window_close.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/emit_on_window_close.yaml
@@ -98,3 +98,32 @@
     from t;
   expected_outputs:
     - eowc_stream_dist_plan
+- id: top n ordered by watermark column in eowc mode
+  sql: |
+    create table t (tm timestamp, foo int, bar int, watermark for tm as tm - interval '5 minutes') append only;
+    select tm, foo from (select * from t order by tm limit 10);
+  expected_outputs:
+    - eowc_stream_plan
+- id: top n ordered by watermark column desc cannot run in eowc mode
+  sql: |
+    create table t (tm timestamp, foo int, bar int, watermark for tm as tm - interval '5 minutes') append only;
+    select tm, foo from (select * from t order by tm desc limit 10);
+  expected_outputs:
+    - eowc_stream_error
+- id: group top n with watermark on the second group key column in eowc mode
+  sql: |
+    create table t (tm timestamp, foo int, bar int, watermark for tm as tm - interval '5 minutes') append only;
+    select foo, window_start, bar from (
+      select *, row_number() over (partition by foo, window_start order by bar) as rn
+      from tumble(t, tm, interval '1 hour')
+    ) where rn <= 1;
+  expected_outputs:
+    - eowc_stream_plan
+- id: group top n ordered by watermark column in eowc mode
+  sql: |
+    create table t (tm timestamp, foo int, bar int, watermark for tm as tm - interval '5 minutes') append only;
+    select foo, tm, bar from (
+      select *, row_number() over (partition by foo order by tm) as rn from t
+    ) where rn <= 1;
+  expected_outputs:
+    - eowc_stream_plan

--- a/src/frontend/planner_test/tests/testdata/input/watermark.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/watermark.yaml
@@ -135,3 +135,39 @@
     select mv1.ts1 as mv1ts1, mv1.ts2 as mv1ts2, mv2.ts1 as mv2ts1, mv2.ts2 as mv2ts2 from mv1, mv2 where mv1.ts1 = mv2.ts1 and mv1.ts2 >= mv2.ts2 and mv1.ts2 <= mv2.ts2 + INTERVAL '1' HOUR;
   expected_outputs:
   - stream_dist_plan
+- name: two-phase top n ordered by watermark column
+  sql: |
+    create table t (ts timestamp with time zone, v1 int, watermark for ts as ts - INTERVAL '1' SECOND) append only;
+    select * from (select ts, count(*) as cnt from t group by ts) order by ts limit 10;
+  expected_outputs:
+  - stream_plan
+- name: top n ordered by watermark column desc
+  sql: |
+    create table t (ts timestamp with time zone, v1 int, watermark for ts as ts - INTERVAL '1' SECOND) append only;
+    select * from (select ts, count(*) as cnt from t group by ts) order by ts desc limit 10;
+  expected_outputs:
+  - stream_plan
+- name: top n with watermark column not being the first order by column
+  sql: |
+    create table t (ts timestamp with time zone, v1 int, watermark for ts as ts - INTERVAL '1' SECOND) append only;
+    select * from t order by v1, ts limit 10;
+  expected_outputs:
+  - stream_plan
+- name: group top n with watermark on the second group key column
+  sql: |
+    create table t (ts timestamp with time zone, v1 int, v2 int, watermark for ts as ts - INTERVAL '1' SECOND) append only;
+    select * from (select *, row_number() over (partition by v1, ts order by v2) as rn from t) where rn <= 1;
+  expected_outputs:
+  - stream_plan
+- name: group top n ordered by watermark column
+  sql: |
+    create table t (ts timestamp with time zone, v1 int, v2 int, watermark for ts as ts - INTERVAL '1' SECOND) append only;
+    select * from (select *, row_number() over (partition by v1 order by ts) as rn from t) where rn <= 1;
+  expected_outputs:
+  - stream_plan
+- name: group top n ordered by watermark column desc
+  sql: |
+    create table t (ts timestamp with time zone, v1 int, v2 int, watermark for ts as ts - INTERVAL '1' SECOND) append only;
+    select * from (select *, row_number() over (partition by v1 order by ts desc) as rn from t) where rn <= 1;
+  expected_outputs:
+  - stream_plan

--- a/src/frontend/planner_test/tests/testdata/output/emit_on_window_close.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/emit_on_window_close.yaml
@@ -408,3 +408,48 @@
 
     Table 4294967294 { columns: [ lag1, lag2, _row_id, b, _rw_timestamp ], primary key: [ $2 ASC, $3 ASC ], value indices: [ 0, 1, 2, 3 ], distribution key: [ 3 ], read pk prefix len hint: 2 }
 
+- id: top n ordered by watermark column in eowc mode
+  sql: |
+    create table t (tm timestamp, foo int, bar int, watermark for tm as tm - interval '5 minutes') append only;
+    select tm, foo from (select * from t order by tm limit 10);
+  eowc_stream_plan: |-
+    StreamMaterialize { columns: [tm, foo, t._row_id(hidden)], stream_key: [t._row_id], pk_columns: [t._row_id], pk_conflict: NoCheck, watermark_columns: [tm] }
+    └─StreamEowcSort { sort_column: t.tm }
+      └─StreamTopN [append_only] { order: [t.tm ASC], limit: 10, offset: 0, output_watermarks: [[t.tm]] }
+        └─StreamExchange { dist: Single }
+          └─StreamTableScan { table: t, columns: [t.tm, t.foo, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- id: top n ordered by watermark column desc cannot run in eowc mode
+  sql: |
+    create table t (tm timestamp, foo int, bar int, watermark for tm as tm - interval '5 minutes') append only;
+    select tm, foo from (select * from t order by tm desc limit 10);
+  eowc_stream_error: |-
+    Not supported: The query cannot be executed in Emit-On-Window-Close mode.
+    HINT: Try define a watermark column in the source, or avoid aggregation without GROUP BY
+- id: group top n with watermark on the second group key column in eowc mode
+  sql: |
+    create table t (tm timestamp, foo int, bar int, watermark for tm as tm - interval '5 minutes') append only;
+    select foo, window_start, bar from (
+      select *, row_number() over (partition by foo, window_start order by bar) as rn
+      from tumble(t, tm, interval '1 hour')
+    ) where rn <= 1;
+  eowc_stream_plan: |-
+    StreamMaterialize { columns: [foo, window_start, bar], stream_key: [foo, window_start], pk_columns: [foo, window_start], pk_conflict: NoCheck, watermark_columns: [window_start] }
+    └─StreamEowcSort { sort_column: $expr1 }
+      └─StreamProject { exprs: [t.foo, $expr1, t.bar], output_watermarks: [[$expr1]] }
+        └─StreamGroupTopN [append_only] { order: [t.bar ASC], limit: 1, offset: 0, group_key: [t.foo, $expr1], output_watermarks: [[$expr1]] }
+          └─StreamExchange { dist: HashShard(t.foo, $expr1) }
+            └─StreamProject { exprs: [t.foo, t.bar, TumbleStart(t.tm, '01:00:00':Interval) as $expr1, t._row_id], output_watermarks: [[$expr1]] }
+              └─StreamTableScan { table: t, columns: [t.tm, t.foo, t.bar, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- id: group top n ordered by watermark column in eowc mode
+  sql: |
+    create table t (tm timestamp, foo int, bar int, watermark for tm as tm - interval '5 minutes') append only;
+    select foo, tm, bar from (
+      select *, row_number() over (partition by foo order by tm) as rn from t
+    ) where rn <= 1;
+  eowc_stream_plan: |-
+    StreamMaterialize { columns: [foo, tm, bar], stream_key: [foo], pk_columns: [foo], pk_conflict: NoCheck, watermark_columns: [tm] }
+    └─StreamEowcSort { sort_column: t.tm }
+      └─StreamProject { exprs: [t.foo, t.tm, t.bar], output_watermarks: [[t.tm]] }
+        └─StreamGroupTopN [append_only] { order: [t.tm ASC], limit: 1, offset: 0, group_key: [t.foo], output_watermarks: [[t.tm]] }
+          └─StreamExchange { dist: HashShard(t.foo) }
+            └─StreamTableScan { table: t, columns: [t.tm, t.foo, t.bar, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }

--- a/src/frontend/planner_test/tests/testdata/output/watermark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/watermark.yaml
@@ -366,3 +366,73 @@
 
     Table 4294967294 { columns: [ mv1ts1, mv1ts2, mv2ts1, mv2ts2, mv1.t1._row_id, mv2.t2._row_id, _rw_timestamp ], primary key: [ $4 ASC, $5 ASC, $0 ASC ], value indices: [ 0, 1, 2, 3, 4, 5 ], distribution key: [ 0, 4, 5 ], read pk prefix len hint: 3 }
 
+- name: two-phase top n ordered by watermark column
+  sql: |
+    create table t (ts timestamp with time zone, v1 int, watermark for ts as ts - INTERVAL '1' SECOND) append only;
+    select * from (select ts, count(*) as cnt from t group by ts) order by ts limit 10;
+  stream_plan: |-
+    StreamMaterialize { columns: [ts, cnt], stream_key: [ts], pk_columns: [ts], pk_conflict: NoCheck, watermark_columns: [ts] }
+    └─StreamProject { exprs: [t.ts, count], output_watermarks: [[t.ts]] }
+      └─StreamTopN { order: [t.ts ASC], limit: 10, offset: 0, output_watermarks: [[t.ts]] }
+        └─StreamExchange { dist: Single }
+          └─StreamGroupTopN { order: [t.ts ASC], limit: 10, offset: 0, group_key: [_vnode], output_watermarks: [[t.ts]] }
+            └─StreamProject { exprs: [t.ts, count, Vnode(t.ts) as _vnode], output_watermarks: [[t.ts]] }
+              └─StreamHashAgg [append_only] { group_key: [t.ts], aggs: [count], output_watermarks: [[t.ts]] }
+                └─StreamExchange { dist: HashShard(t.ts) }
+                  └─StreamTableScan { table: t, columns: [t.ts, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: top n ordered by watermark column desc
+  sql: |
+    create table t (ts timestamp with time zone, v1 int, watermark for ts as ts - INTERVAL '1' SECOND) append only;
+    select * from (select ts, count(*) as cnt from t group by ts) order by ts desc limit 10;
+  stream_plan: |-
+    StreamMaterialize { columns: [ts, cnt], stream_key: [ts], pk_columns: [ts], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [t.ts, count] }
+      └─StreamTopN { order: [t.ts DESC], limit: 10, offset: 0 }
+        └─StreamExchange { dist: Single }
+          └─StreamGroupTopN { order: [t.ts DESC], limit: 10, offset: 0, group_key: [_vnode] }
+            └─StreamProject { exprs: [t.ts, count, Vnode(t.ts) as _vnode], output_watermarks: [[t.ts]] }
+              └─StreamHashAgg [append_only] { group_key: [t.ts], aggs: [count], output_watermarks: [[t.ts]] }
+                └─StreamExchange { dist: HashShard(t.ts) }
+                  └─StreamTableScan { table: t, columns: [t.ts, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: top n with watermark column not being the first order by column
+  sql: |
+    create table t (ts timestamp with time zone, v1 int, watermark for ts as ts - INTERVAL '1' SECOND) append only;
+    select * from t order by v1, ts limit 10;
+  stream_plan: |-
+    StreamMaterialize { columns: [ts, v1, t._row_id(hidden)], stream_key: [t._row_id], pk_columns: [v1, ts, t._row_id], pk_conflict: NoCheck }
+    └─StreamTopN [append_only] { order: [t.v1 ASC, t.ts ASC], limit: 10, offset: 0 }
+      └─StreamExchange { dist: Single }
+        └─StreamTableScan { table: t, columns: [t.ts, t.v1, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: group top n with watermark on the second group key column
+  sql: |
+    create table t (ts timestamp with time zone, v1 int, v2 int, watermark for ts as ts - INTERVAL '1' SECOND) append only;
+    select * from (select *, row_number() over (partition by v1, ts order by v2) as rn from t) where rn <= 1;
+  stream_plan: |-
+    StreamMaterialize { columns: [ts, v1, v2, rn], stream_key: [v1, ts], pk_columns: [v1, ts], pk_conflict: NoCheck }
+    └─StreamOverWindow { window_functions: [row_number() OVER(PARTITION BY t.v1, t.ts ORDER BY t.v2 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
+      └─StreamProject { exprs: [t.ts, t.v1, t.v2], output_watermarks: [[t.ts]] }
+        └─StreamGroupTopN [append_only] { order: [t.v2 ASC], limit: 1, offset: 0, group_key: [t.v1, t.ts], output_watermarks: [[t.ts]] }
+          └─StreamExchange { dist: HashShard(t.ts, t.v1) }
+            └─StreamTableScan { table: t, columns: [t.ts, t.v1, t.v2, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: group top n ordered by watermark column
+  sql: |
+    create table t (ts timestamp with time zone, v1 int, v2 int, watermark for ts as ts - INTERVAL '1' SECOND) append only;
+    select * from (select *, row_number() over (partition by v1 order by ts) as rn from t) where rn <= 1;
+  stream_plan: |-
+    StreamMaterialize { columns: [ts, v1, v2, rn], stream_key: [v1], pk_columns: [v1], pk_conflict: NoCheck }
+    └─StreamOverWindow { window_functions: [row_number() OVER(PARTITION BY t.v1 ORDER BY t.ts ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
+      └─StreamProject { exprs: [t.ts, t.v1, t.v2], output_watermarks: [[t.ts]] }
+        └─StreamGroupTopN [append_only] { order: [t.ts ASC], limit: 1, offset: 0, group_key: [t.v1], output_watermarks: [[t.ts]] }
+          └─StreamExchange { dist: HashShard(t.v1) }
+            └─StreamTableScan { table: t, columns: [t.ts, t.v1, t.v2, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }
+- name: group top n ordered by watermark column desc
+  sql: |
+    create table t (ts timestamp with time zone, v1 int, v2 int, watermark for ts as ts - INTERVAL '1' SECOND) append only;
+    select * from (select *, row_number() over (partition by v1 order by ts desc) as rn from t) where rn <= 1;
+  stream_plan: |-
+    StreamMaterialize { columns: [ts, v1, v2, rn], stream_key: [v1], pk_columns: [v1], pk_conflict: NoCheck }
+    └─StreamOverWindow { window_functions: [row_number() OVER(PARTITION BY t.v1 ORDER BY t.ts DESC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
+      └─StreamProject { exprs: [t.ts, t.v1, t.v2] }
+        └─StreamGroupTopN [append_only] { order: [t.ts DESC], limit: 1, offset: 0, group_key: [t.v1] }
+          └─StreamExchange { dist: HashShard(t.v1) }
+            └─StreamTableScan { table: t, columns: [t.ts, t.v1, t.v2, t._row_id], stream_scan_type: SnapshotBackfill, stream_key: [t._row_id], pk: [_row_id], dist: UpstreamHashShard(t._row_id) }

--- a/src/frontend/src/optimizer/plan_node/stream_group_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_group_topn.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use pretty_xmlish::XmlNode;
+use risingwave_common::util::sort_util::topn_watermark_forwardable_order_key;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
 use super::generic::{DistillUnit, TopNLimit};
@@ -44,13 +45,17 @@ impl StreamGroupTopN {
 
         let input = &core.input;
 
-        // NOTE: The executor only forwards watermarks on the first group-by column.
-        // Keep the optimizer in sync so EOWC won't be enabled on unsupported plans.
-        //
-        // TODO: Actually it's also safe to forward watermarks on
-        // - other group key columns,
-        // - ascending ORDER BY columns on append-only input.
-        let watermark_columns = input.watermark_columns().retain_clone(&[core.group_key[0]]);
+        // The executor forwards watermarks on group key columns, and on the first `ORDER BY`
+        // column if it's ordered `ASC NULLS LAST`. Keep the optimizer in sync so EOWC won't be
+        // enabled on unsupported plans. See `topn_watermark_forwardable_order_key` for the
+        // reasoning.
+        let watermark_columns = {
+            let mut cols = core.group_key.clone();
+            cols.extend(topn_watermark_forwardable_order_key(
+                &core.order.column_orders,
+            ));
+            input.watermark_columns().retain_clone(&cols)
+        };
 
         let mut stream_key = core
             .stream_key()

--- a/src/frontend/src/optimizer/plan_node/stream_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_topn.rs
@@ -15,11 +15,12 @@
 use std::assert_matches;
 
 use pretty_xmlish::XmlNode;
+use risingwave_common::util::sort_util::topn_watermark_forwardable_order_key;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
 use super::generic::{DistillUnit, TopNLimit};
 use super::stream::prelude::*;
-use super::utils::{Distill, plan_node_name};
+use super::utils::{Distill, plan_node_name, watermark_pretty};
 use super::{
     ExprRewritable, PlanBase, PlanTreeNodeUnary, StreamNode, StreamPlanRef as PlanRef, generic,
 };
@@ -41,7 +42,14 @@ impl StreamTopN {
         let input = &core.input;
         assert_matches!(input.distribution(), Distribution::Single);
         reject_upsert_input!(input);
-        let watermark_columns = WatermarkColumns::new();
+        // The executor only forwards watermarks on the first `ORDER BY` column ordered
+        // `ASC NULLS LAST`. Keep the optimizer in sync so EOWC won't be enabled on unsupported
+        // plans. See `topn_watermark_forwardable_order_key` for the reasoning.
+        let watermark_columns =
+            match topn_watermark_forwardable_order_key(&core.order.column_orders) {
+                Some(col_idx) => input.watermark_columns().retain_clone(&[col_idx]),
+                None => WatermarkColumns::new(),
+            };
 
         let base = PlanBase::new_stream_with_core(
             &core,
@@ -73,7 +81,11 @@ impl Distill for StreamTopN {
         let name = plan_node_name!("StreamTopN",
             { "append_only", self.input().append_only() },
         );
-        self.core.distill_with_name(name)
+        let mut node = self.core.distill_with_name(name);
+        if let Some(ow) = watermark_pretty(self.base.watermark_columns(), self.schema()) {
+            node.fields.push(("output_watermarks".into(), ow));
+        }
+        node
     }
 }
 

--- a/src/stream/src/executor/top_n/group_top_n.rs
+++ b/src/stream/src/executor/top_n/group_top_n.rs
@@ -20,7 +20,7 @@ use risingwave_common::hash::HashKey;
 use risingwave_common::row::{RowDeserializer, RowExt};
 use risingwave_common::util::epoch::EpochPair;
 use risingwave_common::util::iter_util::ZipEqDebug;
-use risingwave_common::util::sort_util::ColumnOrder;
+use risingwave_common::util::sort_util::{ColumnOrder, topn_watermark_forwardable_order_key};
 
 use super::top_n_cache::TopNCacheTrait;
 use super::utils::*;
@@ -79,6 +79,9 @@ pub struct InnerGroupTopNExecutor<K: HashKey, S: StateStore, const WITH_TIES: bo
     /// which column we used to group the data.
     group_by: Vec<usize>,
 
+    /// The `ORDER BY` column whose watermarks can be forwarded, if any.
+    watermark_order_key: Option<usize>,
+
     /// group key -> cache for this group
     caches: GroupTopNCache<K, WITH_TIES>,
 
@@ -124,6 +127,7 @@ impl<K: HashKey, S: StateStore, const WITH_TIES: bool> InnerGroupTopNExecutor<K,
             limit: offset_and_limit.1,
             managed_state,
             storage_key_indices: storage_key.into_iter().map(|op| op.column_index).collect(),
+            watermark_order_key: topn_watermark_forwardable_order_key(&order_by),
             group_by,
             caches: GroupTopNCache::new(watermark_epoch, metrics_info),
             cache_key_serde,
@@ -265,11 +269,17 @@ where
 
     async fn handle_watermark(&mut self, watermark: Watermark) -> Option<Watermark> {
         if watermark.col_idx == self.group_by[0] {
+            // The state table is ordered by the first group key column, so the watermark on it can
+            // also be used to clean up the states of the groups below it.
             self.managed_state.update_watermark(watermark.val.clone());
-            Some(watermark)
-        } else {
-            None
         }
+        // A row can only change the output of its own group, so watermarks on group key columns
+        // can always be forwarded. Watermarks on the first `ORDER BY` column can be forwarded if
+        // it's ordered `ASC NULLS LAST`. See `topn_watermark_forwardable_order_key` for the
+        // reasoning.
+        (self.group_by.contains(&watermark.col_idx)
+            || Some(watermark.col_idx) == self.watermark_order_key)
+            .then_some(watermark)
     }
 }
 
@@ -719,5 +729,95 @@ mod tests {
 
         // no output chunk for the last input chunk
         top_n.expect_barrier().await;
+    }
+
+    /// Watermarks on group key columns are always forwarded (the first one also cleans the state),
+    /// and the watermark on the first `ORDER BY` column is forwarded only when it's ordered
+    /// `ASC NULLS LAST`.
+    #[tokio::test]
+    async fn test_watermark_forwarding() {
+        let asc = OrderType::ascending();
+        let desc = OrderType::descending();
+        // (group_by, order_by, storage_key, forwarded watermark columns)
+        let cases = [
+            (
+                vec![1],
+                vec![ColumnOrder::new(2, asc)],
+                vec![
+                    ColumnOrder::new(1, asc),
+                    ColumnOrder::new(2, asc),
+                    ColumnOrder::new(0, asc),
+                ],
+                vec![1, 2],
+            ),
+            (
+                vec![1],
+                vec![ColumnOrder::new(2, desc)],
+                vec![
+                    ColumnOrder::new(1, asc),
+                    ColumnOrder::new(2, desc),
+                    ColumnOrder::new(0, asc),
+                ],
+                vec![1],
+            ),
+            (
+                vec![1, 2],
+                vec![ColumnOrder::new(0, asc)],
+                vec![
+                    ColumnOrder::new(1, asc),
+                    ColumnOrder::new(2, asc),
+                    ColumnOrder::new(0, asc),
+                ],
+                vec![0, 1, 2],
+            ),
+        ];
+        for (group_by, order_by, storage_key, forwarded) in cases {
+            let mut messages = vec![
+                Message::Barrier(Barrier::new_test_barrier(test_epoch(1))),
+                Message::Chunk(create_stream_chunks().swap_remove(0)),
+            ];
+            messages.extend((0..3).map(|col_idx| {
+                Message::Watermark(Watermark::new(
+                    col_idx,
+                    DataType::Int64,
+                    ScalarImpl::Int64(5),
+                ))
+            }));
+            messages.push(Message::Barrier(Barrier::new_test_barrier(test_epoch(2))));
+            let source =
+                MockSource::with_messages(messages).into_executor(create_schema(), stream_key());
+            let state_table = create_in_memory_state_table(
+                &[DataType::Int64, DataType::Int64, DataType::Int64],
+                &storage_key.iter().map(|o| o.order_type).collect::<Vec<_>>(),
+                &storage_key
+                    .iter()
+                    .map(|o| o.column_index)
+                    .collect::<Vec<_>>(),
+            )
+            .await;
+            let schema = source.schema().clone();
+            let top_n = GroupTopNExecutor::<SerializedKey, MemoryStateStore, false>::new(
+                source,
+                ActorContext::for_test(0),
+                schema,
+                storage_key,
+                (0, 2),
+                order_by,
+                group_by,
+                state_table,
+                Arc::new(AtomicU64::new(0)),
+            )
+            .unwrap();
+            let mut top_n = top_n.boxed().execute();
+
+            top_n.expect_barrier().await;
+            top_n.expect_chunk().await;
+            for col_idx in forwarded {
+                let watermark = top_n.expect_watermark().await;
+                assert_eq!(watermark.col_idx, col_idx);
+                assert_eq!(watermark.val, ScalarImpl::Int64(5));
+            }
+            top_n.expect_barrier().await;
+        }
     }
 }

--- a/src/stream/src/executor/top_n/group_top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n/group_top_n_appendonly.rs
@@ -19,7 +19,7 @@ use risingwave_common::hash::HashKey;
 use risingwave_common::row::{RowDeserializer, RowExt};
 use risingwave_common::util::epoch::EpochPair;
 use risingwave_common::util::iter_util::ZipEqDebug;
-use risingwave_common::util::sort_util::ColumnOrder;
+use risingwave_common::util::sort_util::{ColumnOrder, topn_watermark_forwardable_order_key};
 
 use super::group_top_n::GroupTopNCache;
 use super::top_n_cache::AppendOnlyTopNCacheTrait;
@@ -83,6 +83,9 @@ pub struct InnerAppendOnlyGroupTopNExecutor<K: HashKey, S: StateStore, const WIT
     /// which column we used to group the data.
     group_by: Vec<usize>,
 
+    /// The `ORDER BY` column whose watermarks can be forwarded, if any.
+    watermark_order_key: Option<usize>,
+
     /// group key -> cache for this group
     caches: GroupTopNCache<K, WITH_TIES>,
 
@@ -130,6 +133,7 @@ impl<K: HashKey, S: StateStore, const WITH_TIES: bool>
             limit: offset_and_limit.1,
             managed_state,
             storage_key_indices: storage_key.into_iter().map(|op| op.column_index).collect(),
+            watermark_order_key: topn_watermark_forwardable_order_key(&order_by),
             group_by,
             caches: GroupTopNCache::new(watermark_epoch, metrics_info),
             cache_key_serde,
@@ -235,10 +239,136 @@ where
 
     async fn handle_watermark(&mut self, watermark: Watermark) -> Option<Watermark> {
         if watermark.col_idx == self.group_by[0] {
+            // The state table is ordered by the first group key column, so the watermark on it can
+            // also be used to clean up the states of the groups below it.
             self.managed_state.update_watermark(watermark.val.clone());
-            Some(watermark)
-        } else {
-            None
+        }
+        // A row can only change the output of its own group, so watermarks on group key columns
+        // can always be forwarded. Watermarks on the first `ORDER BY` column can be forwarded if
+        // it's ordered `ASC NULLS LAST`. See `topn_watermark_forwardable_order_key` for the
+        // reasoning.
+        (self.group_by.contains(&watermark.col_idx)
+            || Some(watermark.col_idx) == self.watermark_order_key)
+            .then_some(watermark)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicU64;
+
+    use risingwave_common::array::stream_chunk::StreamChunkTestExt;
+    use risingwave_common::catalog::Field;
+    use risingwave_common::hash::SerializedKey;
+    use risingwave_common::util::epoch::test_epoch;
+    use risingwave_common::util::sort_util::OrderType;
+    use risingwave_storage::memory::MemoryStateStore;
+
+    use super::*;
+    use crate::executor::test_utils::top_n_executor::create_in_memory_state_table;
+    use crate::executor::test_utils::{MockSource, StreamExecutorTestExt};
+
+    /// Same as `GroupTopNExecutor`: watermarks on group key columns are always forwarded (the
+    /// first one also cleans the state), and the watermark on the first `ORDER BY` column is
+    /// forwarded only when it's ordered `ASC NULLS LAST`.
+    #[tokio::test]
+    async fn test_watermark_forwarding() {
+        let asc = OrderType::ascending();
+        let desc = OrderType::descending();
+        // (group_by, order_by, storage_key, forwarded watermark columns)
+        let cases = [
+            (
+                vec![1],
+                vec![ColumnOrder::new(2, asc)],
+                vec![
+                    ColumnOrder::new(1, asc),
+                    ColumnOrder::new(2, asc),
+                    ColumnOrder::new(0, asc),
+                ],
+                vec![1, 2],
+            ),
+            (
+                vec![1],
+                vec![ColumnOrder::new(2, desc)],
+                vec![
+                    ColumnOrder::new(1, asc),
+                    ColumnOrder::new(2, desc),
+                    ColumnOrder::new(0, asc),
+                ],
+                vec![1],
+            ),
+            (
+                vec![1, 2],
+                vec![ColumnOrder::new(0, asc)],
+                vec![
+                    ColumnOrder::new(1, asc),
+                    ColumnOrder::new(2, asc),
+                    ColumnOrder::new(0, asc),
+                ],
+                vec![0, 1, 2],
+            ),
+        ];
+        for (group_by, order_by, storage_key, forwarded) in cases {
+            let schema = Schema {
+                fields: vec![
+                    Field::unnamed(DataType::Int64),
+                    Field::unnamed(DataType::Int64),
+                    Field::unnamed(DataType::Int64),
+                ],
+            };
+            let mut messages = vec![
+                Message::Barrier(Barrier::new_test_barrier(test_epoch(1))),
+                Message::Chunk(StreamChunk::from_pretty(
+                    "  I I I
+                    + 10 9 1
+                    +  8 8 2
+                    +  7 8 2
+                    +  9 1 1
+                    + 10 1 1
+                    +  8 1 3",
+                )),
+            ];
+            messages.extend((0..3).map(|col_idx| {
+                Message::Watermark(Watermark::new(
+                    col_idx,
+                    DataType::Int64,
+                    ScalarImpl::Int64(5),
+                ))
+            }));
+            messages.push(Message::Barrier(Barrier::new_test_barrier(test_epoch(2))));
+            let source =
+                MockSource::with_messages(messages).into_executor(schema.clone(), vec![1, 2, 0]);
+            let state_table = create_in_memory_state_table(
+                &[DataType::Int64, DataType::Int64, DataType::Int64],
+                &storage_key.iter().map(|o| o.order_type).collect::<Vec<_>>(),
+                &storage_key
+                    .iter()
+                    .map(|o| o.column_index)
+                    .collect::<Vec<_>>(),
+            )
+            .await;
+            let top_n = AppendOnlyGroupTopNExecutor::<SerializedKey, MemoryStateStore, false>::new(
+                source,
+                ActorContext::for_test(0),
+                schema,
+                storage_key,
+                (0, 2),
+                order_by,
+                group_by,
+                state_table,
+                Arc::new(AtomicU64::new(0)),
+            )
+            .unwrap();
+            let mut top_n = top_n.boxed().execute();
+
+            top_n.expect_barrier().await;
+            top_n.expect_chunk().await;
+            for col_idx in forwarded {
+                let watermark = top_n.expect_watermark().await;
+                assert_eq!(watermark.col_idx, col_idx);
+                assert_eq!(watermark.val, ScalarImpl::Int64(5));
+            }
+            top_n.expect_barrier().await;
         }
     }
 }

--- a/src/stream/src/executor/top_n/top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n/top_n_appendonly.rs
@@ -15,7 +15,7 @@
 use risingwave_common::array::Op;
 use risingwave_common::row::{RowDeserializer, RowExt};
 use risingwave_common::util::epoch::EpochPair;
-use risingwave_common::util::sort_util::ColumnOrder;
+use risingwave_common::util::sort_util::{ColumnOrder, topn_watermark_forwardable_order_key};
 
 use super::top_n_cache::{AppendOnlyTopNCacheTrait, TopNStaging};
 use super::utils::*;
@@ -71,6 +71,9 @@ pub struct InnerAppendOnlyTopNExecutor<S: StateStore, const WITH_TIES: bool> {
 
     /// Used for serializing pk into `CacheKey`.
     cache_key_serde: CacheKeySerde,
+
+    /// The `ORDER BY` column whose watermarks can be forwarded, if any.
+    watermark_order_key: Option<usize>,
 }
 
 impl<S: StateStore, const WITH_TIES: bool> InnerAppendOnlyTopNExecutor<S, WITH_TIES> {
@@ -94,6 +97,7 @@ impl<S: StateStore, const WITH_TIES: bool> InnerAppendOnlyTopNExecutor<S, WITH_T
             storage_key_indices: storage_key.into_iter().map(|op| op.column_index).collect(),
             cache: TopNCache::new(num_offset, num_limit, data_types),
             cache_key_serde,
+            watermark_order_key: topn_watermark_forwardable_order_key(&order_by),
         })
     }
 }
@@ -155,9 +159,10 @@ where
             .await
     }
 
-    async fn handle_watermark(&mut self, _: Watermark) -> Option<Watermark> {
-        // TODO(yuhao): handle watermark
-        None
+    async fn handle_watermark(&mut self, watermark: Watermark) -> Option<Watermark> {
+        // Only watermarks on the first `ORDER BY` column ordered `ASC NULLS LAST` can be forwarded.
+        // See `topn_watermark_forwardable_order_key` for the reasoning.
+        (Some(watermark.col_idx) == self.watermark_order_key).then_some(watermark)
     }
 }
 
@@ -167,14 +172,16 @@ mod tests {
     use risingwave_common::array::StreamChunk;
     use risingwave_common::array::stream_chunk::StreamChunkTestExt;
     use risingwave_common::catalog::{Field, Schema};
-    use risingwave_common::types::DataType;
+    use risingwave_common::types::{DataType, ScalarImpl};
     use risingwave_common::util::epoch::test_epoch;
     use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
 
     use super::AppendOnlyTopNExecutor;
     use crate::executor::test_utils::top_n_executor::create_in_memory_state_table;
     use crate::executor::test_utils::{MockSource, StreamExecutorTestExt};
-    use crate::executor::{ActorContext, Barrier, Execute, Executor, Message, StreamKey};
+    use crate::executor::{
+        ActorContext, Barrier, Execute, Executor, Message, StreamKey, Watermark,
+    };
 
     fn create_stream_chunks() -> Vec<StreamChunk> {
         let chunk1 = StreamChunk::from_pretty(
@@ -382,5 +389,56 @@ mod tests {
         );
         // We added (1, 1, 2, 3).
         // Now (1, 1, 1) -> (1, 2, 2, 3)
+    }
+
+    /// Only the watermark on the first `ORDER BY` column is forwarded, and only when the column
+    /// is ordered `ASC NULLS LAST`.
+    #[tokio::test]
+    async fn test_append_only_top_n_executor_watermark_forwarding() {
+        for order_type in [OrderType::ascending(), OrderType::descending()] {
+            let source = MockSource::with_messages(vec![
+                Message::Barrier(Barrier::new_test_barrier(test_epoch(1))),
+                Message::Chunk(StreamChunk::from_pretty(
+                    " I I
+                    + 1 0
+                    + 2 1
+                    + 3 2",
+                )),
+                Message::Watermark(Watermark::new(0, DataType::Int64, ScalarImpl::Int64(2))),
+                Message::Watermark(Watermark::new(1, DataType::Int64, ScalarImpl::Int64(1))),
+                Message::Barrier(Barrier::new_test_barrier(test_epoch(2))),
+            ])
+            .into_executor(create_schema(), stream_key());
+            let state_table = create_in_memory_state_table(
+                &[DataType::Int64, DataType::Int64],
+                &[order_type, OrderType::ascending()],
+                &stream_key(),
+            )
+            .await;
+            let schema = source.schema().clone();
+            let top_n = AppendOnlyTopNExecutor::<_, false>::new(
+                source,
+                ActorContext::for_test(0),
+                schema,
+                vec![
+                    ColumnOrder::new(0, order_type),
+                    ColumnOrder::new(1, OrderType::ascending()),
+                ],
+                (0, 2),
+                vec![ColumnOrder::new(0, order_type)],
+                state_table,
+            )
+            .unwrap();
+            let mut top_n = top_n.boxed().execute();
+
+            top_n.expect_barrier().await;
+            top_n.expect_chunk().await;
+            if order_type.is_ascending() {
+                let watermark = top_n.expect_watermark().await;
+                assert_eq!(watermark.col_idx, 0);
+                assert_eq!(watermark.val, ScalarImpl::Int64(2));
+            }
+            top_n.expect_barrier().await;
+        }
     }
 }

--- a/src/stream/src/executor/top_n/top_n_plain.rs
+++ b/src/stream/src/executor/top_n/top_n_plain.rs
@@ -15,7 +15,7 @@
 use risingwave_common::array::Op;
 use risingwave_common::row::{RowDeserializer, RowExt};
 use risingwave_common::util::epoch::EpochPair;
-use risingwave_common::util::sort_util::ColumnOrder;
+use risingwave_common::util::sort_util::{ColumnOrder, topn_watermark_forwardable_order_key};
 
 use super::top_n_cache::TopNStaging;
 use super::utils::*;
@@ -89,6 +89,9 @@ pub struct InnerTopNExecutor<S: StateStore, const WITH_TIES: bool> {
 
     /// Used for serializing pk into `CacheKey`.
     cache_key_serde: CacheKeySerde,
+
+    /// The `ORDER BY` column whose watermarks can be forwarded, if any.
+    watermark_order_key: Option<usize>,
 }
 
 impl<S: StateStore, const WITH_TIES: bool> InnerTopNExecutor<S, WITH_TIES> {
@@ -120,6 +123,7 @@ impl<S: StateStore, const WITH_TIES: bool> InnerTopNExecutor<S, WITH_TIES> {
             storage_key_indices: storage_key.into_iter().map(|op| op.column_index).collect(),
             cache: TopNCache::new(num_offset, num_limit, data_types),
             cache_key_serde,
+            watermark_order_key: topn_watermark_forwardable_order_key(&order_by),
         })
     }
 }
@@ -194,9 +198,10 @@ where
             .await
     }
 
-    async fn handle_watermark(&mut self, _: Watermark) -> Option<Watermark> {
-        // TODO(yuhao): handle watermark
-        None
+    async fn handle_watermark(&mut self, watermark: Watermark) -> Option<Watermark> {
+        // Only watermarks on the first `ORDER BY` column ordered `ASC NULLS LAST` can be forwarded.
+        // See `topn_watermark_forwardable_order_key` for the reasoning.
+        (Some(watermark.col_idx) == self.watermark_order_key).then_some(watermark)
     }
 }
 
@@ -1209,6 +1214,70 @@ mod tests {
             );
             // barrier
             top_n.expect_barrier().await;
+        }
+    }
+
+    mod test_watermark {
+        use risingwave_common::util::epoch::test_epoch;
+        use risingwave_storage::memory::MemoryStateStore;
+
+        use super::*;
+        use crate::executor::test_utils::StreamExecutorTestExt;
+
+        /// Only the watermark on the first `ORDER BY` column is forwarded, and only when the
+        /// column is ordered `ASC NULLS LAST`.
+        #[tokio::test]
+        async fn test_watermark_forwarding() {
+            for order_type in [OrderType::ascending(), OrderType::descending()] {
+                let schema = Schema {
+                    fields: vec![
+                        Field::unnamed(DataType::Int64),
+                        Field::unnamed(DataType::Int64),
+                    ],
+                };
+                let source = MockSource::with_messages(vec![
+                    Message::Barrier(Barrier::new_test_barrier(test_epoch(1))),
+                    Message::Chunk(StreamChunk::from_pretty(
+                        " I I
+                        + 1 0
+                        + 2 1
+                        + 3 2",
+                    )),
+                    Message::Watermark(Watermark::new(0, DataType::Int64, ScalarImpl::Int64(2))),
+                    Message::Watermark(Watermark::new(1, DataType::Int64, ScalarImpl::Int64(1))),
+                    Message::Barrier(Barrier::new_test_barrier(test_epoch(2))),
+                ])
+                .into_executor(schema.clone(), vec![0, 1]);
+                let state_table = create_in_memory_state_table(
+                    &[DataType::Int64, DataType::Int64],
+                    &[order_type, OrderType::ascending()],
+                    &[0, 1],
+                )
+                .await;
+                let top_n = TopNExecutor::<MemoryStateStore, false>::new(
+                    source,
+                    ActorContext::for_test(0),
+                    schema,
+                    vec![
+                        ColumnOrder::new(0, order_type),
+                        ColumnOrder::new(1, OrderType::ascending()),
+                    ],
+                    (0, 2),
+                    vec![ColumnOrder::new(0, order_type)],
+                    state_table,
+                )
+                .unwrap();
+                let mut top_n = top_n.boxed().execute();
+
+                top_n.expect_barrier().await;
+                top_n.expect_chunk().await;
+                if order_type.is_ascending() {
+                    let watermark = top_n.expect_watermark().await;
+                    assert_eq!(watermark.col_idx, 0);
+                    assert_eq!(watermark.val, ScalarImpl::Int64(2));
+                }
+                top_n.expect_barrier().await;
+            }
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://raw.githubusercontent.com/risingwavelabs/risingwave/17af8a747593ebdbfa826691daf75bdab7d14fa0/.github/contributor-license-agreement.txt).

## What's changed and what's your intention?

Follow-up of #27050 (over window) and #24481 (group TopN). Together they make a whole class of EOWC plans possible.

Before this PR:

- plain / append-only TopN dropped every watermark (`handle_watermark` returned `None`, and `StreamTopN` declared no output watermark columns);
- group TopN only forwarded the watermark on `group_key[0]`, although the optimizer already noted that other group key columns and ascending `ORDER BY` columns are safe.

Now all four TopN executors (`TopN`, `AppendOnlyTopN`, `GroupTopN`, `AppendOnlyGroupTopN`) forward

- **watermarks on any group key column** (group TopN): a row only affects the output of its own group, so a watermark on a group key column stays valid downstream. The watermark on `group_key[0]` still drives state cleaning as before.
- **the watermark on the first `ORDER BY` column, if it is ordered `ASC NULLS LAST`**: a row arriving at TopN can only change its own output and the output of rows ordered *after* it (by evicting them from / restoring them into the top N), and all those rows are `>= wm` (or NULL, treated as the largest) in that column by the watermark guarantee. This holds for retractable input too: a delete of a row `>= wm` can only promote a row ordered after the top N, which is also `>= wm`. With `DESC` or `ASC NULLS FIRST`, a new row may evict rows `< wm` instead, so the watermark must be dropped.

The rule is implemented once in `risingwave_common::util::sort_util::topn_watermark_forwardable_order_key` and shared by the executors and the optimizer: `StreamTopN` and `StreamGroupTopN` derive their `watermark_columns` from it, so the optimizer stays in sync with the executors and EOWC can be enabled on such plans, e.g.

```sql
SELECT ts, v FROM (SELECT * FROM t ORDER BY ts LIMIT 3) EMIT ON WINDOW CLOSE;

-- top 1 per (k, window_start): the watermark on `window_start`, the second group key, is forwarded
SELECT k, window_start, v FROM (
  SELECT *, row_number() OVER (PARTITION BY k, window_start ORDER BY v) AS rn FROM tumble(t, ts, INTERVAL '1 hour')
) WHERE rn <= 1 EMIT ON WINDOW CLOSE;

-- first row per key: the watermark on the `ORDER BY` column `ts` is forwarded
SELECT k, ts, v FROM (
  SELECT *, row_number() OVER (PARTITION BY k ORDER BY ts) AS rn FROM t
) WHERE rn <= 1 EMIT ON WINDOW CLOSE;
```

`StreamTopN` now also shows `output_watermarks` in `EXPLAIN`, like `StreamGroupTopN`.

Tests:

- planner: `watermark.yaml` (two-phase TopN, `DESC`, watermark column not being the first `ORDER BY` column, group TopN cases) and `emit_on_window_close.yaml` (TopN / group TopN EOWC plans, `DESC` rejected).
- e2e: `e2e_test/streaming/eowc/eowc_top_n_watermark_forwarding.slt`, covering plain TopN, group TopN with the watermark on the second group key, and group TopN ordered by the watermark column in EOWC mode, including a row that enters the top N and gets evicted before the window closes.

- Closes #17952

## Checklist

- [x] I have written necessary rustdoc comments.
- [x] I have added planner and end-to-end tests.
- [ ] I have added test labels as necessary.
- [ ] I have added fuzzing tests or opened an issue to track them.
- [ ] My PR contains breaking changes.
- [ ] My PR changes performance-critical code, so I will run (micro) benchmarks and present the results.
- [ ] I have checked the [Release Timeline](https://github.com/risingwavelabs/rw-commits-history/blob/main/release_timeline.md) and [Currently Supported Versions](https://docs.risingwave.com/changelog/release-support-policy#support-end-dates-for-recent-releases) to determine which release branches I need to cherry-pick this PR into.

## Documentation

- [ ] My PR needs documentation updates.

<details>
<summary><b>Release note</b></summary>

Streaming TopN operators now forward watermarks on the first `ORDER BY` column (when ordered `ASC NULLS LAST`), and group TopN forwards watermarks on all group key columns. Queries with `ORDER BY <watermark column> LIMIT n`, `row_number() OVER (PARTITION BY ..., <watermark column> ...)` or `row_number() OVER (PARTITION BY ... ORDER BY <watermark column>)` filtered by `rn <= n` can now be executed with `EMIT ON WINDOW CLOSE`, and watermark-driven state cleaning in downstream operators keeps working across TopN.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Top-N and Group Top-N queries now forward watermarks when ordered by a leading ascending watermark column.
  - Watermarks propagate through grouped, partitioned, and windowed Top-N queries in Emit-On-Window-Close mode.
  - Rows held above the watermark are released or suppressed correctly as watermarks advance and windows close.

- **Bug Fixes**
  - Improved watermark handling across append-only and standard Top-N queries.
  - Watermark forwarding remains disabled for unsupported ordering, including descending or non-leading watermark columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->